### PR TITLE
Adds required imagepullpolicy to flannel resources

### DIFF
--- a/resources/flannel_client.go
+++ b/resources/flannel_client.go
@@ -26,6 +26,7 @@ func (f *flannelClient) generateInitFlannelContainers() (string, error) {
 		{
 			Name:  "set-network-env",
 			Image: "leaseweb-registry.private.giantswarm.io/giantswarm/set-flannel-network-env",
+			ImagePullPolicy: apiv1.PullAlways,
 			Command: []string{
 				"/bin/bash",
 				"-c",
@@ -231,6 +232,7 @@ func (f *flannelClient) GenerateResources() ([]runtime.Object, error) {
 						{
 							Name:  "flannel-client",
 							Image: fmt.Sprintf("giantswarm/flannel:%s", f.Spec.FlannelConfiguration.Version),
+							ImagePullPolicy: apiv1.PullAlways,
 							Command: []string{
 								"/bin/sh",
 								"-c",


### PR DESCRIPTION
Fixes:
```
2017/01/17 14:33:41 could not reconcile resource state: Deployment.extensions "jo301-flannel-client" is invalid: spec.template.spec.initContainers[0].imagePullPolicy: Required value
```