### PR TITLE
Adds support for explicitly setting api server

### DIFF
--- a/controller/controller.go
+++ b/controller/controller.go
@@ -89,6 +89,11 @@ func New(config Config) Controller {
 		if err != nil {
 			panic(fmt.Sprintf("Could not create in cluster config: %v\n", err.Error()))
 		}
+
+		log.Println("using explicit api server")
+		if config.APIServer != "" {
+			kubernetesConfig.Host = config.APIServer
+		}
 	} else {
 		log.Println("using external config")
 		kubernetesConfig = &rest.Config{


### PR DESCRIPTION
`inClusterConfig` seems to produce an odd api server on G8S. While we sort that out, this is a quick fix that gets the cluster controller running on G8S.