### PR TITLE
renamed service to operator

### DIFF
--- a/service/operator/operator.go
+++ b/service/operator/operator.go
@@ -37,8 +37,21 @@ func DefaultConfig() Config {
 	}
 }
 
+// Operator implements the reconciliation of custom objects.
+type Operator struct {
+	// Dependencies.
+	backOff           backoff.BackOff
+	logger            micrologger.Logger
+	operatorFramework *framework.Framework
+
+	// Internals.
+	bootOnce sync.Once
+	mutex    sync.Mutex
+	tpr      *tpr.TPR
+}
+
 // New creates a new configured service.
-func New(config Config) (*Service, error) {
+func New(config Config) (*Operator, error) {
 	// Dependencies.
 	if config.BackOff == nil {
 		return nil, microerror.Maskf(invalidConfigError, "config.BackOff must not be empty")
@@ -72,7 +85,7 @@ func New(config Config) (*Service, error) {
 		}
 	}
 
-	newService := &Service{
+	newOperator := &Operator{
 		// Dependencies.
 		backOff:           config.BackOff,
 		logger:            config.Logger,
@@ -84,26 +97,13 @@ func New(config Config) (*Service, error) {
 		tpr:      newTPR,
 	}
 
-	return newService, nil
+	return newOperator, nil
 }
 
-// Service implements the service.
-type Service struct {
-	// Dependencies.
-	backOff           backoff.BackOff
-	logger            micrologger.Logger
-	operatorFramework *framework.Framework
-
-	// Internals.
-	bootOnce sync.Once
-	mutex    sync.Mutex
-	tpr      *tpr.TPR
-}
-
-func (s *Service) Boot() {
-	s.bootOnce.Do(func() {
-		o := func() error {
-			err := s.bootWithError()
+func (o *Operator) Boot() {
+	o.bootOnce.Do(func() {
+		operation := func() error {
+			err := o.bootWithError()
 			if err != nil {
 				return microerror.Mask(err)
 			}
@@ -111,36 +111,36 @@ func (s *Service) Boot() {
 			return nil
 		}
 
-		n := func(err error, d time.Duration) {
-			s.logger.Log("warning", fmt.Sprintf("retrying operator boot due to error: %#v", microerror.Mask(err)))
+		notifier := func(err error, d time.Duration) {
+			o.logger.Log("warning", fmt.Sprintf("retrying operator boot due to error: %#v", microerror.Mask(err)))
 		}
 
-		err := backoff.RetryNotify(o, s.backOff, n)
+		err := backoff.RetryNotify(operation, o.backOff, notifier)
 		if err != nil {
-			s.logger.Log("error", fmt.Sprintf("stop operator boot retries due to too many errors: %#v", microerror.Mask(err)))
+			o.logger.Log("error", fmt.Sprintf("stop operator boot retries due to too many errors: %#v", microerror.Mask(err)))
 			os.Exit(1)
 		}
 	})
 }
 
-func (s *Service) bootWithError() error {
-	err := s.tpr.CreateAndWait()
+func (o *Operator) bootWithError() error {
+	err := o.tpr.CreateAndWait()
 	if tpr.IsAlreadyExists(err) {
-		s.logger.Log("debug", "third party resource already exists")
+		o.logger.Log("debug", "third party resource already exists")
 	} else if err != nil {
 		return microerror.Mask(err)
 	}
 
-	s.logger.Log("debug", "starting list/watch")
+	o.logger.Log("debug", "starting list/watch")
 
-	newResourceEventHandler := s.operatorFramework.NewCacheResourceEventHandler()
+	newResourceEventHandler := o.operatorFramework.NewCacheResourceEventHandler()
 
 	newZeroObjectFactory := &tpr.ZeroObjectFactoryFuncs{
 		NewObjectFunc:     func() runtime.Object { return &kvmtpr.CustomObject{} },
 		NewObjectListFunc: func() runtime.Object { return &kvmtpr.List{} },
 	}
 
-	s.tpr.NewInformer(newResourceEventHandler, newZeroObjectFactory).Run(nil)
+	o.tpr.NewInformer(newResourceEventHandler, newZeroObjectFactory).Run(nil)
 
 	return nil
 }

--- a/service/service.go
+++ b/service/service.go
@@ -72,7 +72,7 @@ func DefaultConfig() Config {
 type Service struct {
 	// Dependencies.
 	Healthz  *healthz.Service
-	Operator *operator.Service
+	Operator *operator.Operator
 	Version  *version.Service
 
 	// Internals.
@@ -286,7 +286,7 @@ func New(config Config) (*Service, error) {
 		operatorBackOff.MaxElapsedTime = 5 * time.Minute
 	}
 
-	var operatorService *operator.Service
+	var operatorService *operator.Operator
 	{
 		operatorConfig := operator.DefaultConfig()
 


### PR DESCRIPTION
We should not name everything "service". further the main go file should be called after the package/directory name. 