### PR TITLE
example: Update cluster definition example

### DIFF
--- a/example/test-1.yml
+++ b/example/test-1.yml
@@ -1,4 +1,4 @@
-apiVersion: "kvm.cluster.giantswarm.io/v1"
+apiVersion: "cluster.giantswarm.io/v1"
 kind: Kvm
 metadata:
   name: test
@@ -6,7 +6,7 @@ spec:
   cluster:
 
     calico:
-      cidr: "16"
+      cidr: 16
       subnet: "192.168.0.0"
 
     cluster:


### PR DESCRIPTION
- Change apiVersion from kvm.cluster.giantswarm.io/v1 to cluster.giantswarm.io/vi.
- Change cidr in calico section from string to int.

Fixes #123