### PR TITLE
moved resource keys to new resource package

### DIFF
--- a/service/resource/flannel/deployment.go
+++ b/service/resource/flannel/deployment.go
@@ -7,7 +7,7 @@ import (
 	apiv1 "k8s.io/client-go/pkg/api/v1"
 	extensionsv1 "k8s.io/client-go/pkg/apis/extensions/v1beta1"
 
-	"github.com/giantswarm/kvm-operator/resources"
+	"github.com/giantswarm/kvm-operator/service/resource"
 )
 
 func (s *Service) newDeployment(obj interface{}) (*extensionsv1.Deployment, error) {
@@ -27,8 +27,8 @@ func (s *Service) newDeployment(obj interface{}) (*extensionsv1.Deployment, erro
 		ObjectMeta: apiv1.ObjectMeta{
 			Name: "flannel-client",
 			Labels: map[string]string{
-				"cluster":  resources.ClusterID(*customObject),
-				"customer": resources.ClusterCustomer(*customObject),
+				"cluster":  resource.ClusterID(*customObject),
+				"customer": resource.ClusterCustomer(*customObject),
 				"app":      "flannel-client",
 			},
 		},
@@ -41,8 +41,8 @@ func (s *Service) newDeployment(obj interface{}) (*extensionsv1.Deployment, erro
 				ObjectMeta: apiv1.ObjectMeta{
 					GenerateName: "flannel-client",
 					Labels: map[string]string{
-						"cluster":  resources.ClusterID(*customObject),
-						"customer": resources.ClusterCustomer(*customObject),
+						"cluster":  resource.ClusterID(*customObject),
+						"customer": resource.ClusterCustomer(*customObject),
 						"app":      "flannel-client",
 					},
 					Annotations: map[string]string{
@@ -138,7 +138,7 @@ func (s *Service) newDeployment(obj interface{}) (*extensionsv1.Deployment, erro
 							Env: []apiv1.EnvVar{
 								{
 									Name:  "NETWORK_BRIDGE_NAME",
-									Value: resources.NetworkBridgeName(resources.ClusterID(*customObject)),
+									Value: resource.NetworkBridgeName(resource.ClusterID(*customObject)),
 								},
 								{
 									Name: "NODE_IP",
@@ -176,7 +176,7 @@ func (s *Service) newDeployment(obj interface{}) (*extensionsv1.Deployment, erro
 							Env: []apiv1.EnvVar{
 								{
 									Name:  "NETWORK_ENV_FILE_PATH",
-									Value: resources.NetworkEnvFilePath(resources.ClusterID(*customObject)),
+									Value: resource.NetworkEnvFilePath(resource.ClusterID(*customObject)),
 								},
 								{
 									Name:  "NETWORK_SUBNET_RANGE",
@@ -184,7 +184,7 @@ func (s *Service) newDeployment(obj interface{}) (*extensionsv1.Deployment, erro
 								},
 								{
 									Name:  "NETWORK_BRIDGE_NAME",
-									Value: resources.NetworkBridgeName(resources.ClusterID(*customObject)),
+									Value: resource.NetworkBridgeName(resource.ClusterID(*customObject)),
 								},
 								{
 									Name:  "NETWORK_INTERFACE_NAME",

--- a/service/resource/flannel/init_container.go
+++ b/service/resource/flannel/init_container.go
@@ -7,7 +7,7 @@ import (
 	microerror "github.com/giantswarm/microkit/error"
 	apiv1 "k8s.io/client-go/pkg/api/v1"
 
-	"github.com/giantswarm/kvm-operator/resources"
+	"github.com/giantswarm/kvm-operator/service/resource"
 )
 
 func (s *Service) newInitContainers(obj interface{}) ([]apiv1.Container, error) {
@@ -54,7 +54,7 @@ func (s *Service) newInitContainers(obj interface{}) ([]apiv1.Container, error) 
 				},
 				{
 					Name:  "NETWORK_BRIDGE_NAME", // e.g. br-h8s2l
-					Value: resources.NetworkBridgeName(resources.ClusterID(*customObject)),
+					Value: resource.NetworkBridgeName(resource.ClusterID(*customObject)),
 				},
 				{
 					Name:  "SUBNET_LEN", // e.g. 30

--- a/service/resource/flannel/pod_affinity.go
+++ b/service/resource/flannel/pod_affinity.go
@@ -6,7 +6,7 @@ import (
 	"k8s.io/client-go/pkg/api"
 	apiunversioned "k8s.io/client-go/pkg/api/unversioned"
 
-	"github.com/giantswarm/kvm-operator/resources"
+	"github.com/giantswarm/kvm-operator/service/resource"
 )
 
 func (s *Service) newPodAfinity(obj interface{}) (*api.Affinity, error) {
@@ -29,7 +29,7 @@ func (s *Service) newPodAfinity(obj interface{}) (*api.Affinity, error) {
 						},
 					},
 					TopologyKey: "kubernetes.io/hostname",
-					Namespaces:  []string{resources.ClusterID(*customObject)},
+					Namespaces:  []string{resource.ClusterID(*customObject)},
 				},
 			},
 		},

--- a/service/resource/keys.go
+++ b/service/resource/keys.go
@@ -1,4 +1,4 @@
-package resources
+package resource
 
 import (
 	"fmt"

--- a/service/resource/keys_test.go
+++ b/service/resource/keys_test.go
@@ -1,4 +1,4 @@
-package resources
+package resource
 
 import (
 	"testing"

--- a/service/resource/master/deployment.go
+++ b/service/resource/master/deployment.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"path/filepath"
 
-	"github.com/giantswarm/kvm-operator/resources"
+	"github.com/giantswarm/kvm-operator/service/resource"
 	"github.com/giantswarm/kvmtpr"
 	microerror "github.com/giantswarm/microkit/error"
 	apiunversioned "k8s.io/client-go/pkg/api/unversioned"
@@ -30,8 +30,8 @@ func (s *Service) newDeployment(obj interface{}) (*extensionsv1.Deployment, erro
 		ObjectMeta: apiv1.ObjectMeta{
 			Name: "master",
 			Labels: map[string]string{
-				"cluster":  resources.ClusterID(*customObject),
-				"customer": resources.ClusterCustomer(*customObject),
+				"cluster":  resource.ClusterID(*customObject),
+				"customer": resource.ClusterCustomer(*customObject),
 				"app":      "master",
 			},
 		},
@@ -44,8 +44,8 @@ func (s *Service) newDeployment(obj interface{}) (*extensionsv1.Deployment, erro
 				ObjectMeta: apiv1.ObjectMeta{
 					GenerateName: "master",
 					Labels: map[string]string{
-						"cluster":  resources.ClusterID(*customObject),
-						"customer": resources.ClusterCustomer(*customObject),
+						"cluster":  resource.ClusterID(*customObject),
+						"customer": resource.ClusterCustomer(*customObject),
 						"app":      "master",
 					},
 				},
@@ -56,7 +56,7 @@ func (s *Service) newDeployment(obj interface{}) (*extensionsv1.Deployment, erro
 							Name: "etcd-data",
 							VolumeSource: apiv1.VolumeSource{
 								HostPath: &apiv1.HostPathVolumeSource{
-									Path: filepath.Join("/home/core/", resources.ClusterID(*customObject), "-k8s-master-vm/"),
+									Path: filepath.Join("/home/core/", resource.ClusterID(*customObject), "-k8s-master-vm/"),
 								},
 							},
 						},
@@ -72,7 +72,7 @@ func (s *Service) newDeployment(obj interface{}) (*extensionsv1.Deployment, erro
 							Name: "rootfs",
 							VolumeSource: apiv1.VolumeSource{
 								HostPath: &apiv1.HostPathVolumeSource{
-									Path: filepath.Join("/home/core/vms/", resources.ClusterID(*customObject), "-k8s-master-vm/"),
+									Path: filepath.Join("/home/core/vms/", resource.ClusterID(*customObject), "-k8s-master-vm/"),
 								},
 							},
 						},
@@ -117,7 +117,7 @@ func (s *Service) newDeployment(obj interface{}) (*extensionsv1.Deployment, erro
 								},
 								{
 									Name:  "NETWORK_BRIDGE_NAME",
-									Value: resources.NetworkBridgeName(resources.ClusterID(*customObject)),
+									Value: resource.NetworkBridgeName(resource.ClusterID(*customObject)),
 								},
 								{
 									Name:  "MEMORY",

--- a/service/resource/master/ingress.go
+++ b/service/resource/master/ingress.go
@@ -8,7 +8,7 @@ import (
 	extensionsv1 "k8s.io/client-go/pkg/apis/extensions/v1beta1"
 	"k8s.io/client-go/pkg/util/intstr"
 
-	"github.com/giantswarm/kvm-operator/resources"
+	"github.com/giantswarm/kvm-operator/service/resource"
 )
 
 func (s *Service) newIngresses(obj interface{}) ([]*extensionsv1.Ingress, error) {
@@ -26,8 +26,8 @@ func (s *Service) newIngresses(obj interface{}) ([]*extensionsv1.Ingress, error)
 			ObjectMeta: apiv1.ObjectMeta{
 				Name: "etcd",
 				Labels: map[string]string{
-					"cluster":  resources.ClusterID(*customObject),
-					"customer": resources.ClusterCustomer(*customObject),
+					"cluster":  resource.ClusterID(*customObject),
+					"customer": resource.ClusterCustomer(*customObject),
 					"app":      "master",
 				},
 				Annotations: map[string]string{
@@ -70,8 +70,8 @@ func (s *Service) newIngresses(obj interface{}) ([]*extensionsv1.Ingress, error)
 			ObjectMeta: apiv1.ObjectMeta{
 				Name: "api",
 				Labels: map[string]string{
-					"cluster":  resources.ClusterID(*customObject),
-					"customer": resources.ClusterCustomer(*customObject),
+					"cluster":  resource.ClusterID(*customObject),
+					"customer": resource.ClusterCustomer(*customObject),
 					"app":      "master",
 				},
 				Annotations: map[string]string{

--- a/service/resource/master/init_container.go
+++ b/service/resource/master/init_container.go
@@ -3,7 +3,7 @@ package master
 import (
 	"fmt"
 
-	"github.com/giantswarm/kvm-operator/resources"
+	"github.com/giantswarm/kvm-operator/service/resource"
 	"github.com/giantswarm/kvmtpr"
 	microerror "github.com/giantswarm/microkit/error"
 	apiv1 "k8s.io/client-go/pkg/api/v1"
@@ -37,7 +37,7 @@ func (s *Service) newInitContainers(obj interface{}) ([]apiv1.Container, error) 
 				},
 				{
 					Name:  "NETWORK_BRIDGE_NAME",
-					Value: resources.NetworkBridgeName(resources.ClusterID(*customObject)),
+					Value: resource.NetworkBridgeName(resource.ClusterID(*customObject)),
 				},
 				{
 					Name: "NODE_IP",
@@ -65,7 +65,7 @@ func (s *Service) newInitContainers(obj interface{}) ([]apiv1.Container, error) 
 			Env: []apiv1.EnvVar{
 				{
 					Name:  "NETWORK_BRIDGE_NAME",
-					Value: resources.NetworkBridgeName(resources.ClusterID(*customObject)),
+					Value: resource.NetworkBridgeName(resource.ClusterID(*customObject)),
 				},
 				{
 					Name: "POD_NAME",

--- a/service/resource/master/pod_affinity.go
+++ b/service/resource/master/pod_affinity.go
@@ -1,7 +1,7 @@
 package master
 
 import (
-	"github.com/giantswarm/kvm-operator/resources"
+	"github.com/giantswarm/kvm-operator/service/resource"
 	"github.com/giantswarm/kvmtpr"
 	microerror "github.com/giantswarm/microkit/error"
 	"k8s.io/client-go/pkg/api"
@@ -28,7 +28,7 @@ func (s *Service) newPodAfinity(obj interface{}) (*api.Affinity, error) {
 						},
 					},
 					TopologyKey: "kubernetes.io/hostname",
-					Namespaces:  []string{resources.ClusterID(*customObject)},
+					Namespaces:  []string{resource.ClusterID(*customObject)},
 				},
 			},
 		},
@@ -45,7 +45,7 @@ func (s *Service) newPodAfinity(obj interface{}) (*api.Affinity, error) {
 						},
 					},
 					TopologyKey: "kubernetes.io/hostname",
-					Namespaces:  []string{resources.ClusterID(*customObject)},
+					Namespaces:  []string{resource.ClusterID(*customObject)},
 				},
 			},
 		},

--- a/service/resource/master/service.go
+++ b/service/resource/master/service.go
@@ -6,7 +6,7 @@ import (
 	apiunversioned "k8s.io/client-go/pkg/api/unversioned"
 	apiv1 "k8s.io/client-go/pkg/api/v1"
 
-	"github.com/giantswarm/kvm-operator/resources"
+	"github.com/giantswarm/kvm-operator/service/resource"
 )
 
 func (s *Service) newService(obj interface{}) (*apiv1.Service, error) {
@@ -23,8 +23,8 @@ func (s *Service) newService(obj interface{}) (*apiv1.Service, error) {
 		ObjectMeta: apiv1.ObjectMeta{
 			Name: "master",
 			Labels: map[string]string{
-				"cluster":  resources.ClusterID(*customObject),
-				"customer": resources.ClusterCustomer(*customObject),
+				"cluster":  resource.ClusterID(*customObject),
+				"customer": resource.ClusterCustomer(*customObject),
 				"app":      "master",
 			},
 		},

--- a/service/resource/namespace/namespace.go
+++ b/service/resource/namespace/namespace.go
@@ -8,7 +8,7 @@ import (
 	"k8s.io/client-go/pkg/api/v1"
 	"k8s.io/client-go/pkg/runtime"
 
-	"github.com/giantswarm/kvm-operator/resources"
+	"github.com/giantswarm/kvm-operator/service/resource"
 )
 
 // Config represents the configuration used to create a new service.
@@ -86,10 +86,10 @@ func (s *Service) newRuntimeObjects(obj interface{}) ([]runtime.Object, error) {
 			APIVersion: "v1",
 		},
 		ObjectMeta: v1.ObjectMeta{
-			Name: resources.ClusterNamespace(*customObject),
+			Name: resource.ClusterNamespace(*customObject),
 			Labels: map[string]string{
-				"cluster":  resources.ClusterID(*customObject),
-				"customer": resources.ClusterCustomer(*customObject),
+				"cluster":  resource.ClusterID(*customObject),
+				"customer": resource.ClusterCustomer(*customObject),
 			},
 		},
 	}

--- a/service/resource/worker/deployment.go
+++ b/service/resource/worker/deployment.go
@@ -6,7 +6,7 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/giantswarm/kvm-operator/resources"
+	"github.com/giantswarm/kvm-operator/service/resource"
 	"github.com/giantswarm/kvmtpr"
 	microerror "github.com/giantswarm/microkit/error"
 	apiunversioned "k8s.io/client-go/pkg/api/unversioned"
@@ -33,8 +33,8 @@ func (s *Service) newDeployment(obj interface{}) (*extensionsv1.Deployment, erro
 		ObjectMeta: apiv1.ObjectMeta{
 			Name: "worker",
 			Labels: map[string]string{
-				"cluster":  resources.ClusterID(*customObject),
-				"customer": resources.ClusterCustomer(*customObject),
+				"cluster":  resource.ClusterID(*customObject),
+				"customer": resource.ClusterCustomer(*customObject),
 				"app":      "worker",
 			},
 		},
@@ -47,8 +47,8 @@ func (s *Service) newDeployment(obj interface{}) (*extensionsv1.Deployment, erro
 				ObjectMeta: apiv1.ObjectMeta{
 					Name: "worker",
 					Labels: map[string]string{
-						"cluster":  resources.ClusterID(*customObject),
-						"customer": resources.ClusterCustomer(*customObject),
+						"cluster":  resource.ClusterID(*customObject),
+						"customer": resource.ClusterCustomer(*customObject),
 						"app":      "worker",
 					},
 				},
@@ -67,7 +67,7 @@ func (s *Service) newDeployment(obj interface{}) (*extensionsv1.Deployment, erro
 							Name: "rootfs",
 							VolumeSource: apiv1.VolumeSource{
 								HostPath: &apiv1.HostPathVolumeSource{
-									Path: filepath.Join("/home/core/vms", resources.ClusterID(*customObject), workerID),
+									Path: filepath.Join("/home/core/vms", resource.ClusterID(*customObject), workerID),
 								},
 							},
 						},
@@ -104,7 +104,7 @@ func (s *Service) newDeployment(obj interface{}) (*extensionsv1.Deployment, erro
 								},
 								{
 									Name:  "NETWORK_BRIDGE_NAME",
-									Value: resources.NetworkBridgeName(resources.ClusterID(*customObject)),
+									Value: resource.NetworkBridgeName(resource.ClusterID(*customObject)),
 								},
 								{
 									Name:  "MEMORY",

--- a/service/resource/worker/init_container.go
+++ b/service/resource/worker/init_container.go
@@ -1,7 +1,7 @@
 package worker
 
 import (
-	"github.com/giantswarm/kvm-operator/resources"
+	"github.com/giantswarm/kvm-operator/service/resource"
 	"github.com/giantswarm/kvmtpr"
 	microerror "github.com/giantswarm/microkit/error"
 	apiv1 "k8s.io/client-go/pkg/api/v1"
@@ -31,7 +31,7 @@ func (s *Service) newInitContainers(obj interface{}) ([]apiv1.Container, error) 
 			Env: []apiv1.EnvVar{
 				{
 					Name:  "NETWORK_BRIDGE_NAME",
-					Value: resources.NetworkBridgeName(resources.ClusterID(*customObject)),
+					Value: resource.NetworkBridgeName(resource.ClusterID(*customObject)),
 				},
 				{
 					Name: "POD_NAME",

--- a/service/resource/worker/pod_affinity.go
+++ b/service/resource/worker/pod_affinity.go
@@ -1,7 +1,7 @@
 package worker
 
 import (
-	"github.com/giantswarm/kvm-operator/resources"
+	"github.com/giantswarm/kvm-operator/service/resource"
 	"github.com/giantswarm/kvmtpr"
 	microerror "github.com/giantswarm/microkit/error"
 	"k8s.io/client-go/pkg/api"
@@ -28,7 +28,7 @@ func (s *Service) newPodAfinity(obj interface{}) (*api.Affinity, error) {
 						},
 					},
 					TopologyKey: "kubernetes.io/hostname",
-					Namespaces:  []string{resources.ClusterID(*customObject)},
+					Namespaces:  []string{resource.ClusterID(*customObject)},
 				},
 			},
 		},
@@ -45,7 +45,7 @@ func (s *Service) newPodAfinity(obj interface{}) (*api.Affinity, error) {
 						},
 					},
 					TopologyKey: "kubernetes.io/hostname",
-					Namespaces:  []string{resources.ClusterID(*customObject)},
+					Namespaces:  []string{resource.ClusterID(*customObject)},
 				},
 			},
 		},

--- a/service/resource/worker/service.go
+++ b/service/resource/worker/service.go
@@ -1,7 +1,7 @@
 package worker
 
 import (
-	"github.com/giantswarm/kvm-operator/resources"
+	"github.com/giantswarm/kvm-operator/service/resource"
 	"github.com/giantswarm/kvmtpr"
 	microerror "github.com/giantswarm/microkit/error"
 	apiunversioned "k8s.io/client-go/pkg/api/unversioned"
@@ -22,8 +22,8 @@ func (s *Service) newService(obj interface{}) (*apiv1.Service, error) {
 		ObjectMeta: apiv1.ObjectMeta{
 			Name: "worker",
 			Labels: map[string]string{
-				"cluster":  resources.ClusterID(*customObject),
-				"customer": resources.ClusterCustomer(*customObject),
+				"cluster":  resource.ClusterID(*customObject),
+				"customer": resource.ClusterCustomer(*customObject),
 				"app":      "worker",
 			},
 		},


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/1197. Here we just move the keys logic to the new resource file. The refactoring ends here for now. The old resource package is gone. Next step is to add a cloud config resource to actually integrate k8scloudconfig. 