### PR TITLE
print error stack on panic

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/giantswarm/kvm-operator/flag"
@@ -31,7 +32,7 @@ func main() {
 		loggerConfig.IOWriter = os.Stdout
 		newLogger, err = micrologger.New(loggerConfig)
 		if err != nil {
-			panic(err)
+			panic(fmt.Sprintf("%#v", err))
 		}
 	}
 
@@ -54,7 +55,7 @@ func main() {
 
 			newService, err = service.New(serviceConfig)
 			if err != nil {
-				panic(err)
+				panic(fmt.Sprintf("%#v", err))
 			}
 			go newService.Boot()
 		}
@@ -71,7 +72,7 @@ func main() {
 
 			newServer, err = server.New(serverConfig)
 			if err != nil {
-				panic(err)
+				panic(fmt.Sprintf("%#v", err))
 			}
 		}
 
@@ -93,7 +94,7 @@ func main() {
 
 		newCommand, err = command.New(commandConfig)
 		if err != nil {
-			panic(err)
+			panic(fmt.Sprintf("%#v", err))
 		}
 	}
 


### PR DESCRIPTION
Currently they are missing. Example:

```
panic: config.K8sClient must not be empty: invalid config

goroutine 1 [running]:
main.main.func1(0xc4200bc1e0, 0xc4200bca50, 0xc42038e8e0)
        /go/src/github.com/giantswarm/kvm-operator/main.go:57 +0x38b
github.com/giantswarm/kvm-operator/vendor/github.com/giantswarm/microkit/command/daemon.(*command).Execute(0xc4202d6600, 0xc420360d80, 0xc4202b5ca0, 0x0, 0x2)
        /go/src/github.com/giantswarm/kvm-operator/vendor/github.com/giantswarm/microkit/command/daemon/command.go:121 +0x1a6
github.com/giantswarm/kvm-operator/vendor/github.com/giantswarm/microkit/command/daemon.(*command).Execute-fm(0xc420360d80, 0xc4202b5ca0, 0x0, 0x2)
        /go/src/github.com/giantswarm/kvm-operator/vendor/github.com/giantswarm/microkit/command/daemon/command.go:75 +0x52
github.com/giantswarm/kvm-operator/vendor/github.com/spf13/cobra.(*Command).execute(0xc420360d80, 0xc4202b5c40, 0x2, 0x2, 0xc420360d80, 0xc4202b5c40)
        /go/src/github.com/giantswarm/kvm-operator/vendor/github.com/spf13/cobra/command.go:653 +0x299
github.com/giantswarm/kvm-operator/vendor/github.com/spf13/cobra.(*Command).ExecuteC(0xc420358240, 0x17003d5, 0x35, 0xc42038e700)
        /go/src/github.com/giantswarm/kvm-operator/vendor/github.com/spf13/cobra/command.go:728 +0x339
github.com/giantswarm/kvm-operator/vendor/github.com/spf13/cobra.(*Command).Execute(0xc420358240, 0xc420358240, 0x1e)
        /go/src/github.com/giantswarm/kvm-operator/vendor/github.com/spf13/cobra/command.go:687 +0x2b
main.main()
        /go/src/github.com/giantswarm/kvm-operator/main.go:108 +0x83e
```