### PR TITLE
fixed wrong type error in namespace resource

### DIFF
--- a/service/resource/namespace/resource.go
+++ b/service/resource/namespace/resource.go
@@ -171,7 +171,7 @@ func (r *Resource) GetDeleteState(obj, currentState, desiredState interface{}) (
 }
 
 func (r *Resource) GetUpdateState(obj, currentState, desiredState interface{}) (interface{}, interface{}, interface{}, error) {
-	return []*apiv1.Namespace{}, []*apiv1.Namespace{}, []*apiv1.Namespace{}, nil
+	return *apiv1.Namespace{}, *apiv1.Namespace{}, *apiv1.Namespace{}, nil
 }
 
 func (r *Resource) Name() string {

--- a/service/resource/namespace/resource.go
+++ b/service/resource/namespace/resource.go
@@ -171,7 +171,7 @@ func (r *Resource) GetDeleteState(obj, currentState, desiredState interface{}) (
 }
 
 func (r *Resource) GetUpdateState(obj, currentState, desiredState interface{}) (interface{}, interface{}, interface{}, error) {
-	return *apiv1.Namespace{}, *apiv1.Namespace{}, *apiv1.Namespace{}, nil
+	return &apiv1.Namespace{}, &apiv1.Namespace{}, &apiv1.Namespace{}, nil
 }
 
 func (r *Resource) Name() string {


### PR DESCRIPTION
This fixes the following error.

```
{"caller":"github.com/giantswarm/kvm-operator/vendor/github.com/giantswarm/operatorkit/framework/framework.go:87","error":"[{/go/src/github.com/giantswarm/kvm-operator/vendor/github.com/giantswarm/operatorkit/framework/framework.go:266: } {/go/src/github.com/giantswarm/kvm-operator/service/resource/namespace/resource.go:188: } {/go/src/github.com/giantswarm/kvm-operator/service/resource/namespace/resource.go:262: expected '*v1.Namespace', got '[]*v1.Namespace'} {wrong type}]","event":"update","time":"17-09-15 13:37:49.927"}
```