### PR TITLE
moved key functions to own package

### DIFF
--- a/service/key/key.go
+++ b/service/key/key.go
@@ -1,4 +1,4 @@
-package resource
+package key
 
 import (
 	"fmt"

--- a/service/key/key_test.go
+++ b/service/key/key_test.go
@@ -1,4 +1,4 @@
-package resource
+package key
 
 import (
 	"net"
@@ -9,7 +9,7 @@ import (
 	"github.com/giantswarm/kvmtpr"
 )
 
-func TestClusterID(t *testing.T) {
+func Test_ClusterID(t *testing.T) {
 	expectedID := "test-cluster"
 
 	cluster := clustertpr.Spec{
@@ -32,7 +32,7 @@ func TestClusterID(t *testing.T) {
 	}
 }
 
-func TestClusterCustomer(t *testing.T) {
+func Test_ClusterCustomer(t *testing.T) {
 	expectedID := "test-customer"
 
 	cluster := clustertpr.Spec{

--- a/service/resource/cloudconfig/cloud_config.go
+++ b/service/resource/cloudconfig/cloud_config.go
@@ -3,14 +3,13 @@ package cloudconfig
 import (
 	"github.com/giantswarm/certificatetpr"
 	cloudconfig "github.com/giantswarm/k8scloudconfig"
+	"github.com/giantswarm/kvm-operator/service/key"
 	"github.com/giantswarm/kvmtpr"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
 	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	apiv1 "k8s.io/client-go/pkg/api/v1"
-
-	"github.com/giantswarm/kvm-operator/service/resource"
 )
 
 const (
@@ -107,10 +106,10 @@ func (s *Service) newConfigMap(customObject kvmtpr.CustomObject, template string
 	{
 		newConfigMap = &apiv1.ConfigMap{
 			ObjectMeta: apismetav1.ObjectMeta{
-				Name: resource.ConfigMapName(customObject, params.Node, prefix),
+				Name: key.ConfigMapName(customObject, params.Node, prefix),
 				Labels: map[string]string{
-					"cluster":  resource.ClusterID(customObject),
-					"customer": resource.ClusterCustomer(customObject),
+					"cluster":  key.ClusterID(customObject),
+					"customer": key.ClusterCustomer(customObject),
 				},
 			},
 			Data: map[string]string{

--- a/service/resource/master/deployment.go
+++ b/service/resource/master/deployment.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"path/filepath"
 
-	"github.com/giantswarm/kvm-operator/service/resource"
+	"github.com/giantswarm/kvm-operator/service/key"
 	"github.com/giantswarm/kvmtpr"
 	"github.com/giantswarm/microerror"
 	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -34,8 +34,8 @@ func (s *Service) newDeployments(obj interface{}) ([]*extensionsv1.Deployment, e
 			ObjectMeta: apismetav1.ObjectMeta{
 				Name: "master-" + masterNode.ID,
 				Labels: map[string]string{
-					"cluster":  resource.ClusterID(*customObject),
-					"customer": resource.ClusterCustomer(*customObject),
+					"cluster":  key.ClusterID(*customObject),
+					"customer": key.ClusterCustomer(*customObject),
 					"app":      "master",
 					"node":     masterNode.ID,
 				},
@@ -49,8 +49,8 @@ func (s *Service) newDeployments(obj interface{}) ([]*extensionsv1.Deployment, e
 					ObjectMeta: apismetav1.ObjectMeta{
 						GenerateName: "master",
 						Labels: map[string]string{
-							"cluster":  resource.ClusterID(*customObject),
-							"customer": resource.ClusterCustomer(*customObject),
+							"cluster":  key.ClusterID(*customObject),
+							"customer": key.ClusterCustomer(*customObject),
 							"app":      "master",
 							"node":     masterNode.ID,
 						},
@@ -64,7 +64,7 @@ func (s *Service) newDeployments(obj interface{}) ([]*extensionsv1.Deployment, e
 								VolumeSource: apiv1.VolumeSource{
 									ConfigMap: &apiv1.ConfigMapVolumeSource{
 										LocalObjectReference: apiv1.LocalObjectReference{
-											Name: resource.ConfigMapName(*customObject, masterNode, "master"),
+											Name: key.ConfigMapName(*customObject, masterNode, "master"),
 										},
 									},
 								},
@@ -73,7 +73,7 @@ func (s *Service) newDeployments(obj interface{}) ([]*extensionsv1.Deployment, e
 								Name: "etcd-data",
 								VolumeSource: apiv1.VolumeSource{
 									HostPath: &apiv1.HostPathVolumeSource{
-										Path: filepath.Join("/home/core/", resource.ClusterID(*customObject), "-k8s-master-vm/"),
+										Path: filepath.Join("/home/core/", key.ClusterID(*customObject), "-k8s-master-vm/"),
 									},
 								},
 							},
@@ -89,7 +89,7 @@ func (s *Service) newDeployments(obj interface{}) ([]*extensionsv1.Deployment, e
 								Name: "rootfs",
 								VolumeSource: apiv1.VolumeSource{
 									HostPath: &apiv1.HostPathVolumeSource{
-										Path: filepath.Join("/home/core/vms", resource.ClusterID(*customObject), masterNode.ID),
+										Path: filepath.Join("/home/core/vms", key.ClusterID(*customObject), masterNode.ID),
 									},
 								},
 							},
@@ -110,7 +110,7 @@ func (s *Service) newDeployments(obj interface{}) ([]*extensionsv1.Deployment, e
 								Env: []apiv1.EnvVar{
 									{
 										Name:  "NETWORK_BRIDGE_NAME",
-										Value: resource.NetworkBridgeName(resource.ClusterID(*customObject)),
+										Value: key.NetworkBridgeName(key.ClusterID(*customObject)),
 									},
 									{
 										Name: "POD_NAME",
@@ -162,7 +162,7 @@ func (s *Service) newDeployments(obj interface{}) ([]*extensionsv1.Deployment, e
 									},
 									{
 										Name:  "NETWORK_BRIDGE_NAME",
-										Value: resource.NetworkBridgeName(resource.ClusterID(*customObject)),
+										Value: key.NetworkBridgeName(key.ClusterID(*customObject)),
 									},
 									{
 										Name: "MEMORY",

--- a/service/resource/master/ingress.go
+++ b/service/resource/master/ingress.go
@@ -1,13 +1,12 @@
 package master
 
 import (
+	"github.com/giantswarm/kvm-operator/service/key"
 	"github.com/giantswarm/kvmtpr"
 	"github.com/giantswarm/microerror"
 	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	extensionsv1 "k8s.io/client-go/pkg/apis/extensions/v1beta1"
-
-	"github.com/giantswarm/kvm-operator/service/resource"
 )
 
 func (s *Service) newIngresses(obj interface{}) ([]*extensionsv1.Ingress, error) {
@@ -25,8 +24,8 @@ func (s *Service) newIngresses(obj interface{}) ([]*extensionsv1.Ingress, error)
 			ObjectMeta: apismetav1.ObjectMeta{
 				Name: "etcd",
 				Labels: map[string]string{
-					"cluster":  resource.ClusterID(*customObject),
-					"customer": resource.ClusterCustomer(*customObject),
+					"cluster":  key.ClusterID(*customObject),
+					"customer": key.ClusterCustomer(*customObject),
 					"app":      "master",
 				},
 				Annotations: map[string]string{
@@ -69,8 +68,8 @@ func (s *Service) newIngresses(obj interface{}) ([]*extensionsv1.Ingress, error)
 			ObjectMeta: apismetav1.ObjectMeta{
 				Name: "api",
 				Labels: map[string]string{
-					"cluster":  resource.ClusterID(*customObject),
-					"customer": resource.ClusterCustomer(*customObject),
+					"cluster":  key.ClusterID(*customObject),
+					"customer": key.ClusterCustomer(*customObject),
 					"app":      "master",
 				},
 				Annotations: map[string]string{

--- a/service/resource/master/pod_affinity.go
+++ b/service/resource/master/pod_affinity.go
@@ -1,7 +1,7 @@
 package master
 
 import (
-	"github.com/giantswarm/kvm-operator/service/resource"
+	"github.com/giantswarm/kvm-operator/service/key"
 	"github.com/giantswarm/kvmtpr"
 	"github.com/giantswarm/microerror"
 	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -31,7 +31,7 @@ func (s *Service) newPodAfinity(obj interface{}) (*apiv1.Affinity, error) {
 						},
 					},
 					TopologyKey: "kubernetes.io/hostname",
-					Namespaces:  []string{resource.ClusterID(*customObject)},
+					Namespaces:  []string{key.ClusterID(*customObject)},
 				},
 			},
 		},

--- a/service/resource/master/service.go
+++ b/service/resource/master/service.go
@@ -1,12 +1,11 @@
 package master
 
 import (
+	"github.com/giantswarm/kvm-operator/service/key"
 	"github.com/giantswarm/kvmtpr"
 	"github.com/giantswarm/microerror"
 	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	apiv1 "k8s.io/client-go/pkg/api/v1"
-
-	"github.com/giantswarm/kvm-operator/service/resource"
 )
 
 func (s *Service) newService(obj interface{}) (*apiv1.Service, error) {
@@ -23,8 +22,8 @@ func (s *Service) newService(obj interface{}) (*apiv1.Service, error) {
 		ObjectMeta: apismetav1.ObjectMeta{
 			Name: "master",
 			Labels: map[string]string{
-				"cluster":  resource.ClusterID(*customObject),
-				"customer": resource.ClusterCustomer(*customObject),
+				"cluster":  key.ClusterID(*customObject),
+				"customer": key.ClusterCustomer(*customObject),
 				"app":      "master",
 			},
 		},

--- a/service/resource/namespace/namespace.go
+++ b/service/resource/namespace/namespace.go
@@ -1,14 +1,13 @@
 package namespace
 
 import (
+	"github.com/giantswarm/kvm-operator/service/key"
 	"github.com/giantswarm/kvmtpr"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
 	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	apiv1 "k8s.io/client-go/pkg/api/v1"
-
-	"github.com/giantswarm/kvm-operator/service/resource"
 )
 
 // Config represents the configuration used to create a new service.
@@ -86,10 +85,10 @@ func (s *Service) newRuntimeObjects(obj interface{}) ([]runtime.Object, error) {
 			APIVersion: "v1",
 		},
 		ObjectMeta: apismetav1.ObjectMeta{
-			Name: resource.ClusterNamespace(*customObject),
+			Name: key.ClusterNamespace(*customObject),
 			Labels: map[string]string{
-				"cluster":  resource.ClusterID(*customObject),
-				"customer": resource.ClusterCustomer(*customObject),
+				"cluster":  key.ClusterID(*customObject),
+				"customer": key.ClusterCustomer(*customObject),
 			},
 		},
 	}

--- a/service/resource/worker/deployment.go
+++ b/service/resource/worker/deployment.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"path/filepath"
 
-	"github.com/giantswarm/kvm-operator/service/resource"
+	"github.com/giantswarm/kvm-operator/service/key"
 	"github.com/giantswarm/kvmtpr"
 	"github.com/giantswarm/microerror"
 	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -34,8 +34,8 @@ func (s *Service) newDeployments(obj interface{}) ([]*extensionsv1.Deployment, e
 			ObjectMeta: apismetav1.ObjectMeta{
 				Name: "worker-" + workerNode.ID,
 				Labels: map[string]string{
-					"cluster":  resource.ClusterID(*customObject),
-					"customer": resource.ClusterCustomer(*customObject),
+					"cluster":  key.ClusterID(*customObject),
+					"customer": key.ClusterCustomer(*customObject),
 					"app":      "worker",
 					"node":     workerNode.ID,
 				},
@@ -49,8 +49,8 @@ func (s *Service) newDeployments(obj interface{}) ([]*extensionsv1.Deployment, e
 					ObjectMeta: apismetav1.ObjectMeta{
 						Name: "worker",
 						Labels: map[string]string{
-							"cluster":  resource.ClusterID(*customObject),
-							"customer": resource.ClusterCustomer(*customObject),
+							"cluster":  key.ClusterID(*customObject),
+							"customer": key.ClusterCustomer(*customObject),
 							"app":      "worker",
 							"node":     workerNode.ID,
 						},
@@ -64,7 +64,7 @@ func (s *Service) newDeployments(obj interface{}) ([]*extensionsv1.Deployment, e
 								VolumeSource: apiv1.VolumeSource{
 									ConfigMap: &apiv1.ConfigMapVolumeSource{
 										LocalObjectReference: apiv1.LocalObjectReference{
-											Name: resource.ConfigMapName(*customObject, workerNode, "worker"),
+											Name: key.ConfigMapName(*customObject, workerNode, "worker"),
 										},
 									},
 								},
@@ -81,7 +81,7 @@ func (s *Service) newDeployments(obj interface{}) ([]*extensionsv1.Deployment, e
 								Name: "rootfs",
 								VolumeSource: apiv1.VolumeSource{
 									HostPath: &apiv1.HostPathVolumeSource{
-										Path: filepath.Join("/home/core/vms", resource.ClusterID(*customObject), workerNode.ID),
+										Path: filepath.Join("/home/core/vms", key.ClusterID(*customObject), workerNode.ID),
 									},
 								},
 							},
@@ -102,7 +102,7 @@ func (s *Service) newDeployments(obj interface{}) ([]*extensionsv1.Deployment, e
 								Env: []apiv1.EnvVar{
 									{
 										Name:  "NETWORK_BRIDGE_NAME",
-										Value: resource.NetworkBridgeName(resource.ClusterID(*customObject)),
+										Value: key.NetworkBridgeName(key.ClusterID(*customObject)),
 									},
 									{
 										Name: "POD_NAME",
@@ -154,7 +154,7 @@ func (s *Service) newDeployments(obj interface{}) ([]*extensionsv1.Deployment, e
 									},
 									{
 										Name:  "NETWORK_BRIDGE_NAME",
-										Value: resource.NetworkBridgeName(resource.ClusterID(*customObject)),
+										Value: key.NetworkBridgeName(key.ClusterID(*customObject)),
 									},
 									{
 										Name: "MEMORY",

--- a/service/resource/worker/pod_affinity.go
+++ b/service/resource/worker/pod_affinity.go
@@ -1,7 +1,7 @@
 package worker
 
 import (
-	"github.com/giantswarm/kvm-operator/service/resource"
+	"github.com/giantswarm/kvm-operator/service/key"
 	"github.com/giantswarm/kvmtpr"
 	"github.com/giantswarm/microerror"
 	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -31,7 +31,7 @@ func (s *Service) newPodAfinity(obj interface{}) (*apiv1.Affinity, error) {
 						},
 					},
 					TopologyKey: "kubernetes.io/hostname",
-					Namespaces:  []string{resource.ClusterID(*customObject)},
+					Namespaces:  []string{key.ClusterID(*customObject)},
 				},
 			},
 		},

--- a/service/resource/worker/service.go
+++ b/service/resource/worker/service.go
@@ -1,13 +1,12 @@
 package worker
 
 import (
+	"github.com/giantswarm/kvm-operator/service/key"
 	"github.com/giantswarm/kvmtpr"
 	"github.com/giantswarm/microerror"
 	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	apiv1 "k8s.io/client-go/pkg/api/v1"
-
-	"github.com/giantswarm/kvm-operator/service/resource"
 )
 
 func (s *Service) newService(obj interface{}) (*apiv1.Service, error) {
@@ -26,8 +25,8 @@ func (s *Service) newService(obj interface{}) (*apiv1.Service, error) {
 		ObjectMeta: apismetav1.ObjectMeta{
 			Name: "worker",
 			Labels: map[string]string{
-				"cluster":  resource.ClusterID(*customObject),
-				"customer": resource.ClusterCustomer(*customObject),
+				"cluster":  key.ClusterID(*customObject),
+				"customer": key.ClusterCustomer(*customObject),
 				"app":      "worker",
 			},
 		},


### PR DESCRIPTION
This only moves code around to improve the project structure. The keys have been in the resource package which is only intended to hold the reconciliation framework resources. 