### PR TITLE
create consistent names for worker/master deployments

### DIFF
--- a/service/resource/master/deployment.go
+++ b/service/resource/master/deployment.go
@@ -32,7 +32,7 @@ func (s *Service) newDeployments(obj interface{}) ([]*extensionsv1.Deployment, e
 				APIVersion: "extensions/v1beta",
 			},
 			ObjectMeta: apiv1.ObjectMeta{
-				GenerateName: "master-",
+				Name: "master-" + masterNode.ID,
 				Labels: map[string]string{
 					"cluster":  resource.ClusterID(*customObject),
 					"customer": resource.ClusterCustomer(*customObject),

--- a/service/resource/worker/deployment.go
+++ b/service/resource/worker/deployment.go
@@ -32,7 +32,7 @@ func (s *Service) newDeployments(obj interface{}) ([]*extensionsv1.Deployment, e
 				APIVersion: "extensions/v1beta",
 			},
 			ObjectMeta: apiv1.ObjectMeta{
-				GenerateName: "worker-",
+				Name: "worker-" + workerNode.ID,
 				Labels: map[string]string{
 					"cluster":  resource.ClusterID(*customObject),
 					"customer": resource.ClusterCustomer(*customObject),


### PR DESCRIPTION
Otherwise new deployments are created every time the operator sees the
TPO. This includes `ResyncPeriod` and the operator restarts.