### PR TITLE
fix sleeping forever

### DIFF
--- a/service/resource/master/deployment.go
+++ b/service/resource/master/deployment.go
@@ -120,7 +120,7 @@ func (s *Service) newDeployments(obj interface{}) ([]*extensionsv1.Deployment, e
 								Command: []string{
 									"/bin/sh",
 									"-c",
-									"/opt/k8s-endpoint-updater update --provider.bridge.name=${NETWORK_BRIDGE_NAME} --provider.kind=bridge --service.kubernetes.address=\"\" --service.kubernetes.cluster.namespace=${POD_NAMESPACE} --service.kubernetes.cluster.service=master --service.kubernetes.inCluster=true --updater.pod.names=${POD_NAME}; while true; do sleep inf; done",
+									"/opt/k8s-endpoint-updater update --provider.bridge.name=${NETWORK_BRIDGE_NAME} --provider.kind=bridge --service.kubernetes.address=\"\" --service.kubernetes.cluster.namespace=${POD_NAMESPACE} --service.kubernetes.cluster.service=master --service.kubernetes.inCluster=true --updater.pod.names=${POD_NAME}; while true; do sleep 1000000; done",
 								},
 								SecurityContext: &apiv1.SecurityContext{
 									Privileged: &privileged,

--- a/service/resource/worker/deployment.go
+++ b/service/resource/worker/deployment.go
@@ -94,7 +94,7 @@ func (s *Service) newDeployments(obj interface{}) ([]*extensionsv1.Deployment, e
 								Command: []string{
 									"/bin/sh",
 									"-c",
-									"/opt/k8s-endpoint-updater update --provider.bridge.name=${NETWORK_BRIDGE_NAME} --provider.kind=bridge --service.kubernetes.address=\"\" --service.kubernetes.cluster.namespace=${POD_NAMESPACE} --service.kubernetes.cluster.service=worker --service.kubernetes.inCluster=true --updater.pod.names=${POD_NAME}; while true; do sleep inf; done",
+									"/opt/k8s-endpoint-updater update --provider.bridge.name=${NETWORK_BRIDGE_NAME} --provider.kind=bridge --service.kubernetes.address=\"\" --service.kubernetes.cluster.namespace=${POD_NAMESPACE} --service.kubernetes.cluster.service=worker --service.kubernetes.inCluster=true --updater.pod.names=${POD_NAME}; while true; do sleep 1000000; done",
 								},
 								SecurityContext: &apiv1.SecurityContext{
 									Privileged: &privileged,


### PR DESCRIPTION
The logs of the endpoint updater are spammed with sleep errors. This PR fixes this. 

```
$ kubectl -n b7xbr logs --tail 100 worker-nxr87-321176585-50mcz k8s-endpoint-updater
...
sleep: invalid number 'inf'
sleep: invalid number 'inf'
sleep: invalid number 'inf'
sleep: invalid number 'inf'
sleep: invalid number 'inf'
sleep: invalid number 'inf'
...