### PR TITLE
hotfix-update

### DIFF
--- a/vendor/github.com/giantswarm/k8scloudconfig/v_0_1_0/master_template.go
+++ b/vendor/github.com/giantswarm/k8scloudconfig/v_0_1_0/master_template.go
@@ -1306,6 +1306,7 @@ coreos:
       --insecure_bind_address=0.0.0.0 \
       --insecure_port={{.Cluster.Kubernetes.API.InsecurePort}} \
       --kubelet_https=true \
+      --kubelet-preferred-address-types=InternalIP \
       --secure_port={{.Cluster.Kubernetes.API.SecurePort}} \
       --bind-address=${DEFAULT_IPV4} \
       --etcd-prefix={{.Cluster.Etcd.Prefix}} \


### PR DESCRIPTION
manual hotfix from https://github.com/giantswarm/k8scloudconfig/pull/215

The current situation means that each time master is restarted it will break operations kubectl `logs` and `exec` and we need to manually edit.