### PR TITLE
Update vendor

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: cb090b02793142b273d85791b0339228c241c9b36e3798478c227123e31a44ee
-updated: 2017-10-27T16:53:52.365910271+02:00
+hash: e4713821f0bf46fa425f80249a00a1db0fa6a90edacef7b0718078edf35188c8
+updated: 2017-10-31T08:04:20.062737094+01:00
 imports:
 - name: github.com/beorn7/perks
   version: 4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9
@@ -9,6 +9,10 @@ imports:
   version: 309aa717adbf351e92864cbedf9cca0b769a4b5a
 - name: github.com/cenkalti/backoff
   version: 309aa717adbf351e92864cbedf9cca0b769a4b5a
+- name: github.com/coreos/go-semver
+  version: 8ab6407b697782a06568d4b7f1db25550ec2e4c6
+  subpackages:
+  - semver
 - name: github.com/davecgh/go-spew
   version: 5215b55f46b2b919f50a1df0eaa5886afe4e3b3d
   subpackages:
@@ -44,7 +48,7 @@ imports:
   - spec/kubernetes/networksetup
   - spec/kubernetes/ssh
 - name: github.com/giantswarm/k8scloudconfig
-  version: 2698afb73c5e231611fae787ec6e1ebe015c41c0
+  version: 1a59619b01b5f70c3849667d71c8695ccb777c06
   subpackages:
   - v_0_1_0
 - name: github.com/giantswarm/k8shealthz
@@ -58,7 +62,7 @@ imports:
   - spec/kvm/k8skvm
   - spec/kvm/nodecontroller
 - name: github.com/giantswarm/microendpoint
-  version: 3ad61884ce7869f637cf4cdf4ff0a35a9ef60d5d
+  version: b93a1e9b89c26ba3bdcd5d19986d550fd090d213
   subpackages:
   - endpoint/healthz
   - endpoint/version
@@ -105,7 +109,7 @@ imports:
   - informer
   - tpr
 - name: github.com/giantswarm/versionbundle
-  version: 33129aa9036421b72ac122e0a8b643dc6b4454e5
+  version: 74ece9fd181fc5ef2a8510cbeb408485f9a0b1a3
 - name: github.com/go-kit/kit
   version: a9ca6725cbbea455e61c6bc8a1ed28e81eb3493b
   subpackages:
@@ -214,7 +218,7 @@ imports:
 - name: github.com/spf13/cast
   version: acbeb36b902d72a7a4c18e8f3241075e7ab763e4
 - name: github.com/spf13/cobra
-  version: 7b2c5ac9fc04fc5efafb60700713d4fa609b777b
+  version: b3426bbac13d7110c4d8fce456ea0012f79f3b8b
 - name: github.com/spf13/jwalterweatherman
   version: 12bd96e66386c1960ab0f74ced1362f66f552f7b
 - name: github.com/spf13/pflag

--- a/glide.yaml
+++ b/glide.yaml
@@ -10,9 +10,10 @@ import:
   version: master
 - package: github.com/giantswarm/kvmtpr
   version: master
-# Pinned to a version before RBAC magic came in.
+# Pinned to a branch with disabled RBAC.
+# Make sure to rebase k8scloudconfig "kvm-operator-disable-rbac" with "master"
 - package: github.com/giantswarm/k8scloudconfig
-  version: 2698afb73c5e231611fae787ec6e1ebe015c41c0
+  version: kvm-operator-disable-rbac
 - package: github.com/giantswarm/k8shealthz
   version: master
 - package: github.com/giantswarm/microendpoint

--- a/vendor/github.com/coreos/go-semver/.travis.yml
+++ b/vendor/github.com/coreos/go-semver/.travis.yml
@@ -1,0 +1,8 @@
+language: go
+sudo: false
+go:
+  - 1.4
+  - 1.5
+  - 1.6
+  - tip
+script: cd semver && go test

--- a/vendor/github.com/coreos/go-semver/LICENSE
+++ b/vendor/github.com/coreos/go-semver/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/github.com/coreos/go-semver/README.md
+++ b/vendor/github.com/coreos/go-semver/README.md
@@ -1,0 +1,28 @@
+# go-semver - Semantic Versioning Library
+
+[![Build Status](https://travis-ci.org/coreos/go-semver.svg?branch=master)](https://travis-ci.org/coreos/go-semver)
+[![GoDoc](https://godoc.org/github.com/coreos/go-semver/semver?status.svg)](https://godoc.org/github.com/coreos/go-semver/semver)
+
+go-semver is a [semantic versioning][semver] library for Go. It lets you parse
+and compare two semantic version strings.
+
+[semver]: http://semver.org/
+
+## Usage
+
+```go
+vA := semver.New("1.2.3")
+vB := semver.New("3.2.1")
+
+fmt.Printf("%s < %s == %t\n", vA, vB, vA.LessThan(*vB))
+```
+
+## Example Application
+
+```
+$ go run example.go 1.2.3 3.2.1
+1.2.3 < 3.2.1 == true
+
+$ go run example.go 5.2.3 3.2.1
+5.2.3 < 3.2.1 == false
+```

--- a/vendor/github.com/coreos/go-semver/example.go
+++ b/vendor/github.com/coreos/go-semver/example.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"fmt"
+	"github.com/coreos/go-semver/semver"
+	"os"
+)
+
+func main() {
+	vA, err := semver.NewVersion(os.Args[1])
+	if err != nil {
+		fmt.Println(err.Error())
+	}
+	vB, err := semver.NewVersion(os.Args[2])
+	if err != nil {
+		fmt.Println(err.Error())
+	}
+
+	fmt.Printf("%s < %s == %t\n", vA, vB, vA.LessThan(*vB))
+}

--- a/vendor/github.com/coreos/go-semver/semver/semver.go
+++ b/vendor/github.com/coreos/go-semver/semver/semver.go
@@ -1,0 +1,268 @@
+// Copyright 2013-2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Semantic Versions http://semver.org
+package semver
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+type Version struct {
+	Major      int64
+	Minor      int64
+	Patch      int64
+	PreRelease PreRelease
+	Metadata   string
+}
+
+type PreRelease string
+
+func splitOff(input *string, delim string) (val string) {
+	parts := strings.SplitN(*input, delim, 2)
+
+	if len(parts) == 2 {
+		*input = parts[0]
+		val = parts[1]
+	}
+
+	return val
+}
+
+func New(version string) *Version {
+	return Must(NewVersion(version))
+}
+
+func NewVersion(version string) (*Version, error) {
+	v := Version{}
+
+	if err := v.Set(version); err != nil {
+		return nil, err
+	}
+
+	return &v, nil
+}
+
+// Must is a helper for wrapping NewVersion and will panic if err is not nil.
+func Must(v *Version, err error) *Version {
+	if err != nil {
+		panic(err)
+	}
+	return v
+}
+
+// Set parses and updates v from the given version string. Implements flag.Value
+func (v *Version) Set(version string) error {
+	metadata := splitOff(&version, "+")
+	preRelease := PreRelease(splitOff(&version, "-"))
+	dotParts := strings.SplitN(version, ".", 3)
+
+	if len(dotParts) != 3 {
+		return fmt.Errorf("%s is not in dotted-tri format", version)
+	}
+
+	parsed := make([]int64, 3, 3)
+
+	for i, v := range dotParts[:3] {
+		val, err := strconv.ParseInt(v, 10, 64)
+		parsed[i] = val
+		if err != nil {
+			return err
+		}
+	}
+
+	v.Metadata = metadata
+	v.PreRelease = preRelease
+	v.Major = parsed[0]
+	v.Minor = parsed[1]
+	v.Patch = parsed[2]
+	return nil
+}
+
+func (v Version) String() string {
+	var buffer bytes.Buffer
+
+	fmt.Fprintf(&buffer, "%d.%d.%d", v.Major, v.Minor, v.Patch)
+
+	if v.PreRelease != "" {
+		fmt.Fprintf(&buffer, "-%s", v.PreRelease)
+	}
+
+	if v.Metadata != "" {
+		fmt.Fprintf(&buffer, "+%s", v.Metadata)
+	}
+
+	return buffer.String()
+}
+
+func (v *Version) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var data string
+	if err := unmarshal(&data); err != nil {
+		return err
+	}
+	return v.Set(data)
+}
+
+func (v Version) MarshalJSON() ([]byte, error) {
+	return []byte(`"` + v.String() + `"`), nil
+}
+
+func (v *Version) UnmarshalJSON(data []byte) error {
+	l := len(data)
+	if l == 0 || string(data) == `""` {
+		return nil
+	}
+	if l < 2 || data[0] != '"' || data[l-1] != '"' {
+		return errors.New("invalid semver string")
+	}
+	return v.Set(string(data[1 : l-1]))
+}
+
+// Compare tests if v is less than, equal to, or greater than versionB,
+// returning -1, 0, or +1 respectively.
+func (v Version) Compare(versionB Version) int {
+	if cmp := recursiveCompare(v.Slice(), versionB.Slice()); cmp != 0 {
+		return cmp
+	}
+	return preReleaseCompare(v, versionB)
+}
+
+// Equal tests if v is equal to versionB.
+func (v Version) Equal(versionB Version) bool {
+	return v.Compare(versionB) == 0
+}
+
+// LessThan tests if v is less than versionB.
+func (v Version) LessThan(versionB Version) bool {
+	return v.Compare(versionB) < 0
+}
+
+// Slice converts the comparable parts of the semver into a slice of integers.
+func (v Version) Slice() []int64 {
+	return []int64{v.Major, v.Minor, v.Patch}
+}
+
+func (p PreRelease) Slice() []string {
+	preRelease := string(p)
+	return strings.Split(preRelease, ".")
+}
+
+func preReleaseCompare(versionA Version, versionB Version) int {
+	a := versionA.PreRelease
+	b := versionB.PreRelease
+
+	/* Handle the case where if two versions are otherwise equal it is the
+	 * one without a PreRelease that is greater */
+	if len(a) == 0 && (len(b) > 0) {
+		return 1
+	} else if len(b) == 0 && (len(a) > 0) {
+		return -1
+	}
+
+	// If there is a prerelease, check and compare each part.
+	return recursivePreReleaseCompare(a.Slice(), b.Slice())
+}
+
+func recursiveCompare(versionA []int64, versionB []int64) int {
+	if len(versionA) == 0 {
+		return 0
+	}
+
+	a := versionA[0]
+	b := versionB[0]
+
+	if a > b {
+		return 1
+	} else if a < b {
+		return -1
+	}
+
+	return recursiveCompare(versionA[1:], versionB[1:])
+}
+
+func recursivePreReleaseCompare(versionA []string, versionB []string) int {
+	// A larger set of pre-release fields has a higher precedence than a smaller set,
+	// if all of the preceding identifiers are equal.
+	if len(versionA) == 0 {
+		if len(versionB) > 0 {
+			return -1
+		}
+		return 0
+	} else if len(versionB) == 0 {
+		// We're longer than versionB so return 1.
+		return 1
+	}
+
+	a := versionA[0]
+	b := versionB[0]
+
+	aInt := false
+	bInt := false
+
+	aI, err := strconv.Atoi(versionA[0])
+	if err == nil {
+		aInt = true
+	}
+
+	bI, err := strconv.Atoi(versionB[0])
+	if err == nil {
+		bInt = true
+	}
+
+	// Handle Integer Comparison
+	if aInt && bInt {
+		if aI > bI {
+			return 1
+		} else if aI < bI {
+			return -1
+		}
+	}
+
+	// Handle String Comparison
+	if a > b {
+		return 1
+	} else if a < b {
+		return -1
+	}
+
+	return recursivePreReleaseCompare(versionA[1:], versionB[1:])
+}
+
+// BumpMajor increments the Major field by 1 and resets all other fields to their default values
+func (v *Version) BumpMajor() {
+	v.Major += 1
+	v.Minor = 0
+	v.Patch = 0
+	v.PreRelease = PreRelease("")
+	v.Metadata = ""
+}
+
+// BumpMinor increments the Minor field by 1 and resets all other fields to their default values
+func (v *Version) BumpMinor() {
+	v.Minor += 1
+	v.Patch = 0
+	v.PreRelease = PreRelease("")
+	v.Metadata = ""
+}
+
+// BumpPatch increments the Patch field by 1 and resets all other fields to their default values
+func (v *Version) BumpPatch() {
+	v.Patch += 1
+	v.PreRelease = PreRelease("")
+	v.Metadata = ""
+}

--- a/vendor/github.com/coreos/go-semver/semver/semver_test.go
+++ b/vendor/github.com/coreos/go-semver/semver/semver_test.go
@@ -1,0 +1,370 @@
+// Copyright 2013-2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package semver
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"math/rand"
+	"reflect"
+	"testing"
+	"time"
+
+	"gopkg.in/yaml.v2"
+)
+
+type fixture struct {
+	GreaterVersion string
+	LesserVersion  string
+}
+
+var fixtures = []fixture{
+	fixture{"0.0.0", "0.0.0-foo"},
+	fixture{"0.0.1", "0.0.0"},
+	fixture{"1.0.0", "0.9.9"},
+	fixture{"0.10.0", "0.9.0"},
+	fixture{"0.99.0", "0.10.0"},
+	fixture{"2.0.0", "1.2.3"},
+	fixture{"0.0.0", "0.0.0-foo"},
+	fixture{"0.0.1", "0.0.0"},
+	fixture{"1.0.0", "0.9.9"},
+	fixture{"0.10.0", "0.9.0"},
+	fixture{"0.99.0", "0.10.0"},
+	fixture{"2.0.0", "1.2.3"},
+	fixture{"0.0.0", "0.0.0-foo"},
+	fixture{"0.0.1", "0.0.0"},
+	fixture{"1.0.0", "0.9.9"},
+	fixture{"0.10.0", "0.9.0"},
+	fixture{"0.99.0", "0.10.0"},
+	fixture{"2.0.0", "1.2.3"},
+	fixture{"1.2.3", "1.2.3-asdf"},
+	fixture{"1.2.3", "1.2.3-4"},
+	fixture{"1.2.3", "1.2.3-4-foo"},
+	fixture{"1.2.3-5-foo", "1.2.3-5"},
+	fixture{"1.2.3-5", "1.2.3-4"},
+	fixture{"1.2.3-5-foo", "1.2.3-5-Foo"},
+	fixture{"3.0.0", "2.7.2+asdf"},
+	fixture{"3.0.0+foobar", "2.7.2"},
+	fixture{"1.2.3-a.10", "1.2.3-a.5"},
+	fixture{"1.2.3-a.b", "1.2.3-a.5"},
+	fixture{"1.2.3-a.b", "1.2.3-a"},
+	fixture{"1.2.3-a.b.c.10.d.5", "1.2.3-a.b.c.5.d.100"},
+	fixture{"1.0.0", "1.0.0-rc.1"},
+	fixture{"1.0.0-rc.2", "1.0.0-rc.1"},
+	fixture{"1.0.0-rc.1", "1.0.0-beta.11"},
+	fixture{"1.0.0-beta.11", "1.0.0-beta.2"},
+	fixture{"1.0.0-beta.2", "1.0.0-beta"},
+	fixture{"1.0.0-beta", "1.0.0-alpha.beta"},
+	fixture{"1.0.0-alpha.beta", "1.0.0-alpha.1"},
+	fixture{"1.0.0-alpha.1", "1.0.0-alpha"},
+}
+
+func TestCompare(t *testing.T) {
+	for _, v := range fixtures {
+		gt, err := NewVersion(v.GreaterVersion)
+		if err != nil {
+			t.Error(err)
+		}
+
+		lt, err := NewVersion(v.LesserVersion)
+		if err != nil {
+			t.Error(err)
+		}
+
+		if gt.LessThan(*lt) {
+			t.Errorf("%s should not be less than %s", gt, lt)
+		}
+		if gt.Equal(*lt) {
+			t.Errorf("%s should not be equal to %s", gt, lt)
+		}
+		if gt.Compare(*lt) <= 0 {
+			t.Errorf("%s should be greater than %s", gt, lt)
+		}
+		if !lt.LessThan(*gt) {
+			t.Errorf("%s should be less than %s", lt, gt)
+		}
+		if !lt.Equal(*lt) {
+			t.Errorf("%s should be equal to %s", lt, lt)
+		}
+		if lt.Compare(*gt) > 0 {
+			t.Errorf("%s should not be greater than %s", lt, gt)
+		}
+	}
+}
+
+func testString(t *testing.T, orig string, version *Version) {
+	if orig != version.String() {
+		t.Errorf("%s != %s", orig, version)
+	}
+}
+
+func TestString(t *testing.T) {
+	for _, v := range fixtures {
+		gt, err := NewVersion(v.GreaterVersion)
+		if err != nil {
+			t.Error(err)
+		}
+		testString(t, v.GreaterVersion, gt)
+
+		lt, err := NewVersion(v.LesserVersion)
+		if err != nil {
+			t.Error(err)
+		}
+		testString(t, v.LesserVersion, lt)
+	}
+}
+
+func shuffleStringSlice(src []string) []string {
+	dest := make([]string, len(src))
+	rand.Seed(time.Now().Unix())
+	perm := rand.Perm(len(src))
+	for i, v := range perm {
+		dest[v] = src[i]
+	}
+	return dest
+}
+
+func TestSort(t *testing.T) {
+	sortedVersions := []string{"1.0.0", "1.0.2", "1.2.0", "3.1.1"}
+	unsortedVersions := shuffleStringSlice(sortedVersions)
+
+	semvers := []*Version{}
+	for _, v := range unsortedVersions {
+		sv, err := NewVersion(v)
+		if err != nil {
+			t.Fatal(err)
+		}
+		semvers = append(semvers, sv)
+	}
+
+	Sort(semvers)
+
+	for idx, sv := range semvers {
+		if sv.String() != sortedVersions[idx] {
+			t.Fatalf("incorrect sort at index %v", idx)
+		}
+	}
+}
+
+func TestBumpMajor(t *testing.T) {
+	version, _ := NewVersion("1.0.0")
+	version.BumpMajor()
+	if version.Major != 2 {
+		t.Fatalf("bumping major on 1.0.0 resulted in %v", version)
+	}
+
+	version, _ = NewVersion("1.5.2")
+	version.BumpMajor()
+	if version.Minor != 0 && version.Patch != 0 {
+		t.Fatalf("bumping major on 1.5.2 resulted in %v", version)
+	}
+
+	version, _ = NewVersion("1.0.0+build.1-alpha.1")
+	version.BumpMajor()
+	if version.PreRelease != "" && version.PreRelease != "" {
+		t.Fatalf("bumping major on 1.0.0+build.1-alpha.1 resulted in %v", version)
+	}
+}
+
+func TestBumpMinor(t *testing.T) {
+	version, _ := NewVersion("1.0.0")
+	version.BumpMinor()
+
+	if version.Major != 1 {
+		t.Fatalf("bumping minor on 1.0.0 resulted in %v", version)
+	}
+
+	if version.Minor != 1 {
+		t.Fatalf("bumping major on 1.0.0 resulted in %v", version)
+	}
+
+	version, _ = NewVersion("1.0.0+build.1-alpha.1")
+	version.BumpMinor()
+	if version.PreRelease != "" && version.PreRelease != "" {
+		t.Fatalf("bumping major on 1.0.0+build.1-alpha.1 resulted in %v", version)
+	}
+}
+
+func TestBumpPatch(t *testing.T) {
+	version, _ := NewVersion("1.0.0")
+	version.BumpPatch()
+
+	if version.Major != 1 {
+		t.Fatalf("bumping minor on 1.0.0 resulted in %v", version)
+	}
+
+	if version.Minor != 0 {
+		t.Fatalf("bumping major on 1.0.0 resulted in %v", version)
+	}
+
+	if version.Patch != 1 {
+		t.Fatalf("bumping major on 1.0.0 resulted in %v", version)
+	}
+
+	version, _ = NewVersion("1.0.0+build.1-alpha.1")
+	version.BumpPatch()
+	if version.PreRelease != "" && version.PreRelease != "" {
+		t.Fatalf("bumping major on 1.0.0+build.1-alpha.1 resulted in %v", version)
+	}
+}
+
+func TestMust(t *testing.T) {
+	tests := []struct {
+		versionStr string
+
+		version *Version
+		recov   interface{}
+	}{
+		{
+			versionStr: "1.0.0",
+			version:    &Version{Major: 1},
+		},
+		{
+			versionStr: "version number",
+			recov:      errors.New("version number is not in dotted-tri format"),
+		},
+	}
+
+	for _, tt := range tests {
+		func() {
+			defer func() {
+				recov := recover()
+				if !reflect.DeepEqual(tt.recov, recov) {
+					t.Fatalf("incorrect panic for %q: want %v, got %v", tt.versionStr, tt.recov, recov)
+				}
+			}()
+
+			version := Must(NewVersion(tt.versionStr))
+			if !reflect.DeepEqual(tt.version, version) {
+				t.Fatalf("incorrect version for %q: want %+v, got %+v", tt.versionStr, tt.version, version)
+			}
+		}()
+	}
+}
+
+type fixtureJSON struct {
+	GreaterVersion *Version
+	LesserVersion  *Version
+}
+
+func TestJSON(t *testing.T) {
+	fj := make([]fixtureJSON, len(fixtures))
+	for i, v := range fixtures {
+		var err error
+		fj[i].GreaterVersion, err = NewVersion(v.GreaterVersion)
+		if err != nil {
+			t.Fatal(err)
+		}
+		fj[i].LesserVersion, err = NewVersion(v.LesserVersion)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	fromStrings, err := json.Marshal(fixtures)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fromVersions, err := json.Marshal(fj)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(fromStrings, fromVersions) {
+		t.Errorf("Expected:   %s", fromStrings)
+		t.Errorf("Unexpected: %s", fromVersions)
+	}
+
+	fromJson := make([]fixtureJSON, 0, len(fj))
+	err = json.Unmarshal(fromStrings, &fromJson)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(fromJson, fj) {
+		t.Error("Expected:   ", fj)
+		t.Error("Unexpected: ", fromJson)
+	}
+}
+
+func TestYAML(t *testing.T) {
+	document, err := yaml.Marshal(fixtures)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := make([]fixtureJSON, len(fixtures))
+	for i, v := range fixtures {
+		var err error
+		expected[i].GreaterVersion, err = NewVersion(v.GreaterVersion)
+		if err != nil {
+			t.Fatal(err)
+		}
+		expected[i].LesserVersion, err = NewVersion(v.LesserVersion)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	fromYAML := make([]fixtureJSON, 0, len(fixtures))
+	err = yaml.Unmarshal(document, &fromYAML)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !reflect.DeepEqual(fromYAML, expected) {
+		t.Error("Expected:   ", expected)
+		t.Error("Unexpected: ", fromYAML)
+	}
+}
+
+func TestBadInput(t *testing.T) {
+	bad := []string{
+		"1.2",
+		"1.2.3x",
+		"0x1.3.4",
+		"-1.2.3",
+		"1.2.3.4",
+	}
+	for _, b := range bad {
+		if _, err := NewVersion(b); err == nil {
+			t.Error("Improperly accepted value: ", b)
+		}
+	}
+}
+
+func TestFlag(t *testing.T) {
+	v := Version{}
+	f := flag.NewFlagSet("version", flag.ContinueOnError)
+	f.Var(&v, "version", "set version")
+
+	if err := f.Set("version", "1.2.3"); err != nil {
+		t.Fatal(err)
+	}
+
+	if v.String() != "1.2.3" {
+		t.Errorf("Set wrong value %q", v)
+	}
+}
+
+func ExampleVersion_LessThan() {
+	vA := New("1.2.3")
+	vB := New("3.2.1")
+
+	fmt.Printf("%s < %s == %t\n", vA, vB, vA.LessThan(*vB))
+	// Output:
+	// 1.2.3 < 3.2.1 == true
+}

--- a/vendor/github.com/coreos/go-semver/semver/sort.go
+++ b/vendor/github.com/coreos/go-semver/semver/sort.go
@@ -1,0 +1,38 @@
+// Copyright 2013-2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package semver
+
+import (
+	"sort"
+)
+
+type Versions []*Version
+
+func (s Versions) Len() int {
+	return len(s)
+}
+
+func (s Versions) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}
+
+func (s Versions) Less(i, j int) bool {
+	return s[i].LessThan(*s[j])
+}
+
+// Sort sorts the given slice of Version
+func Sort(versions []*Version) {
+	sort.Sort(Versions(versions))
+}

--- a/vendor/github.com/giantswarm/k8scloudconfig/v_0_1_0/master_template.go
+++ b/vendor/github.com/giantswarm/k8scloudconfig/v_0_1_0/master_template.go
@@ -10,14 +10,87 @@ users:
        - "{{ $user.PublicKey }}"
 {{end}}
 write_files:
-- path: /srv/calico-policy-controller-sa.yaml
+- path: /srv/calico-node-controller-sa.yaml
   owner: root
   permissions: 644
   content: |
     apiVersion: v1
     kind: ServiceAccount
     metadata:
-      name: calico-policy-controller
+      name: calico-node-controller
+      namespace: kube-system
+- path: /srv/calico-node-controller.yaml
+  owner: root
+  permissions: 644
+  content: |
+    apiVersion: extensions/v1beta1
+    kind: Deployment
+    metadata:
+      name: calico-node-controller
+      namespace: kube-system
+      labels:
+        k8s-app: calico-node-controller
+    spec:
+      replicas: 1
+      strategy:
+        type: Recreate
+      template:
+        metadata:
+          name: calico-node-controller
+          namespace: kube-system
+          labels:
+            k8s-app: calico-node-controller
+        spec:
+          serviceAccountName: calico-node-controller
+          containers:
+            - name: calico-node-controller
+              image: quay.io/giantswarm/calico-node-controller
+              env:
+                # The location of the Calico etcd cluster.
+                - name: ETCD_ENDPOINTS
+                  valueFrom:
+                    configMapKeyRef:
+                      name: calico-config
+                      key: etcd_endpoints
+                # Location of the CA certificate for etcd.
+                - name: ETCD_CA_CERT_FILE
+                  valueFrom:
+                    configMapKeyRef:
+                      name: calico-config
+                      key: etcd_ca
+                # Location of the client key for etcd.
+                - name: ETCD_KEY_FILE
+                  valueFrom:
+                    configMapKeyRef:
+                      name: calico-config
+                      key: etcd_key
+                # Location of the client certificate for etcd.
+                - name: ETCD_CERT_FILE
+                  valueFrom:
+                    configMapKeyRef:
+                      name: calico-config
+                      key: etcd_cert
+                # The location of the Kubernetes API.  Use the default Kubernetes
+                # service for API access.
+                - name: K8S_API
+                  value: "https://kubernetes.default:443"
+              volumeMounts:
+                # Mount in the etcd TLS secrets.
+                - mountPath: /etc/kubernetes/ssl/etcd
+                  name: etcd-certs
+          volumes:
+            # Mount in the etcd TLS secrets.
+            - name: etcd-certs
+              hostPath:
+                path: /etc/kubernetes/ssl/etcd
+- path: /srv/calico-kube-controllers-sa.yaml
+  owner: root
+  permissions: 644
+  content: |
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      name: calico-kube-controllers
       namespace: kube-system
 - path: /srv/calico-node-sa.yaml
   owner: root
@@ -32,12 +105,12 @@ write_files:
   owner: root
   permissions: 644
   content: |
-    # Calico Version v2.5.1
-    # https://docs.projectcalico.org/v2.5/releases#v2.5.1
+    # Calico Version v2.6.2
+    # https://docs.projectcalico.org/v2.6/releases#v2.6.2
     # This manifest includes the following component versions:
-    #   calico/node:v2.5.1
-    #   calico/cni:v1.10.0
-    #   calico/kube-policy-controller:v0.7.0
+    #   calico/node:v2.6.2
+    #   calico/cni:v1.11.0
+    #   calico/kube-controllers:v1.0.0
 
     # This ConfigMap is used to configure a self-hosted Calico installation.
     kind: ConfigMap
@@ -126,7 +199,7 @@ write_files:
             # container programs network policy and routes on each
             # host.
             - name: calico-node
-              image: quay.io/calico/node:v2.5.1
+              image: quay.io/calico/node:v2.6.2
               env:
                 # The location of the Calico etcd cluster.
                 - name: ETCD_ENDPOINTS
@@ -215,7 +288,7 @@ write_files:
             # This container installs the Calico CNI binaries
             # and CNI network config file on each node.
             - name: install-cni
-              image: quay.io/calico/cni:v1.10.0
+              image: quay.io/calico/cni:v1.11.0
               command: ["/install-cni.sh"]
               env:
                 # The location of the Calico etcd cluster.
@@ -272,24 +345,21 @@ write_files:
             - name: cni-net-dir
               hostPath:
                path: /etc/cni/net.d
-- path: /srv/calico-policy-controller.yaml
+- path: /srv/calico-kube-controllers.yaml
   owner: root
   permissions: 644
   content: |
-    # This manifest deploys the Calico policy controller on Kubernetes.
-    # See https://github.com/projectcalico/k8s-policy
+    # This manifest deploys the Calico Kubernetes controllers.
+    # See https://github.com/projectcalico/kube-controllers
     apiVersion: extensions/v1beta1
     kind: Deployment
     metadata:
-      name: calico-policy-controller
+      name: calico-kube-controllers
       namespace: kube-system
       labels:
-        k8s-app: calico-policy
+        k8s-app: calico-kube-controllers
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
-        scheduler.alpha.kubernetes.io/tolerations: |
-          [{"key": "dedicated", "value": "master", "effect": "NoSchedule" },
-           {"key":"CriticalAddonsOnly", "operator":"Exists"}]
     spec:
       # The policy controller can only have a single active instance.
       replicas: 1
@@ -297,18 +367,24 @@ write_files:
         type: Recreate
       template:
         metadata:
-          name: calico-policy-controller
+          name: calico-kube-controllers
           namespace: kube-system
           labels:
-            k8s-app: calico-policy
+            k8s-app: calico-kube-controllers
         spec:
-          # The policy controller must run in the host network namespace so that
+          tolerations:
+          - key: node-role.kubernetes.io/master
+            operator: Exists
+            effect: NoSchedule
+          - key: CriticalAddonsOnly
+            operator: Exists
+          # The controllers must run in the host network namespace so that
           # it isn't governed by policy that would prevent it from working.
           hostNetwork: true
-          serviceAccountName: calico-policy-controller
+          serviceAccountName: calico-kube-controllers
           containers:
-            - name: calico-policy-controller
-              image: quay.io/calico/kube-policy-controller:v0.7.0
+            - name: calico-kube-controllers
+              image: quay.io/calico/kube-controllers:v1.0.0
               env:
                 # The location of the Calico etcd cluster.
                 - name: ETCD_ENDPOINTS
@@ -334,7 +410,7 @@ write_files:
                     configMapKeyRef:
                       name: calico-config
                       key: etcd_cert
-                # The location of the Kubernetes API.  Use the default Kubernetes
+                # The location of the Kubernetes API. Use the default Kubernetes
                 # service for API access.
                 - name: K8S_API
                   value: "https://{{.Cluster.Kubernetes.API.Domain}}:443"
@@ -687,6 +763,7 @@ write_files:
                         values:
                         - nginx-ingress-controller
                   topologyKey: kubernetes.io/hostname
+          serviceAccountName: nginx-ingress-controller
           containers:
           - name: nginx-ingress-controller
             image: {{.Cluster.Kubernetes.IngressController.Docker.Image}}
@@ -746,6 +823,441 @@ write_files:
         targetPort: 443
       selector:
         k8s-app: nginx-ingress-controller
+- path: /srv/rbac_bindings.yaml
+  owner: root
+  permissions: 0644
+  content: |
+    ## User
+    kind: ClusterRoleBinding
+    apiVersion: rbac.authorization.k8s.io/v1beta1
+    metadata:
+      name: giantswarm-admin
+    subjects:
+    - kind: User
+      name: {{.Cluster.Kubernetes.API.Domain}}
+      apiGroup: rbac.authorization.k8s.io
+    roleRef:
+      kind: ClusterRole
+      name: cluster-admin
+      apiGroup: rbac.authorization.k8s.io
+    ---
+    ## Worker
+    kind: ClusterRoleBinding
+    apiVersion: rbac.authorization.k8s.io/v1beta1
+    metadata:
+      name: kubelet
+    subjects:
+    - kind: User
+      name: {{.Cluster.Kubernetes.Kubelet.Domain}}
+      apiGroup: rbac.authorization.k8s.io
+    roleRef:
+      kind: ClusterRole
+      name: system:node
+      apiGroup: rbac.authorization.k8s.io
+    ---
+    kind: ClusterRoleBinding
+    apiVersion: rbac.authorization.k8s.io/v1beta1
+    metadata:
+      name: proxy
+    subjects:
+    - kind: User
+      name: {{.Cluster.Kubernetes.Kubelet.Domain}}
+      apiGroup: rbac.authorization.k8s.io
+    roleRef:
+      kind: ClusterRole
+      name: system:node-proxier
+      apiGroup: rbac.authorization.k8s.io
+    ---
+    ## Master
+    kind: ClusterRoleBinding
+    apiVersion: rbac.authorization.k8s.io/v1beta1
+    metadata:
+      name: kube-controller-manager
+    subjects:
+    - kind: User
+      name: {{.Cluster.Kubernetes.API.Domain}}
+      apiGroup: rbac.authorization.k8s.io
+    roleRef:
+      kind: ClusterRole
+      name: system:kube-controller-manager
+      apiGroup: rbac.authorization.k8s.io
+    ---
+    kind: ClusterRoleBinding
+    apiVersion: rbac.authorization.k8s.io/v1beta1
+    metadata:
+      name: kube-scheduler
+    subjects:
+    - kind: User
+      name: {{.Cluster.Kubernetes.API.Domain}}
+      apiGroup: rbac.authorization.k8s.io
+    roleRef:
+      kind: ClusterRole
+      name: system:kube-scheduler
+      apiGroup: rbac.authorization.k8s.io
+    ---
+    ## Calico
+    kind: ClusterRoleBinding
+    apiVersion: rbac.authorization.k8s.io/v1beta1
+    metadata:
+      name: calico-kube-controllers
+    subjects:
+    - kind: ServiceAccount
+      name: calico-kube-controllers
+      namespace: kube-system
+    roleRef:
+      kind: ClusterRole
+      name: calico-kube-controllers
+      apiGroup: rbac.authorization.k8s.io
+    ---
+    kind: ClusterRoleBinding
+    apiVersion: rbac.authorization.k8s.io/v1beta1
+    metadata:
+      name: calico-node
+    subjects:
+    - kind: ServiceAccount
+      name: calico-node
+      namespace: kube-system
+    roleRef:
+      kind: ClusterRole
+      name: calico-node
+      apiGroup: rbac.authorization.k8s.io
+    ---
+    kind: ClusterRoleBinding
+    apiVersion: rbac.authorization.k8s.io/v1beta1
+    metadata:
+      name: calico-node-controller
+    subjects:
+    - kind: ServiceAccount
+      name: calico-node-controller
+      namespace: kube-system
+    roleRef:
+      kind: ClusterRole
+      name: calico-node-controller
+      apiGroup: rbac.authorization.k8s.io
+    ---
+    ## DNS
+    kind: ClusterRoleBinding
+    apiVersion: rbac.authorization.k8s.io/v1beta1
+    metadata:
+      name: kube-dns
+    subjects:
+    - kind: ServiceAccount
+      name: kube-dns
+      namespace: kube-system
+    roleRef:
+      kind: ClusterRole
+      name: system:kube-dns
+      apiGroup: rbac.authorization.k8s.io
+    ---
+    ## IC
+    kind: ClusterRoleBinding
+    apiVersion: rbac.authorization.k8s.io/v1beta1
+    metadata:
+      name: nginx-ingress-controller
+    subjects:
+    - kind: ServiceAccount
+      name: nginx-ingress-controller
+      namespace: kube-system
+    roleRef:
+      kind: ClusterRole
+      name: nginx-ingress-controller
+      apiGroup: rbac.authorization.k8s.io
+    ---
+    kind: RoleBinding
+    apiVersion: rbac.authorization.k8s.io/v1beta1
+    metadata:
+      name: nginx-ingress-controller
+      namespace: kube-system
+    subjects:
+    - kind: ServiceAccount
+      name: nginx-ingress-controller
+      namespace: kube-system
+    roleRef:
+      kind: Role
+      name: nginx-ingress-role
+      apiGroup: rbac.authorization.k8s.io
+- path: /srv/rbac_roles.yaml
+  owner: root
+  permissions: 0644
+  content: |
+    ## Calico
+    kind: ClusterRole
+    apiVersion: rbac.authorization.k8s.io/v1beta1
+    metadata:
+      name: calico-kube-controllers
+      namespace: kube-system
+    rules:
+      - apiGroups:
+        - ""
+        - extensions
+        resources:
+          - pods
+          - namespaces
+          - networkpolicies
+        verbs:
+          - watch
+          - list
+    ---
+    kind: ClusterRole
+    apiVersion: rbac.authorization.k8s.io/v1beta1
+    metadata:
+      name: calico-node
+      namespace: kube-system
+    rules:
+      - apiGroups: [""]
+        resources:
+          - pods
+          - nodes
+        verbs:
+          - get
+    ---
+    kind: ClusterRole
+    apiVersion: rbac.authorization.k8s.io/v1beta1
+    metadata:
+      name: calico-node-controller
+      namespace: kube-system
+    rules:
+      - apiGroups:
+        - ""
+        - extensions
+        resources:
+          - nodes
+        verbs:
+          - watch
+          - list
+    ---
+    ## IC
+    apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      name: nginx-ingress-controller
+      namespace: kube-system
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1beta1
+    kind: ClusterRole
+    metadata:
+      name: nginx-ingress-controller
+      namespace: kube-system
+    rules:
+      - apiGroups:
+          - ""
+        resources:
+          - configmaps
+          - endpoints
+          - nodes
+          - pods
+          - secrets
+        verbs:
+          - list
+          - watch
+      - apiGroups:
+          - ""
+        resources:
+          - nodes
+        verbs:
+          - get
+      - apiGroups:
+          - ""
+        resources:
+          - services
+        verbs:
+          - get
+          - list
+          - watch
+      - apiGroups:
+          - "extensions"
+        resources:
+          - ingresses
+        verbs:
+          - get
+          - list
+          - watch
+      - apiGroups:
+          - ""
+        resources:
+            - events
+        verbs:
+            - create
+            - patch
+      - apiGroups:
+          - "extensions"
+        resources:
+          - ingresses/status
+        verbs:
+          - update
+    ---
+    apiVersion: rbac.authorization.k8s.io/v1beta1
+    kind: Role
+    metadata:
+      name: nginx-ingress-role
+      namespace: kube-system
+    rules:
+      - apiGroups:
+          - ""
+        resources:
+          - configmaps
+          - pods
+          - secrets
+          - namespaces
+        verbs:
+          - get
+      - apiGroups:
+          - ""
+        resources:
+          - configmaps
+        resourceNames:
+          # Defaults to "<election-id>-<ingress-class>"
+          # Here: "<ingress-controller-leader>-<nginx>"
+          # This has to be adapted if you change either parameter
+          # when launching the nginx-ingress-controller.
+          - "ingress-controller-leader-nginx"
+        verbs:
+          - get
+          - update
+      - apiGroups:
+          - ""
+        resources:
+          - configmaps
+        verbs:
+          - create
+      - apiGroups:
+          - ""
+        resources:
+          - endpoints
+        verbs:
+          - get
+          - create
+          - update
+- path: /srv/psp_policies.yaml
+  owner: root
+  permissions: 0644
+  content: |
+    apiVersion: extensions/v1beta1
+    kind: PodSecurityPolicy
+    metadata:
+      name: privileged
+    spec:
+      allowPrivilegeEscalation: true
+      fsGroup:
+        rule: RunAsAny
+      privileged: true
+      runAsUser:
+        rule: RunAsAny
+      seLinux:
+        rule: RunAsAny
+      supplementalGroups:
+        rule: RunAsAny
+      volumes:
+      - '*'
+      hostPID: true
+      hostIPC: true
+      hostNetwork: true
+      hostPorts:
+      - min: 1
+        max: 65536
+    ---
+    apiVersion: extensions/v1beta1
+    kind: PodSecurityPolicy
+    metadata:
+      name: restricted
+    spec:
+      privileged: false
+      fsGroup:
+        rule: RunAsAny
+      runAsUser:
+        rule: RunAsAny
+      seLinux:
+        rule: RunAsAny
+      supplementalGroups:
+        rule: RunAsAny
+      volumes:
+      - 'emptyDir'
+      - 'secret'
+      - 'downwardAPI'
+      - 'configMap'
+      - 'persistentVolumeClaim'
+      - 'projected'
+      hostPID: false
+      hostIPC: false
+      hostNetwork: false
+- path: /srv/psp_roles.yaml
+  owner: root
+  permissions: 0644
+  content: |
+    # restrictedPSP grants access to use
+    # the restricted PSP.
+    apiVersion: rbac.authorization.k8s.io/v1beta1
+    kind: ClusterRole
+    metadata:
+      name: restricted-psp-user
+    rules:
+    - apiGroups:
+      - extensions
+      resources:
+      - podsecuritypolicies
+      resourceNames:
+      - restricted
+      verbs:
+      - use
+    ---
+    # privilegedPSP grants access to use the privileged
+    # PSP.
+    apiVersion: rbac.authorization.k8s.io/v1beta1
+    kind: ClusterRole
+    metadata:
+      name: privileged-psp-user
+    rules:
+    - apiGroups:
+      - extensions
+      resources:
+      - podsecuritypolicies
+      resourceNames:
+      - privileged
+      verbs:
+      - use
+- path: /srv/psp_binding.yaml
+  owner: root
+  permissions: 0644
+  content: |
+    apiVersion: rbac.authorization.k8s.io/v1beta1
+    kind: ClusterRoleBinding
+    metadata:
+        name: privileged-psp-users
+    subjects:
+    - kind: ServiceAccount
+      name: calico-node
+      namespace: kube-system
+    - kind: ServiceAccount
+      name: calico-kube-controllers
+      namespace: kube-system
+    - kind: ServiceAccount
+      name: calico-node-controller
+      namespace: kube-system
+    - kind: ServiceAccount
+      name: kube-dns
+      namespace: kube-system
+    - kind: ServiceAccount
+      name: nginx-ingress-controller
+      namespace: kube-system
+    roleRef:
+       apiGroup: rbac.authorization.k8s.io
+       kind: ClusterRole
+       name: privileged-psp-user
+    ---
+    # grants the restricted PSP role to
+    # the all authenticated users.
+    apiVersion: rbac.authorization.k8s.io/v1beta1
+    kind: ClusterRoleBinding
+    metadata:
+        name: restricted-psp-users
+    subjects:
+    - kind: Group
+      apiGroup: rbac.authorization.k8s.io
+      name: system:authenticated
+    roleRef:
+       apiGroup: rbac.authorization.k8s.io
+       kind: ClusterRole
+       name: restricted-psp-user
 - path: /opt/wait-for-domains
   permissions: 0544
   content: |
@@ -764,15 +1276,36 @@ write_files:
   permissions: 0544
   content: |
       #!/bin/bash
-      KUBECTL={{.Cluster.Kubernetes.Kubectl.Docker.Image}}
+      # kubectl 1.8.1
+      KUBECTL=quay.io/giantswarm/docker-kubectl:1dc536ec6dc4597ba46769b3d5d6ce53a7e62038
 
       /usr/bin/docker pull $KUBECTL
 
       # wait for healthy master
       while [ "$(/usr/bin/docker run --net=host --rm $KUBECTL get cs | grep Healthy | wc -l)" -ne "3" ]; do sleep 1 && echo 'Waiting for healthy k8s'; done
 
+      # apply Security bootstrap (RBAC and PSP)
+      SECURITY_FILES="rbac_bindings.yaml rbac_roles.yaml psp_policies.yaml psp_roles.yaml psp_binding.yaml"
+
+      for manifest in $SECURITY_FILES
+      do
+          while
+              /usr/bin/docker run --net=host --rm -v /srv:/srv $KUBECTL apply -f /srv/$manifest
+              [ "$?" -ne "0" ]
+          do
+              echo "failed to apply /src/$manifest, retrying in 5 sec"
+              sleep 5s
+          done
+      done
+
       # apply calico CNI
-      CALICO_FILES="calico-configmap.yaml calico-node-sa.yaml calico-policy-controller-sa.yaml calico-ds.yaml calico-policy-controller.yaml"
+      CALICO_FILES="calico-configmap.yaml\
+       calico-node-sa.yaml\
+       calico-kube-controllers-sa.yaml\
+       calico-ds.yaml\
+       calico-kube-controllers.yaml\
+       calico-node-controller-sa.yaml\
+       calico-node-controller.yaml"
 
       for manifest in $CALICO_FILES
       do
@@ -840,6 +1373,7 @@ write_files:
     - name: local
       cluster:
         certificate-authority: /etc/kubernetes/ssl/apiserver-ca.pem
+        server: https://{{.Cluster.Kubernetes.API.Domain}}
     contexts:
     - context:
         cluster: local
@@ -861,6 +1395,7 @@ write_files:
     - name: local
       cluster:
         certificate-authority: /etc/kubernetes/ssl/apiserver-ca.pem
+        server: https://{{.Cluster.Kubernetes.API.Domain}}
     contexts:
     - context:
         cluster: local
@@ -882,6 +1417,7 @@ write_files:
     - name: local
       cluster:
         certificate-authority: /etc/kubernetes/ssl/apiserver-ca.pem
+        server: https://{{.Cluster.Kubernetes.API.Domain}}
     contexts:
     - context:
         cluster: local
@@ -903,6 +1439,7 @@ write_files:
     - name: local
       cluster:
         certificate-authority: /etc/kubernetes/ssl/apiserver-ca.pem
+        server: https://{{.Cluster.Kubernetes.API.Domain}}
     contexts:
     - context:
         cluster: local
@@ -1020,6 +1557,7 @@ coreos:
       TimeoutStartSec=0
       ExecStart=/usr/bin/mkdir -p /etc/kubernetes/data/etcd
       ExecStart=/usr/bin/chown etcd:etcd /etc/kubernetes/data/etcd
+      ExecStart=/usr/bin/chmod -R 700 /etc/kubernetes/data/etcd
   - name: docker.service
     enable: true
     command: start
@@ -1168,13 +1706,12 @@ coreos:
       RestartSec=0
       TimeoutStopSec=10
       EnvironmentFile=/etc/network-environment
-      Environment="IMAGE={{.Cluster.Kubernetes.Hyperkube.Docker.Image}}"
+      Environment="IMAGE=quay.io/giantswarm/hyperkube:v1.8.1_coreos.0"
       Environment="NAME=%p.service"
       Environment="NETWORK_CONFIG_CONTAINER="
       ExecStartPre=/usr/bin/docker pull $IMAGE
       ExecStartPre=-/usr/bin/docker stop -t 10 $NAME
       ExecStartPre=-/usr/bin/docker rm -f $NAME
-      ExecStartPre=/bin/sh -c "while ! curl --output /dev/null --silent --head --fail --cacert /etc/kubernetes/ssl/apiserver-ca.pem --cert /etc/kubernetes/ssl/apiserver-crt.pem --key /etc/kubernetes/ssl/apiserver-key.pem https://{{.Cluster.Kubernetes.API.Domain}}; do sleep 1 && echo 'Waiting for master'; done"
       ExecStart=/bin/sh -c "/usr/bin/docker run --rm --net=host --privileged=true \
       --name $NAME \
       -v /usr/share/ca-certificates:/etc/ssl/certs \
@@ -1182,7 +1719,6 @@ coreos:
       -v /etc/kubernetes/config/:/etc/kubernetes/config/ \
       $IMAGE \
       /hyperkube proxy \
-      --master=https://{{.Cluster.Kubernetes.API.Domain}} \
       --proxy-mode=iptables \
       --logtostderr=true \
       --kubeconfig=/etc/kubernetes/config/proxy-kubeconfig.yml \
@@ -1203,7 +1739,7 @@ coreos:
       RestartSec=0
       TimeoutStopSec=10
       EnvironmentFile=/etc/network-environment
-      Environment="IMAGE={{.Cluster.Kubernetes.Hyperkube.Docker.Image}}"
+      Environment="IMAGE=quay.io/giantswarm/hyperkube:v1.8.1_coreos.0"
       Environment="NAME=%p.service"
       Environment="NETWORK_CONFIG_CONTAINER="
       ExecStartPre=/usr/bin/docker pull $IMAGE
@@ -1234,7 +1770,6 @@ coreos:
       --address=${DEFAULT_IPV4} \
       --port={{.Cluster.Kubernetes.Kubelet.Port}} \
       --node-ip=${DEFAULT_IPV4} \
-      --api-servers=https://{{.Cluster.Kubernetes.API.Domain}} \
       --containerized \
       --enable-server \
       --logtostderr=true \
@@ -1290,7 +1825,7 @@ coreos:
       RestartSec=0
       TimeoutStopSec=10
       EnvironmentFile=/etc/network-environment
-      Environment="IMAGE={{.Cluster.Kubernetes.Hyperkube.Docker.Image}}"
+      Environment="IMAGE=quay.io/giantswarm/hyperkube:v1.8.1_coreos.0"
       Environment="NAME=%p.service"
       Environment="NETWORK_CONFIG_CONTAINER="
       ExecStartPre=/usr/bin/mkdir -p /etc/kubernetes/manifests
@@ -1300,19 +1835,22 @@ coreos:
       ExecStart=/usr/bin/docker run --rm --name $NAME --net=host \
       -v /etc/kubernetes/ssl/:/etc/kubernetes/ssl/ \
       -v /etc/kubernetes/secrets/token_sign_key.pem:/etc/kubernetes/secrets/token_sign_key.pem \
+      -v /etc/kubernetes/encryption/:/etc/kubernetes/encryption \
       $IMAGE \
       /hyperkube apiserver \
       --allow_privileged=true \
       --insecure_bind_address=0.0.0.0 \
       --insecure_port={{.Cluster.Kubernetes.API.InsecurePort}} \
       --kubelet_https=true \
+      --kubelet-preferred-address-types=InternalIP \
       --secure_port={{.Cluster.Kubernetes.API.SecurePort}} \
       --bind-address=${DEFAULT_IPV4} \
       --etcd-prefix={{.Cluster.Etcd.Prefix}} \
       --profiling=false \
       --repair-malformed-updates=false \
       --service-account-lookup=true \
-      --admission-control=NamespaceLifecycle,LimitRanger,ServiceAccount,ResourceQuota,DefaultStorageClass \
+      --authorization-mode=AlwaysAllow \
+      --admission-control=NamespaceLifecycle,LimitRanger,ServiceAccount,ResourceQuota,DefaultStorageClass,PodSecurityPolicy \
       --cloud-provider={{.Cluster.Kubernetes.CloudProvider}} \
       --service-cluster-ip-range={{.Cluster.Kubernetes.API.ClusterIPRange}} \
       --etcd-servers=https://{{ .Cluster.Etcd.Domain }}:443 \
@@ -1345,7 +1883,7 @@ coreos:
       RestartSec=0
       TimeoutStopSec=10
       EnvironmentFile=/etc/network-environment
-      Environment="IMAGE={{.Cluster.Kubernetes.Hyperkube.Docker.Image}}"
+      Environment="IMAGE=quay.io/giantswarm/hyperkube:v1.8.1_coreos.0"
       Environment="NAME=%p.service"
       Environment="NETWORK_CONFIG_CONTAINER="
       ExecStartPre=/usr/bin/docker pull $IMAGE
@@ -1357,7 +1895,6 @@ coreos:
       -v /etc/kubernetes/secrets/token_sign_key.pem:/etc/kubernetes/secrets/token_sign_key.pem \
       $IMAGE \
       /hyperkube controller-manager \
-      --master=https://{{.Cluster.Kubernetes.API.Domain}}:443 \
       --logtostderr=true \
       --v=2 \
       --cloud-provider={{.Cluster.Kubernetes.CloudProvider}} \
@@ -1382,7 +1919,7 @@ coreos:
       RestartSec=0
       TimeoutStopSec=10
       EnvironmentFile=/etc/network-environment
-      Environment="IMAGE={{.Cluster.Kubernetes.Hyperkube.Docker.Image}}"
+      Environment="IMAGE=quay.io/giantswarm/hyperkube:v1.8.1_coreos.0"
       Environment="NAME=%p.service"
       Environment="NETWORK_CONFIG_CONTAINER="
       ExecStartPre=/usr/bin/docker pull $IMAGE
@@ -1393,7 +1930,6 @@ coreos:
       -v /etc/kubernetes/config/:/etc/kubernetes/config/ \
       $IMAGE \
       /hyperkube scheduler \
-      --master=https://{{.Cluster.Kubernetes.API.Domain}}:443 \
       --logtostderr=true \
       --v=2 \
       --profiling=false \

--- a/vendor/github.com/giantswarm/k8scloudconfig/v_0_1_0/worker_template.go
+++ b/vendor/github.com/giantswarm/k8scloudconfig/v_0_1_0/worker_template.go
@@ -25,6 +25,7 @@ write_files:
     - name: local
       cluster:
         certificate-authority: /etc/kubernetes/ssl/worker-ca.pem
+        server: https://{{.Cluster.Kubernetes.API.Domain}}
     contexts:
     - context:
         cluster: local
@@ -46,6 +47,7 @@ write_files:
     - name: local
       cluster:
         certificate-authority: /etc/kubernetes/ssl/worker-ca.pem
+        server: https://{{.Cluster.Kubernetes.API.Domain}}
     contexts:
     - context:
         cluster: local
@@ -235,16 +237,12 @@ coreos:
       RestartSec=0
       TimeoutStopSec=10
       EnvironmentFile=/etc/network-environment
-      Environment="IMAGE={{.Cluster.Kubernetes.Hyperkube.Docker.Image}}"
+      Environment="IMAGE=quay.io/giantswarm/hyperkube:v1.8.1_coreos.0"
       Environment="NAME=%p.service"
       Environment="NETWORK_CONFIG_CONTAINER="
       ExecStartPre=/usr/bin/docker pull $IMAGE
       ExecStartPre=-/usr/bin/docker stop -t 10 $NAME
-      ExecStartPre=-/usr/bin/docker rm -f $NAME
-      ExecStartPre=/bin/bash -c "while [ ! -f /etc/kubernetes/ssl/worker-ca.pem ]; do echo 'Waiting for /etc/kubernetes/ssl/worker-ca.pem to be written' && sleep 1; done"
-      ExecStartPre=/bin/bash -c "while [ ! -f /etc/kubernetes/ssl/worker-crt.pem ]; do echo 'Waiting for /etc/kubernetes/ssl/worker-crt.pem to be written' && sleep 1; done"
-      ExecStartPre=/bin/bash -c "while [ ! -f /etc/kubernetes/ssl/worker-key.pem ]; do echo 'Waiting for /etc/kubernetes/ssl/worker-key.pem to be written' && sleep 1; done"
-      ExecStartPre=/bin/sh -c "while ! curl --output /dev/null --silent --head --fail --cacert /etc/kubernetes/ssl/worker-ca.pem --cert /etc/kubernetes/ssl/worker-crt.pem --key /etc/kubernetes/ssl/worker-key.pem https://{{.Cluster.Kubernetes.API.Domain}}; do sleep 1 && echo 'Waiting for master'; done"
+      ExecStartPre=-/usr/bin/docker rm -f $NAME      
       ExecStart=/bin/sh -c "/usr/bin/docker run --rm --net=host --privileged=true \
       --name $NAME \
       -v /usr/share/ca-certificates:/etc/ssl/certs \
@@ -252,7 +250,6 @@ coreos:
       -v /etc/kubernetes/config/:/etc/kubernetes/config/ \
       $IMAGE \
       /hyperkube proxy \
-      --master=https://{{.Cluster.Kubernetes.API.Domain}} \
       --proxy-mode=iptables \
       --logtostderr=true \
       --kubeconfig=/etc/kubernetes/config/proxy-kubeconfig.yml \
@@ -273,7 +270,7 @@ coreos:
       RestartSec=0
       TimeoutStopSec=10
       EnvironmentFile=/etc/network-environment
-      Environment="IMAGE={{.Cluster.Kubernetes.Hyperkube.Docker.Image}}"
+      Environment="IMAGE=quay.io/giantswarm/hyperkube:v1.8.1_coreos.0"
       Environment="NAME=%p.service"
       Environment="NETWORK_CONFIG_CONTAINER="
       ExecStartPre=/usr/bin/docker pull $IMAGE
@@ -304,7 +301,6 @@ coreos:
       --address=${DEFAULT_IPV4} \
       --port={{.Cluster.Kubernetes.Kubelet.Port}} \
       --node-ip=${DEFAULT_IPV4} \
-      --api-servers=https://{{.Cluster.Kubernetes.API.Domain}} \
       --containerized \
       --enable-server \
       --logtostderr=true \

--- a/vendor/github.com/giantswarm/microendpoint/endpoint/healthz/endpoint_test.go
+++ b/vendor/github.com/giantswarm/microendpoint/endpoint/healthz/endpoint_test.go
@@ -39,7 +39,7 @@ func Test_Endpoint_ServiceFailed_True(t *testing.T) {
 			}
 			newEndpoint, err := New(endpointConfig)
 			if err != nil {
-				t.Fatalf("test", i+1, "expected", nil, "got", err)
+				t.Fatalf("test %d expected %v got %s", i+1, nil, err)
 			}
 			encoder = newEndpoint.Encoder()
 			endpoint = newEndpoint.Endpoint()
@@ -47,19 +47,19 @@ func Test_Endpoint_ServiceFailed_True(t *testing.T) {
 
 		res, err := endpoint(context.TODO(), nil)
 		if err != nil {
-			t.Fatalf("test", i+1, "expected", nil, "got", err)
+			t.Fatalf("test %d expected %v got %s", i+1, nil, err)
 		}
 
 		w := httptest.NewRecorder()
 
 		err = encoder(context.TODO(), w, res)
 		if err != nil {
-			t.Fatalf("test", i+1, "expected", nil, "got", err)
+			t.Fatalf("test %d expected %v got %s", i+1, nil, err)
 		}
 
 		statusCode := w.Result().StatusCode
 		if statusCode != tc.ExpectedStatusCode {
-			t.Fatalf("test", i+1, "expected", tc.ExpectedStatusCode, "got", statusCode)
+			t.Fatalf("test %d expected %d got %d", i+1, tc.ExpectedStatusCode, statusCode)
 		}
 	}
 }

--- a/vendor/github.com/giantswarm/versionbundle/bundle_test.go
+++ b/vendor/github.com/giantswarm/versionbundle/bundle_test.go
@@ -5,6 +5,1921 @@ import (
 	"time"
 )
 
+func Test_Bundle_IsMajorUpgrade(t *testing.T) {
+	testCases := []struct {
+		Bundle         Bundle
+		Other          Bundle
+		ErrorMatcher   func(err error) bool
+		ExpectedResult bool
+	}{
+		// Test 0 ensures that empty bundles throw an error.
+		{
+			Bundle:         Bundle{},
+			Other:          Bundle{},
+			ErrorMatcher:   IsInvalidBundleError,
+			ExpectedResult: false,
+		},
+
+		// Test 1 is the same as 0 but with the lower bundle being empty.
+		{
+			Bundle: Bundle{
+				Changelogs: []Changelog{
+					{
+						Component:   "calico",
+						Description: "Calico version updated.",
+						Kind:        "changed",
+					},
+				},
+				Components: []Component{
+					{
+						Name:    "calico",
+						Version: "1.1.0",
+					},
+					{
+						Name:    "kube-dns",
+						Version: "1.0.0",
+					},
+				},
+				Dependencies: []Dependency{},
+				Deprecated:   false,
+				Name:         "kubernetes-operator",
+				Time:         time.Unix(10, 5),
+				Version:      "0.1.0",
+				WIP:          false,
+			},
+			Other:          Bundle{},
+			ErrorMatcher:   IsInvalidBundleError,
+			ExpectedResult: false,
+		},
+
+		// Test 2 is the same as 0 but with the higher bundle being empty.
+		{
+			Bundle: Bundle{},
+			Other: Bundle{
+				Changelogs: []Changelog{
+					{
+						Component:   "calico",
+						Description: "Calico version updated.",
+						Kind:        "changed",
+					},
+				},
+				Components: []Component{
+					{
+						Name:    "calico",
+						Version: "1.1.0",
+					},
+					{
+						Name:    "kube-dns",
+						Version: "1.0.0",
+					},
+				},
+				Dependencies: []Dependency{},
+				Deprecated:   false,
+				Name:         "kubernetes-operator",
+				Time:         time.Unix(10, 5),
+				Version:      "0.1.0",
+				WIP:          false,
+			},
+			ErrorMatcher:   IsInvalidBundleError,
+			ExpectedResult: false,
+		},
+
+		// Test 3 ensures the same version results in false.
+		{
+			Bundle: Bundle{
+				Changelogs: []Changelog{
+					{
+						Component:   "calico",
+						Description: "Calico version updated.",
+						Kind:        "changed",
+					},
+				},
+				Components: []Component{
+					{
+						Name:    "calico",
+						Version: "1.1.0",
+					},
+					{
+						Name:    "kube-dns",
+						Version: "1.0.0",
+					},
+				},
+				Dependencies: []Dependency{},
+				Deprecated:   false,
+				Name:         "kubernetes-operator",
+				Time:         time.Unix(10, 5),
+				Version:      "0.1.0",
+				WIP:          false,
+			},
+			Other: Bundle{
+				Changelogs: []Changelog{
+					{
+						Component:   "calico",
+						Description: "Calico version updated.",
+						Kind:        "changed",
+					},
+				},
+				Components: []Component{
+					{
+						Name:    "calico",
+						Version: "1.1.0",
+					},
+					{
+						Name:    "kube-dns",
+						Version: "1.0.0",
+					},
+				},
+				Dependencies: []Dependency{},
+				Deprecated:   false,
+				Name:         "kubernetes-operator",
+				Time:         time.Unix(10, 5),
+				Version:      "0.1.0",
+				WIP:          false,
+			},
+			ErrorMatcher:   nil,
+			ExpectedResult: false,
+		},
+
+		// Test 4 ensures version bundles of different authorities cannot be
+		// compared and result in an error.
+		{
+			Bundle: Bundle{
+				Changelogs: []Changelog{
+					{
+						Component:   "calico",
+						Description: "Calico version updated.",
+						Kind:        "changed",
+					},
+				},
+				Components: []Component{
+					{
+						Name:    "calico",
+						Version: "1.1.0",
+					},
+					{
+						Name:    "kube-dns",
+						Version: "1.0.0",
+					},
+				},
+				Dependencies: []Dependency{},
+				Deprecated:   false,
+				Name:         "ingress-operator",
+				Time:         time.Unix(10, 5),
+				Version:      "0.1.0",
+				WIP:          false,
+			},
+			Other: Bundle{
+				Changelogs: []Changelog{
+					{
+						Component:   "calico",
+						Description: "Calico version updated.",
+						Kind:        "changed",
+					},
+				},
+				Components: []Component{
+					{
+						Name:    "calico",
+						Version: "1.1.0",
+					},
+					{
+						Name:    "kube-dns",
+						Version: "1.0.0",
+					},
+				},
+				Dependencies: []Dependency{},
+				Deprecated:   false,
+				Name:         "kubernetes-operator",
+				Time:         time.Unix(10, 5),
+				Version:      "0.2.0",
+				WIP:          false,
+			},
+			ErrorMatcher:   IsInvalidBundleError,
+			ExpectedResult: false,
+		},
+
+		// Test 5 ensures a smaller major version is not considered a major upgrade.
+		{
+			Bundle: Bundle{
+				Changelogs: []Changelog{
+					{
+						Component:   "calico",
+						Description: "Calico version updated.",
+						Kind:        "changed",
+					},
+				},
+				Components: []Component{
+					{
+						Name:    "calico",
+						Version: "1.1.0",
+					},
+					{
+						Name:    "kube-dns",
+						Version: "1.0.0",
+					},
+				},
+				Dependencies: []Dependency{},
+				Deprecated:   false,
+				Name:         "kubernetes-operator",
+				Time:         time.Unix(10, 5),
+				Version:      "1.1.0",
+				WIP:          false,
+			},
+			Other: Bundle{
+				Changelogs: []Changelog{
+					{
+						Component:   "calico",
+						Description: "Calico version updated.",
+						Kind:        "changed",
+					},
+				},
+				Components: []Component{
+					{
+						Name:    "calico",
+						Version: "1.1.0",
+					},
+					{
+						Name:    "kube-dns",
+						Version: "1.0.0",
+					},
+				},
+				Dependencies: []Dependency{},
+				Deprecated:   false,
+				Name:         "kubernetes-operator",
+				Time:         time.Unix(10, 5),
+				Version:      "0.1.0",
+				WIP:          false,
+			},
+			ErrorMatcher:   nil,
+			ExpectedResult: false,
+		},
+
+		// Test 6 is the same as 5 but with different versions.
+		{
+			Bundle: Bundle{
+				Changelogs: []Changelog{
+					{
+						Component:   "calico",
+						Description: "Calico version updated.",
+						Kind:        "changed",
+					},
+				},
+				Components: []Component{
+					{
+						Name:    "calico",
+						Version: "1.1.0",
+					},
+					{
+						Name:    "kube-dns",
+						Version: "1.0.0",
+					},
+				},
+				Dependencies: []Dependency{},
+				Deprecated:   false,
+				Name:         "kubernetes-operator",
+				Time:         time.Unix(10, 5),
+				Version:      "5.7.18",
+				WIP:          false,
+			},
+			Other: Bundle{
+				Changelogs: []Changelog{
+					{
+						Component:   "calico",
+						Description: "Calico version updated.",
+						Kind:        "changed",
+					},
+				},
+				Components: []Component{
+					{
+						Name:    "calico",
+						Version: "1.1.0",
+					},
+					{
+						Name:    "kube-dns",
+						Version: "1.0.0",
+					},
+				},
+				Dependencies: []Dependency{},
+				Deprecated:   false,
+				Name:         "kubernetes-operator",
+				Time:         time.Unix(10, 5),
+				Version:      "4.17.7",
+				WIP:          false,
+			},
+			ErrorMatcher:   nil,
+			ExpectedResult: false,
+		},
+
+		// Test 7 ensures a smaller minor version is not considered a major upgrade.
+		{
+			Bundle: Bundle{
+				Changelogs: []Changelog{
+					{
+						Component:   "calico",
+						Description: "Calico version updated.",
+						Kind:        "changed",
+					},
+				},
+				Components: []Component{
+					{
+						Name:    "calico",
+						Version: "1.1.0",
+					},
+					{
+						Name:    "kube-dns",
+						Version: "1.0.0",
+					},
+				},
+				Dependencies: []Dependency{},
+				Deprecated:   false,
+				Name:         "kubernetes-operator",
+				Time:         time.Unix(10, 5),
+				Version:      "0.2.0",
+				WIP:          false,
+			},
+			Other: Bundle{
+				Changelogs: []Changelog{
+					{
+						Component:   "calico",
+						Description: "Calico version updated.",
+						Kind:        "changed",
+					},
+				},
+				Components: []Component{
+					{
+						Name:    "calico",
+						Version: "1.1.0",
+					},
+					{
+						Name:    "kube-dns",
+						Version: "1.0.0",
+					},
+				},
+				Dependencies: []Dependency{},
+				Deprecated:   false,
+				Name:         "kubernetes-operator",
+				Time:         time.Unix(10, 5),
+				Version:      "0.1.0",
+				WIP:          false,
+			},
+			ErrorMatcher:   nil,
+			ExpectedResult: false,
+		},
+
+		// Test 8 ensures a smaller patch version is not considered a major upgrade.
+		{
+			Bundle: Bundle{
+				Changelogs: []Changelog{
+					{
+						Component:   "calico",
+						Description: "Calico version updated.",
+						Kind:        "changed",
+					},
+				},
+				Components: []Component{
+					{
+						Name:    "calico",
+						Version: "1.1.0",
+					},
+					{
+						Name:    "kube-dns",
+						Version: "1.0.0",
+					},
+				},
+				Dependencies: []Dependency{},
+				Deprecated:   false,
+				Name:         "kubernetes-operator",
+				Time:         time.Unix(10, 5),
+				Version:      "0.2.1",
+				WIP:          false,
+			},
+			Other: Bundle{
+				Changelogs: []Changelog{
+					{
+						Component:   "calico",
+						Description: "Calico version updated.",
+						Kind:        "changed",
+					},
+				},
+				Components: []Component{
+					{
+						Name:    "calico",
+						Version: "1.1.0",
+					},
+					{
+						Name:    "kube-dns",
+						Version: "1.0.0",
+					},
+				},
+				Dependencies: []Dependency{},
+				Deprecated:   false,
+				Name:         "kubernetes-operator",
+				Time:         time.Unix(10, 5),
+				Version:      "0.2.0",
+				WIP:          false,
+			},
+			ErrorMatcher:   nil,
+			ExpectedResult: false,
+		},
+
+		// Test 9 ensures a bigger major version is considered a major upgrade.
+		{
+			Bundle: Bundle{
+				Changelogs: []Changelog{
+					{
+						Component:   "calico",
+						Description: "Calico version updated.",
+						Kind:        "changed",
+					},
+				},
+				Components: []Component{
+					{
+						Name:    "calico",
+						Version: "1.1.0",
+					},
+					{
+						Name:    "kube-dns",
+						Version: "1.0.0",
+					},
+				},
+				Dependencies: []Dependency{},
+				Deprecated:   false,
+				Name:         "kubernetes-operator",
+				Time:         time.Unix(10, 5),
+				Version:      "0.2.1",
+				WIP:          false,
+			},
+			Other: Bundle{
+				Changelogs: []Changelog{
+					{
+						Component:   "calico",
+						Description: "Calico version updated.",
+						Kind:        "changed",
+					},
+				},
+				Components: []Component{
+					{
+						Name:    "calico",
+						Version: "1.1.0",
+					},
+					{
+						Name:    "kube-dns",
+						Version: "1.0.0",
+					},
+				},
+				Dependencies: []Dependency{},
+				Deprecated:   false,
+				Name:         "kubernetes-operator",
+				Time:         time.Unix(10, 5),
+				Version:      "1.0.0",
+				WIP:          false,
+			},
+			ErrorMatcher:   nil,
+			ExpectedResult: true,
+		},
+
+		// Test 10 is the same as 9 but with different versions.
+		{
+			Bundle: Bundle{
+				Changelogs: []Changelog{
+					{
+						Component:   "calico",
+						Description: "Calico version updated.",
+						Kind:        "changed",
+					},
+				},
+				Components: []Component{
+					{
+						Name:    "calico",
+						Version: "1.1.0",
+					},
+					{
+						Name:    "kube-dns",
+						Version: "1.0.0",
+					},
+				},
+				Dependencies: []Dependency{},
+				Deprecated:   false,
+				Name:         "kubernetes-operator",
+				Time:         time.Unix(10, 5),
+				Version:      "5.17.8",
+				WIP:          false,
+			},
+			Other: Bundle{
+				Changelogs: []Changelog{
+					{
+						Component:   "calico",
+						Description: "Calico version updated.",
+						Kind:        "changed",
+					},
+				},
+				Components: []Component{
+					{
+						Name:    "calico",
+						Version: "1.1.0",
+					},
+					{
+						Name:    "kube-dns",
+						Version: "1.0.0",
+					},
+				},
+				Dependencies: []Dependency{},
+				Deprecated:   false,
+				Name:         "kubernetes-operator",
+				Time:         time.Unix(10, 5),
+				Version:      "11.8.17",
+				WIP:          false,
+			},
+			ErrorMatcher:   nil,
+			ExpectedResult: true,
+		},
+
+		// Test 11 ensures a bigger minor version is not considered a major upgrade.
+		{
+			Bundle: Bundle{
+				Changelogs: []Changelog{
+					{
+						Component:   "calico",
+						Description: "Calico version updated.",
+						Kind:        "changed",
+					},
+				},
+				Components: []Component{
+					{
+						Name:    "calico",
+						Version: "1.1.0",
+					},
+					{
+						Name:    "kube-dns",
+						Version: "1.0.0",
+					},
+				},
+				Dependencies: []Dependency{},
+				Deprecated:   false,
+				Name:         "kubernetes-operator",
+				Time:         time.Unix(10, 5),
+				Version:      "0.2.1",
+				WIP:          false,
+			},
+			Other: Bundle{
+				Changelogs: []Changelog{
+					{
+						Component:   "calico",
+						Description: "Calico version updated.",
+						Kind:        "changed",
+					},
+				},
+				Components: []Component{
+					{
+						Name:    "calico",
+						Version: "1.1.0",
+					},
+					{
+						Name:    "kube-dns",
+						Version: "1.0.0",
+					},
+				},
+				Dependencies: []Dependency{},
+				Deprecated:   false,
+				Name:         "kubernetes-operator",
+				Time:         time.Unix(10, 5),
+				Version:      "0.3.0",
+				WIP:          false,
+			},
+			ErrorMatcher:   nil,
+			ExpectedResult: false,
+		},
+
+		// Test 12 ensures a bigger patch version is not considered a major upgrade.
+		{
+			Bundle: Bundle{
+				Changelogs: []Changelog{
+					{
+						Component:   "calico",
+						Description: "Calico version updated.",
+						Kind:        "changed",
+					},
+				},
+				Components: []Component{
+					{
+						Name:    "calico",
+						Version: "1.1.0",
+					},
+					{
+						Name:    "kube-dns",
+						Version: "1.0.0",
+					},
+				},
+				Dependencies: []Dependency{},
+				Deprecated:   false,
+				Name:         "kubernetes-operator",
+				Time:         time.Unix(10, 5),
+				Version:      "0.2.1",
+				WIP:          false,
+			},
+			Other: Bundle{
+				Changelogs: []Changelog{
+					{
+						Component:   "calico",
+						Description: "Calico version updated.",
+						Kind:        "changed",
+					},
+				},
+				Components: []Component{
+					{
+						Name:    "calico",
+						Version: "1.1.0",
+					},
+					{
+						Name:    "kube-dns",
+						Version: "1.0.0",
+					},
+				},
+				Dependencies: []Dependency{},
+				Deprecated:   false,
+				Name:         "kubernetes-operator",
+				Time:         time.Unix(10, 5),
+				Version:      "0.2.2",
+				WIP:          false,
+			},
+			ErrorMatcher:   nil,
+			ExpectedResult: false,
+		},
+	}
+
+	for i, tc := range testCases {
+		result, err := tc.Bundle.IsMajorUpgrade(tc.Other)
+		if tc.ErrorMatcher != nil {
+			if !tc.ErrorMatcher(err) {
+				t.Fatalf("test %d expected %#v got %#v", i, true, false)
+			}
+		} else if err != nil {
+			t.Fatalf("test %d expected %#v got %#v", i, nil, err)
+		} else {
+			if result != tc.ExpectedResult {
+				t.Fatalf("test %d expected %#v got %#v", i, tc.ExpectedResult, result)
+			}
+		}
+	}
+}
+
+func Test_Bundle_IsMinorUpgrade(t *testing.T) {
+	testCases := []struct {
+		Bundle         Bundle
+		Other          Bundle
+		ErrorMatcher   func(err error) bool
+		ExpectedResult bool
+	}{
+		// Test 0 ensures that empty bundles throw an error.
+		{
+			Bundle:         Bundle{},
+			Other:          Bundle{},
+			ErrorMatcher:   IsInvalidBundleError,
+			ExpectedResult: false,
+		},
+
+		// Test 1 is the same as 0 but with the lower bundle being empty.
+		{
+			Bundle: Bundle{
+				Changelogs: []Changelog{
+					{
+						Component:   "calico",
+						Description: "Calico version updated.",
+						Kind:        "changed",
+					},
+				},
+				Components: []Component{
+					{
+						Name:    "calico",
+						Version: "1.1.0",
+					},
+					{
+						Name:    "kube-dns",
+						Version: "1.0.0",
+					},
+				},
+				Dependencies: []Dependency{},
+				Deprecated:   false,
+				Name:         "kubernetes-operator",
+				Time:         time.Unix(10, 5),
+				Version:      "0.1.0",
+				WIP:          false,
+			},
+			Other:          Bundle{},
+			ErrorMatcher:   IsInvalidBundleError,
+			ExpectedResult: false,
+		},
+
+		// Test 2 is the same as 0 but with the higher bundle being empty.
+		{
+			Bundle: Bundle{},
+			Other: Bundle{
+				Changelogs: []Changelog{
+					{
+						Component:   "calico",
+						Description: "Calico version updated.",
+						Kind:        "changed",
+					},
+				},
+				Components: []Component{
+					{
+						Name:    "calico",
+						Version: "1.1.0",
+					},
+					{
+						Name:    "kube-dns",
+						Version: "1.0.0",
+					},
+				},
+				Dependencies: []Dependency{},
+				Deprecated:   false,
+				Name:         "kubernetes-operator",
+				Time:         time.Unix(10, 5),
+				Version:      "0.1.0",
+				WIP:          false,
+			},
+			ErrorMatcher:   IsInvalidBundleError,
+			ExpectedResult: false,
+		},
+
+		// Test 3 ensures the same version results in false.
+		{
+			Bundle: Bundle{
+				Changelogs: []Changelog{
+					{
+						Component:   "calico",
+						Description: "Calico version updated.",
+						Kind:        "changed",
+					},
+				},
+				Components: []Component{
+					{
+						Name:    "calico",
+						Version: "1.1.0",
+					},
+					{
+						Name:    "kube-dns",
+						Version: "1.0.0",
+					},
+				},
+				Dependencies: []Dependency{},
+				Deprecated:   false,
+				Name:         "kubernetes-operator",
+				Time:         time.Unix(10, 5),
+				Version:      "0.1.0",
+				WIP:          false,
+			},
+			Other: Bundle{
+				Changelogs: []Changelog{
+					{
+						Component:   "calico",
+						Description: "Calico version updated.",
+						Kind:        "changed",
+					},
+				},
+				Components: []Component{
+					{
+						Name:    "calico",
+						Version: "1.1.0",
+					},
+					{
+						Name:    "kube-dns",
+						Version: "1.0.0",
+					},
+				},
+				Dependencies: []Dependency{},
+				Deprecated:   false,
+				Name:         "kubernetes-operator",
+				Time:         time.Unix(10, 5),
+				Version:      "0.1.0",
+				WIP:          false,
+			},
+			ErrorMatcher:   nil,
+			ExpectedResult: false,
+		},
+
+		// Test 4 ensures version bundles of different authorities cannot be
+		// compared and result in an error.
+		{
+			Bundle: Bundle{
+				Changelogs: []Changelog{
+					{
+						Component:   "calico",
+						Description: "Calico version updated.",
+						Kind:        "changed",
+					},
+				},
+				Components: []Component{
+					{
+						Name:    "calico",
+						Version: "1.1.0",
+					},
+					{
+						Name:    "kube-dns",
+						Version: "1.0.0",
+					},
+				},
+				Dependencies: []Dependency{},
+				Deprecated:   false,
+				Name:         "ingress-operator",
+				Time:         time.Unix(10, 5),
+				Version:      "0.1.0",
+				WIP:          false,
+			},
+			Other: Bundle{
+				Changelogs: []Changelog{
+					{
+						Component:   "calico",
+						Description: "Calico version updated.",
+						Kind:        "changed",
+					},
+				},
+				Components: []Component{
+					{
+						Name:    "calico",
+						Version: "1.1.0",
+					},
+					{
+						Name:    "kube-dns",
+						Version: "1.0.0",
+					},
+				},
+				Dependencies: []Dependency{},
+				Deprecated:   false,
+				Name:         "kubernetes-operator",
+				Time:         time.Unix(10, 5),
+				Version:      "0.2.0",
+				WIP:          false,
+			},
+			ErrorMatcher:   IsInvalidBundleError,
+			ExpectedResult: false,
+		},
+
+		// Test 5 ensures a smaller major version is not considered a minor upgrade.
+		{
+			Bundle: Bundle{
+				Changelogs: []Changelog{
+					{
+						Component:   "calico",
+						Description: "Calico version updated.",
+						Kind:        "changed",
+					},
+				},
+				Components: []Component{
+					{
+						Name:    "calico",
+						Version: "1.1.0",
+					},
+					{
+						Name:    "kube-dns",
+						Version: "1.0.0",
+					},
+				},
+				Dependencies: []Dependency{},
+				Deprecated:   false,
+				Name:         "kubernetes-operator",
+				Time:         time.Unix(10, 5),
+				Version:      "1.1.0",
+				WIP:          false,
+			},
+			Other: Bundle{
+				Changelogs: []Changelog{
+					{
+						Component:   "calico",
+						Description: "Calico version updated.",
+						Kind:        "changed",
+					},
+				},
+				Components: []Component{
+					{
+						Name:    "calico",
+						Version: "1.1.0",
+					},
+					{
+						Name:    "kube-dns",
+						Version: "1.0.0",
+					},
+				},
+				Dependencies: []Dependency{},
+				Deprecated:   false,
+				Name:         "kubernetes-operator",
+				Time:         time.Unix(10, 5),
+				Version:      "0.1.0",
+				WIP:          false,
+			},
+			ErrorMatcher:   nil,
+			ExpectedResult: false,
+		},
+
+		// Test 6 is the same as 5 but with different versions.
+		{
+			Bundle: Bundle{
+				Changelogs: []Changelog{
+					{
+						Component:   "calico",
+						Description: "Calico version updated.",
+						Kind:        "changed",
+					},
+				},
+				Components: []Component{
+					{
+						Name:    "calico",
+						Version: "1.1.0",
+					},
+					{
+						Name:    "kube-dns",
+						Version: "1.0.0",
+					},
+				},
+				Dependencies: []Dependency{},
+				Deprecated:   false,
+				Name:         "kubernetes-operator",
+				Time:         time.Unix(10, 5),
+				Version:      "5.7.18",
+				WIP:          false,
+			},
+			Other: Bundle{
+				Changelogs: []Changelog{
+					{
+						Component:   "calico",
+						Description: "Calico version updated.",
+						Kind:        "changed",
+					},
+				},
+				Components: []Component{
+					{
+						Name:    "calico",
+						Version: "1.1.0",
+					},
+					{
+						Name:    "kube-dns",
+						Version: "1.0.0",
+					},
+				},
+				Dependencies: []Dependency{},
+				Deprecated:   false,
+				Name:         "kubernetes-operator",
+				Time:         time.Unix(10, 5),
+				Version:      "4.17.7",
+				WIP:          false,
+			},
+			ErrorMatcher:   nil,
+			ExpectedResult: false,
+		},
+
+		// Test 7 ensures a smaller minor version is not considered a minor upgrade.
+		{
+			Bundle: Bundle{
+				Changelogs: []Changelog{
+					{
+						Component:   "calico",
+						Description: "Calico version updated.",
+						Kind:        "changed",
+					},
+				},
+				Components: []Component{
+					{
+						Name:    "calico",
+						Version: "1.1.0",
+					},
+					{
+						Name:    "kube-dns",
+						Version: "1.0.0",
+					},
+				},
+				Dependencies: []Dependency{},
+				Deprecated:   false,
+				Name:         "kubernetes-operator",
+				Time:         time.Unix(10, 5),
+				Version:      "0.2.0",
+				WIP:          false,
+			},
+			Other: Bundle{
+				Changelogs: []Changelog{
+					{
+						Component:   "calico",
+						Description: "Calico version updated.",
+						Kind:        "changed",
+					},
+				},
+				Components: []Component{
+					{
+						Name:    "calico",
+						Version: "1.1.0",
+					},
+					{
+						Name:    "kube-dns",
+						Version: "1.0.0",
+					},
+				},
+				Dependencies: []Dependency{},
+				Deprecated:   false,
+				Name:         "kubernetes-operator",
+				Time:         time.Unix(10, 5),
+				Version:      "0.1.0",
+				WIP:          false,
+			},
+			ErrorMatcher:   nil,
+			ExpectedResult: false,
+		},
+
+		// Test 8 ensures a smaller patch version is not considered a minor upgrade.
+		{
+			Bundle: Bundle{
+				Changelogs: []Changelog{
+					{
+						Component:   "calico",
+						Description: "Calico version updated.",
+						Kind:        "changed",
+					},
+				},
+				Components: []Component{
+					{
+						Name:    "calico",
+						Version: "1.1.0",
+					},
+					{
+						Name:    "kube-dns",
+						Version: "1.0.0",
+					},
+				},
+				Dependencies: []Dependency{},
+				Deprecated:   false,
+				Name:         "kubernetes-operator",
+				Time:         time.Unix(10, 5),
+				Version:      "0.2.1",
+				WIP:          false,
+			},
+			Other: Bundle{
+				Changelogs: []Changelog{
+					{
+						Component:   "calico",
+						Description: "Calico version updated.",
+						Kind:        "changed",
+					},
+				},
+				Components: []Component{
+					{
+						Name:    "calico",
+						Version: "1.1.0",
+					},
+					{
+						Name:    "kube-dns",
+						Version: "1.0.0",
+					},
+				},
+				Dependencies: []Dependency{},
+				Deprecated:   false,
+				Name:         "kubernetes-operator",
+				Time:         time.Unix(10, 5),
+				Version:      "0.2.0",
+				WIP:          false,
+			},
+			ErrorMatcher:   nil,
+			ExpectedResult: false,
+		},
+
+		// Test 9 ensures a bigger major version is not considered a minor upgrade.
+		{
+			Bundle: Bundle{
+				Changelogs: []Changelog{
+					{
+						Component:   "calico",
+						Description: "Calico version updated.",
+						Kind:        "changed",
+					},
+				},
+				Components: []Component{
+					{
+						Name:    "calico",
+						Version: "1.1.0",
+					},
+					{
+						Name:    "kube-dns",
+						Version: "1.0.0",
+					},
+				},
+				Dependencies: []Dependency{},
+				Deprecated:   false,
+				Name:         "kubernetes-operator",
+				Time:         time.Unix(10, 5),
+				Version:      "0.2.1",
+				WIP:          false,
+			},
+			Other: Bundle{
+				Changelogs: []Changelog{
+					{
+						Component:   "calico",
+						Description: "Calico version updated.",
+						Kind:        "changed",
+					},
+				},
+				Components: []Component{
+					{
+						Name:    "calico",
+						Version: "1.1.0",
+					},
+					{
+						Name:    "kube-dns",
+						Version: "1.0.0",
+					},
+				},
+				Dependencies: []Dependency{},
+				Deprecated:   false,
+				Name:         "kubernetes-operator",
+				Time:         time.Unix(10, 5),
+				Version:      "1.0.0",
+				WIP:          false,
+			},
+			ErrorMatcher:   nil,
+			ExpectedResult: false,
+		},
+
+		// Test 10 ensures a bigger minor version is considered a minor upgrade.
+		{
+			Bundle: Bundle{
+				Changelogs: []Changelog{
+					{
+						Component:   "calico",
+						Description: "Calico version updated.",
+						Kind:        "changed",
+					},
+				},
+				Components: []Component{
+					{
+						Name:    "calico",
+						Version: "1.1.0",
+					},
+					{
+						Name:    "kube-dns",
+						Version: "1.0.0",
+					},
+				},
+				Dependencies: []Dependency{},
+				Deprecated:   false,
+				Name:         "kubernetes-operator",
+				Time:         time.Unix(10, 5),
+				Version:      "0.2.1",
+				WIP:          false,
+			},
+			Other: Bundle{
+				Changelogs: []Changelog{
+					{
+						Component:   "calico",
+						Description: "Calico version updated.",
+						Kind:        "changed",
+					},
+				},
+				Components: []Component{
+					{
+						Name:    "calico",
+						Version: "1.1.0",
+					},
+					{
+						Name:    "kube-dns",
+						Version: "1.0.0",
+					},
+				},
+				Dependencies: []Dependency{},
+				Deprecated:   false,
+				Name:         "kubernetes-operator",
+				Time:         time.Unix(10, 5),
+				Version:      "0.3.0",
+				WIP:          false,
+			},
+			ErrorMatcher:   nil,
+			ExpectedResult: true,
+		},
+
+		// Test 11 is the same as 10 but with different versions.
+		{
+			Bundle: Bundle{
+				Changelogs: []Changelog{
+					{
+						Component:   "calico",
+						Description: "Calico version updated.",
+						Kind:        "changed",
+					},
+				},
+				Components: []Component{
+					{
+						Name:    "calico",
+						Version: "1.1.0",
+					},
+					{
+						Name:    "kube-dns",
+						Version: "1.0.0",
+					},
+				},
+				Dependencies: []Dependency{},
+				Deprecated:   false,
+				Name:         "kubernetes-operator",
+				Time:         time.Unix(10, 5),
+				Version:      "5.7.18",
+				WIP:          false,
+			},
+			Other: Bundle{
+				Changelogs: []Changelog{
+					{
+						Component:   "calico",
+						Description: "Calico version updated.",
+						Kind:        "changed",
+					},
+				},
+				Components: []Component{
+					{
+						Name:    "calico",
+						Version: "1.1.0",
+					},
+					{
+						Name:    "kube-dns",
+						Version: "1.0.0",
+					},
+				},
+				Dependencies: []Dependency{},
+				Deprecated:   false,
+				Name:         "kubernetes-operator",
+				Time:         time.Unix(10, 5),
+				Version:      "5.17.7",
+				WIP:          false,
+			},
+			ErrorMatcher:   nil,
+			ExpectedResult: true,
+		},
+
+		// Test 12 ensures a bigger patch version is not considered a minor upgrade.
+		{
+			Bundle: Bundle{
+				Changelogs: []Changelog{
+					{
+						Component:   "calico",
+						Description: "Calico version updated.",
+						Kind:        "changed",
+					},
+				},
+				Components: []Component{
+					{
+						Name:    "calico",
+						Version: "1.1.0",
+					},
+					{
+						Name:    "kube-dns",
+						Version: "1.0.0",
+					},
+				},
+				Dependencies: []Dependency{},
+				Deprecated:   false,
+				Name:         "kubernetes-operator",
+				Time:         time.Unix(10, 5),
+				Version:      "0.2.1",
+				WIP:          false,
+			},
+			Other: Bundle{
+				Changelogs: []Changelog{
+					{
+						Component:   "calico",
+						Description: "Calico version updated.",
+						Kind:        "changed",
+					},
+				},
+				Components: []Component{
+					{
+						Name:    "calico",
+						Version: "1.1.0",
+					},
+					{
+						Name:    "kube-dns",
+						Version: "1.0.0",
+					},
+				},
+				Dependencies: []Dependency{},
+				Deprecated:   false,
+				Name:         "kubernetes-operator",
+				Time:         time.Unix(10, 5),
+				Version:      "0.2.2",
+				WIP:          false,
+			},
+			ErrorMatcher:   nil,
+			ExpectedResult: false,
+		},
+	}
+
+	for i, tc := range testCases {
+		result, err := tc.Bundle.IsMinorUpgrade(tc.Other)
+		if tc.ErrorMatcher != nil {
+			if !tc.ErrorMatcher(err) {
+				t.Fatalf("test %d expected %#v got %#v", i, true, false)
+			}
+		} else if err != nil {
+			t.Fatalf("test %d expected %#v got %#v", i, nil, err)
+		} else {
+			if result != tc.ExpectedResult {
+				t.Fatalf("test %d expected %#v got %#v", i, tc.ExpectedResult, result)
+			}
+		}
+	}
+}
+
+func Test_Bundle_IsPatchUpgrade(t *testing.T) {
+	testCases := []struct {
+		Bundle         Bundle
+		Other          Bundle
+		ErrorMatcher   func(err error) bool
+		ExpectedResult bool
+	}{
+		// Test 0 ensures that empty bundles throw an error.
+		{
+			Bundle:         Bundle{},
+			Other:          Bundle{},
+			ErrorMatcher:   IsInvalidBundleError,
+			ExpectedResult: false,
+		},
+
+		// Test 1 is the same as 0 but with the lower bundle being empty.
+		{
+			Bundle: Bundle{
+				Changelogs: []Changelog{
+					{
+						Component:   "calico",
+						Description: "Calico version updated.",
+						Kind:        "changed",
+					},
+				},
+				Components: []Component{
+					{
+						Name:    "calico",
+						Version: "1.1.0",
+					},
+					{
+						Name:    "kube-dns",
+						Version: "1.0.0",
+					},
+				},
+				Dependencies: []Dependency{},
+				Deprecated:   false,
+				Name:         "kubernetes-operator",
+				Time:         time.Unix(10, 5),
+				Version:      "0.1.0",
+				WIP:          false,
+			},
+			Other:          Bundle{},
+			ErrorMatcher:   IsInvalidBundleError,
+			ExpectedResult: false,
+		},
+
+		// Test 2 is the same as 0 but with the higher bundle being empty.
+		{
+			Bundle: Bundle{},
+			Other: Bundle{
+				Changelogs: []Changelog{
+					{
+						Component:   "calico",
+						Description: "Calico version updated.",
+						Kind:        "changed",
+					},
+				},
+				Components: []Component{
+					{
+						Name:    "calico",
+						Version: "1.1.0",
+					},
+					{
+						Name:    "kube-dns",
+						Version: "1.0.0",
+					},
+				},
+				Dependencies: []Dependency{},
+				Deprecated:   false,
+				Name:         "kubernetes-operator",
+				Time:         time.Unix(10, 5),
+				Version:      "0.1.0",
+				WIP:          false,
+			},
+			ErrorMatcher:   IsInvalidBundleError,
+			ExpectedResult: false,
+		},
+
+		// Test 3 ensures the same version results in false.
+		{
+			Bundle: Bundle{
+				Changelogs: []Changelog{
+					{
+						Component:   "calico",
+						Description: "Calico version updated.",
+						Kind:        "changed",
+					},
+				},
+				Components: []Component{
+					{
+						Name:    "calico",
+						Version: "1.1.0",
+					},
+					{
+						Name:    "kube-dns",
+						Version: "1.0.0",
+					},
+				},
+				Dependencies: []Dependency{},
+				Deprecated:   false,
+				Name:         "kubernetes-operator",
+				Time:         time.Unix(10, 5),
+				Version:      "0.1.0",
+				WIP:          false,
+			},
+			Other: Bundle{
+				Changelogs: []Changelog{
+					{
+						Component:   "calico",
+						Description: "Calico version updated.",
+						Kind:        "changed",
+					},
+				},
+				Components: []Component{
+					{
+						Name:    "calico",
+						Version: "1.1.0",
+					},
+					{
+						Name:    "kube-dns",
+						Version: "1.0.0",
+					},
+				},
+				Dependencies: []Dependency{},
+				Deprecated:   false,
+				Name:         "kubernetes-operator",
+				Time:         time.Unix(10, 5),
+				Version:      "0.1.0",
+				WIP:          false,
+			},
+			ErrorMatcher:   nil,
+			ExpectedResult: false,
+		},
+
+		// Test 4 version bundles of different authorities cannot be compared and
+		// result in an error.
+		{
+			Bundle: Bundle{
+				Changelogs: []Changelog{
+					{
+						Component:   "calico",
+						Description: "Calico version updated.",
+						Kind:        "changed",
+					},
+				},
+				Components: []Component{
+					{
+						Name:    "calico",
+						Version: "1.1.0",
+					},
+					{
+						Name:    "kube-dns",
+						Version: "1.0.0",
+					},
+				},
+				Dependencies: []Dependency{},
+				Deprecated:   false,
+				Name:         "ingress-operator",
+				Time:         time.Unix(10, 5),
+				Version:      "0.1.0",
+				WIP:          false,
+			},
+			Other: Bundle{
+				Changelogs: []Changelog{
+					{
+						Component:   "calico",
+						Description: "Calico version updated.",
+						Kind:        "changed",
+					},
+				},
+				Components: []Component{
+					{
+						Name:    "calico",
+						Version: "1.1.0",
+					},
+					{
+						Name:    "kube-dns",
+						Version: "1.0.0",
+					},
+				},
+				Dependencies: []Dependency{},
+				Deprecated:   false,
+				Name:         "kubernetes-operator",
+				Time:         time.Unix(10, 5),
+				Version:      "0.2.0",
+				WIP:          false,
+			},
+			ErrorMatcher:   IsInvalidBundleError,
+			ExpectedResult: false,
+		},
+
+		// Test 5 ensures a smaller major version is not considered a patch upgrade.
+		{
+			Bundle: Bundle{
+				Changelogs: []Changelog{
+					{
+						Component:   "calico",
+						Description: "Calico version updated.",
+						Kind:        "changed",
+					},
+				},
+				Components: []Component{
+					{
+						Name:    "calico",
+						Version: "1.1.0",
+					},
+					{
+						Name:    "kube-dns",
+						Version: "1.0.0",
+					},
+				},
+				Dependencies: []Dependency{},
+				Deprecated:   false,
+				Name:         "kubernetes-operator",
+				Time:         time.Unix(10, 5),
+				Version:      "1.1.0",
+				WIP:          false,
+			},
+			Other: Bundle{
+				Changelogs: []Changelog{
+					{
+						Component:   "calico",
+						Description: "Calico version updated.",
+						Kind:        "changed",
+					},
+				},
+				Components: []Component{
+					{
+						Name:    "calico",
+						Version: "1.1.0",
+					},
+					{
+						Name:    "kube-dns",
+						Version: "1.0.0",
+					},
+				},
+				Dependencies: []Dependency{},
+				Deprecated:   false,
+				Name:         "kubernetes-operator",
+				Time:         time.Unix(10, 5),
+				Version:      "0.1.0",
+				WIP:          false,
+			},
+			ErrorMatcher:   nil,
+			ExpectedResult: false,
+		},
+
+		// Test 6 ensures a smaller minor version is not considered a patch upgrade.
+		{
+			Bundle: Bundle{
+				Changelogs: []Changelog{
+					{
+						Component:   "calico",
+						Description: "Calico version updated.",
+						Kind:        "changed",
+					},
+				},
+				Components: []Component{
+					{
+						Name:    "calico",
+						Version: "1.1.0",
+					},
+					{
+						Name:    "kube-dns",
+						Version: "1.0.0",
+					},
+				},
+				Dependencies: []Dependency{},
+				Deprecated:   false,
+				Name:         "kubernetes-operator",
+				Time:         time.Unix(10, 5),
+				Version:      "0.2.0",
+				WIP:          false,
+			},
+			Other: Bundle{
+				Changelogs: []Changelog{
+					{
+						Component:   "calico",
+						Description: "Calico version updated.",
+						Kind:        "changed",
+					},
+				},
+				Components: []Component{
+					{
+						Name:    "calico",
+						Version: "1.1.0",
+					},
+					{
+						Name:    "kube-dns",
+						Version: "1.0.0",
+					},
+				},
+				Dependencies: []Dependency{},
+				Deprecated:   false,
+				Name:         "kubernetes-operator",
+				Time:         time.Unix(10, 5),
+				Version:      "0.1.0",
+				WIP:          false,
+			},
+			ErrorMatcher:   nil,
+			ExpectedResult: false,
+		},
+
+		// Test 7 ensures a smaller patch version is not considered a patch upgrade.
+		{
+			Bundle: Bundle{
+				Changelogs: []Changelog{
+					{
+						Component:   "calico",
+						Description: "Calico version updated.",
+						Kind:        "changed",
+					},
+				},
+				Components: []Component{
+					{
+						Name:    "calico",
+						Version: "1.1.0",
+					},
+					{
+						Name:    "kube-dns",
+						Version: "1.0.0",
+					},
+				},
+				Dependencies: []Dependency{},
+				Deprecated:   false,
+				Name:         "kubernetes-operator",
+				Time:         time.Unix(10, 5),
+				Version:      "0.2.1",
+				WIP:          false,
+			},
+			Other: Bundle{
+				Changelogs: []Changelog{
+					{
+						Component:   "calico",
+						Description: "Calico version updated.",
+						Kind:        "changed",
+					},
+				},
+				Components: []Component{
+					{
+						Name:    "calico",
+						Version: "1.1.0",
+					},
+					{
+						Name:    "kube-dns",
+						Version: "1.0.0",
+					},
+				},
+				Dependencies: []Dependency{},
+				Deprecated:   false,
+				Name:         "kubernetes-operator",
+				Time:         time.Unix(10, 5),
+				Version:      "0.2.0",
+				WIP:          false,
+			},
+			ErrorMatcher:   nil,
+			ExpectedResult: false,
+		},
+
+		// Test 8 ensures a bigger major version is not considered a patch upgrade.
+		{
+			Bundle: Bundle{
+				Changelogs: []Changelog{
+					{
+						Component:   "calico",
+						Description: "Calico version updated.",
+						Kind:        "changed",
+					},
+				},
+				Components: []Component{
+					{
+						Name:    "calico",
+						Version: "1.1.0",
+					},
+					{
+						Name:    "kube-dns",
+						Version: "1.0.0",
+					},
+				},
+				Dependencies: []Dependency{},
+				Deprecated:   false,
+				Name:         "kubernetes-operator",
+				Time:         time.Unix(10, 5),
+				Version:      "0.2.1",
+				WIP:          false,
+			},
+			Other: Bundle{
+				Changelogs: []Changelog{
+					{
+						Component:   "calico",
+						Description: "Calico version updated.",
+						Kind:        "changed",
+					},
+				},
+				Components: []Component{
+					{
+						Name:    "calico",
+						Version: "1.1.0",
+					},
+					{
+						Name:    "kube-dns",
+						Version: "1.0.0",
+					},
+				},
+				Dependencies: []Dependency{},
+				Deprecated:   false,
+				Name:         "kubernetes-operator",
+				Time:         time.Unix(10, 5),
+				Version:      "1.0.0",
+				WIP:          false,
+			},
+			ErrorMatcher:   nil,
+			ExpectedResult: false,
+		},
+
+		// Test 9 ensures a bigger minor version is not considered a patch upgrade.
+		{
+			Bundle: Bundle{
+				Changelogs: []Changelog{
+					{
+						Component:   "calico",
+						Description: "Calico version updated.",
+						Kind:        "changed",
+					},
+				},
+				Components: []Component{
+					{
+						Name:    "calico",
+						Version: "1.1.0",
+					},
+					{
+						Name:    "kube-dns",
+						Version: "1.0.0",
+					},
+				},
+				Dependencies: []Dependency{},
+				Deprecated:   false,
+				Name:         "kubernetes-operator",
+				Time:         time.Unix(10, 5),
+				Version:      "0.2.1",
+				WIP:          false,
+			},
+			Other: Bundle{
+				Changelogs: []Changelog{
+					{
+						Component:   "calico",
+						Description: "Calico version updated.",
+						Kind:        "changed",
+					},
+				},
+				Components: []Component{
+					{
+						Name:    "calico",
+						Version: "1.1.0",
+					},
+					{
+						Name:    "kube-dns",
+						Version: "1.0.0",
+					},
+				},
+				Dependencies: []Dependency{},
+				Deprecated:   false,
+				Name:         "kubernetes-operator",
+				Time:         time.Unix(10, 5),
+				Version:      "0.3.0",
+				WIP:          false,
+			},
+			ErrorMatcher:   nil,
+			ExpectedResult: false,
+		},
+
+		// Test 10 ensures a bigger patch version is considered a patch upgrade.
+		{
+			Bundle: Bundle{
+				Changelogs: []Changelog{
+					{
+						Component:   "calico",
+						Description: "Calico version updated.",
+						Kind:        "changed",
+					},
+				},
+				Components: []Component{
+					{
+						Name:    "calico",
+						Version: "1.1.0",
+					},
+					{
+						Name:    "kube-dns",
+						Version: "1.0.0",
+					},
+				},
+				Dependencies: []Dependency{},
+				Deprecated:   false,
+				Name:         "kubernetes-operator",
+				Time:         time.Unix(10, 5),
+				Version:      "0.2.1",
+				WIP:          false,
+			},
+			Other: Bundle{
+				Changelogs: []Changelog{
+					{
+						Component:   "calico",
+						Description: "Calico version updated.",
+						Kind:        "changed",
+					},
+				},
+				Components: []Component{
+					{
+						Name:    "calico",
+						Version: "1.1.0",
+					},
+					{
+						Name:    "kube-dns",
+						Version: "1.0.0",
+					},
+				},
+				Dependencies: []Dependency{},
+				Deprecated:   false,
+				Name:         "kubernetes-operator",
+				Time:         time.Unix(10, 5),
+				Version:      "0.2.2",
+				WIP:          false,
+			},
+			ErrorMatcher:   nil,
+			ExpectedResult: true,
+		},
+
+		// Test 11 is the same as 10 but with a versions.
+		{
+			Bundle: Bundle{
+				Changelogs: []Changelog{
+					{
+						Component:   "calico",
+						Description: "Calico version updated.",
+						Kind:        "changed",
+					},
+				},
+				Components: []Component{
+					{
+						Name:    "calico",
+						Version: "1.1.0",
+					},
+					{
+						Name:    "kube-dns",
+						Version: "1.0.0",
+					},
+				},
+				Dependencies: []Dependency{},
+				Deprecated:   false,
+				Name:         "kubernetes-operator",
+				Time:         time.Unix(10, 5),
+				Version:      "2.33.5",
+				WIP:          false,
+			},
+			Other: Bundle{
+				Changelogs: []Changelog{
+					{
+						Component:   "calico",
+						Description: "Calico version updated.",
+						Kind:        "changed",
+					},
+				},
+				Components: []Component{
+					{
+						Name:    "calico",
+						Version: "1.1.0",
+					},
+					{
+						Name:    "kube-dns",
+						Version: "1.0.0",
+					},
+				},
+				Dependencies: []Dependency{},
+				Deprecated:   false,
+				Name:         "kubernetes-operator",
+				Time:         time.Unix(10, 5),
+				Version:      "2.33.8",
+				WIP:          false,
+			},
+			ErrorMatcher:   nil,
+			ExpectedResult: true,
+		},
+	}
+
+	for i, tc := range testCases {
+		result, err := tc.Bundle.IsPatchUpgrade(tc.Other)
+		if tc.ErrorMatcher != nil {
+			if !tc.ErrorMatcher(err) {
+				t.Fatalf("test %d expected %#v got %#v", i, true, false)
+			}
+		} else if err != nil {
+			t.Fatalf("test %d expected %#v got %#v", i, nil, err)
+		} else {
+			if result != tc.ExpectedResult {
+				t.Fatalf("test %d expected %#v got %#v", i, tc.ExpectedResult, result)
+			}
+		}
+	}
+}
+
 func Test_Bundle_Validate(t *testing.T) {
 	testCases := []struct {
 		Bundle       Bundle

--- a/vendor/github.com/giantswarm/versionbundle/bundles.go
+++ b/vendor/github.com/giantswarm/versionbundle/bundles.go
@@ -13,6 +13,16 @@ import (
 // of multiple authorities are aggregated and grouped to reflect distributions.
 type Bundles []Bundle
 
+func (b Bundles) Contain(item Bundle) bool {
+	for _, bundle := range b {
+		if reflect.DeepEqual(bundle, item) {
+			return true
+		}
+	}
+
+	return false
+}
+
 func (b Bundles) Copy() Bundles {
 	raw, err := json.Marshal(b)
 	if err != nil {

--- a/vendor/github.com/giantswarm/versionbundle/bundles_test.go
+++ b/vendor/github.com/giantswarm/versionbundle/bundles_test.go
@@ -7,6 +7,317 @@ import (
 	"time"
 )
 
+func Test_Bundles_Contains(t *testing.T) {
+	testCases := []struct {
+		Bundles        []Bundle
+		Bundle         Bundle
+		ExpectedResult bool
+	}{
+		// Test 0 ensures that a nil list and an empty bundle result in false.
+		{
+			Bundles:        nil,
+			Bundle:         Bundle{},
+			ExpectedResult: false,
+		},
+
+		// Test 1 is the same as 0 but with an empty list of bundles.
+		{
+			Bundles:        []Bundle{},
+			Bundle:         Bundle{},
+			ExpectedResult: false,
+		},
+
+		// Test 2 ensures a list containing one version bundle and a matching
+		// version bundle results in true.
+		{
+			Bundles: []Bundle{
+				{
+					Changelogs: []Changelog{
+						{
+							Component:   "calico",
+							Description: "Calico version updated.",
+							Kind:        "changed",
+						},
+					},
+					Components: []Component{
+						{
+							Name:    "calico",
+							Version: "1.1.0",
+						},
+						{
+							Name:    "kube-dns",
+							Version: "1.0.0",
+						},
+					},
+					Dependencies: []Dependency{},
+					Deprecated:   false,
+					Name:         "kubernetes-operator",
+					Time:         time.Unix(10, 5),
+					Version:      "0.1.0",
+					WIP:          false,
+				},
+			},
+			Bundle: Bundle{
+				Changelogs: []Changelog{
+					{
+						Component:   "calico",
+						Description: "Calico version updated.",
+						Kind:        "changed",
+					},
+				},
+				Components: []Component{
+					{
+						Name:    "calico",
+						Version: "1.1.0",
+					},
+					{
+						Name:    "kube-dns",
+						Version: "1.0.0",
+					},
+				},
+				Dependencies: []Dependency{},
+				Deprecated:   false,
+				Name:         "kubernetes-operator",
+				Time:         time.Unix(10, 5),
+				Version:      "0.1.0",
+				WIP:          false,
+			},
+			ExpectedResult: true,
+		},
+
+		// Test 3 ensures a list containing two version bundle and a matching
+		// version bundle results in true.
+		{
+			Bundles: []Bundle{
+				{
+					Changelogs: []Changelog{
+						{
+							Component:   "calico",
+							Description: "Calico version updated.",
+							Kind:        "changed",
+						},
+					},
+					Components: []Component{
+						{
+							Name:    "calico",
+							Version: "1.1.0",
+						},
+						{
+							Name:    "kube-dns",
+							Version: "1.0.0",
+						},
+					},
+					Dependencies: []Dependency{},
+					Deprecated:   false,
+					Name:         "kubernetes-operator",
+					Time:         time.Unix(10, 5),
+					Version:      "0.1.0",
+					WIP:          false,
+				},
+				{
+					Changelogs: []Changelog{
+						{
+							Component:   "calico",
+							Description: "Calico version updated.",
+							Kind:        "changed",
+						},
+					},
+					Components: []Component{
+						{
+							Name:    "calico",
+							Version: "1.2.0",
+						},
+						{
+							Name:    "kube-dns",
+							Version: "1.0.0",
+						},
+					},
+					Dependencies: []Dependency{},
+					Deprecated:   false,
+					Name:         "kubernetes-operator",
+					Time:         time.Unix(10, 5),
+					Version:      "0.2.0",
+					WIP:          false,
+				},
+			},
+			Bundle: Bundle{
+				Changelogs: []Changelog{
+					{
+						Component:   "calico",
+						Description: "Calico version updated.",
+						Kind:        "changed",
+					},
+				},
+				Components: []Component{
+					{
+						Name:    "calico",
+						Version: "1.2.0",
+					},
+					{
+						Name:    "kube-dns",
+						Version: "1.0.0",
+					},
+				},
+				Dependencies: []Dependency{},
+				Deprecated:   false,
+				Name:         "kubernetes-operator",
+				Time:         time.Unix(10, 5),
+				Version:      "0.2.0",
+				WIP:          false,
+			},
+			ExpectedResult: true,
+		},
+
+		// Test 4 ensures a list containing one version bundle and a version bundle
+		// that does not match results in false.
+		{
+			Bundles: []Bundle{
+				{
+					Changelogs: []Changelog{
+						{
+							Component:   "calico",
+							Description: "Calico version updated.",
+							Kind:        "changed",
+						},
+					},
+					Components: []Component{
+						{
+							Name:    "calico",
+							Version: "1.1.0",
+						},
+						{
+							Name:    "kube-dns",
+							Version: "1.0.0",
+						},
+					},
+					Dependencies: []Dependency{},
+					Deprecated:   false,
+					Name:         "kubernetes-operator",
+					Time:         time.Unix(10, 5),
+					Version:      "0.1.0",
+					WIP:          false,
+				},
+			},
+			Bundle: Bundle{
+				Changelogs: []Changelog{
+					{
+						Component:   "calico",
+						Description: "Calico version updated.",
+						Kind:        "changed",
+					},
+				},
+				Components: []Component{
+					{
+						Name:    "calico",
+						Version: "1.2.0",
+					},
+					{
+						Name:    "kube-dns",
+						Version: "1.0.0",
+					},
+				},
+				Dependencies: []Dependency{},
+				Deprecated:   false,
+				Name:         "kubernetes-operator",
+				Time:         time.Unix(10, 5),
+				Version:      "0.2.0",
+				WIP:          false,
+			},
+			ExpectedResult: false,
+		},
+
+		// Test 5 ensures a list containing two version bundle and a version bundle
+		// that does not match results in false.
+		{
+			Bundles: []Bundle{
+				{
+					Changelogs: []Changelog{
+						{
+							Component:   "calico",
+							Description: "Calico version updated.",
+							Kind:        "changed",
+						},
+					},
+					Components: []Component{
+						{
+							Name:    "calico",
+							Version: "1.1.0",
+						},
+						{
+							Name:    "kube-dns",
+							Version: "1.0.0",
+						},
+					},
+					Dependencies: []Dependency{},
+					Deprecated:   false,
+					Name:         "kubernetes-operator",
+					Time:         time.Unix(10, 5),
+					Version:      "0.1.0",
+					WIP:          false,
+				},
+				{
+					Changelogs: []Changelog{
+						{
+							Component:   "calico",
+							Description: "Calico version updated.",
+							Kind:        "changed",
+						},
+					},
+					Components: []Component{
+						{
+							Name:    "calico",
+							Version: "1.2.0",
+						},
+						{
+							Name:    "kube-dns",
+							Version: "1.0.0",
+						},
+					},
+					Dependencies: []Dependency{},
+					Deprecated:   false,
+					Name:         "kubernetes-operator",
+					Time:         time.Unix(10, 5),
+					Version:      "0.2.0",
+					WIP:          false,
+				},
+			},
+			Bundle: Bundle{
+				Changelogs: []Changelog{
+					{
+						Component:   "calico",
+						Description: "Calico version updated.",
+						Kind:        "changed",
+					},
+				},
+				Components: []Component{
+					{
+						Name:    "calico",
+						Version: "1.3.0",
+					},
+					{
+						Name:    "kube-dns",
+						Version: "1.0.0",
+					},
+				},
+				Dependencies: []Dependency{},
+				Deprecated:   false,
+				Name:         "kubernetes-operator",
+				Time:         time.Unix(10, 5),
+				Version:      "0.3.0",
+				WIP:          false,
+			},
+			ExpectedResult: false,
+		},
+	}
+
+	for i, tc := range testCases {
+		result := Bundles(tc.Bundles).Contain(tc.Bundle)
+		if result != tc.ExpectedResult {
+			t.Fatalf("test %d expected %#v got %#v", i, tc.ExpectedResult, result)
+		}
+	}
+}
+
 func Test_Bundles_Copy(t *testing.T) {
 	bundles := []Bundle{
 		{

--- a/vendor/github.com/giantswarm/versionbundle/glide.lock
+++ b/vendor/github.com/giantswarm/versionbundle/glide.lock
@@ -1,6 +1,10 @@
-hash: 5ae760bb57983502080800d0fb28e0db8c757b54ae7c1c9e477d677676ad1094
-updated: 2017-10-23T18:19:53.35602745+02:00
+hash: b5bccbf03e02fb87ee49db770c792da6d247e4cf5b713e514bc31c314afb0df3
+updated: 2017-10-27T14:57:04.740836597+02:00
 imports:
+- name: github.com/coreos/go-semver
+  version: 8ab6407b697782a06568d4b7f1db25550ec2e4c6
+  subpackages:
+  - semver
 - name: github.com/giantswarm/microerror
   version: 5ade94eb4ee35ef72eb9382228470caeddb29989
 - name: github.com/juju/errgo
@@ -8,5 +12,6 @@ imports:
 - name: github.com/kylelemons/godebug
   version: d65d576e9348f5982d7f6d83682b694e731a45c6
   subpackages:
+  - diff
   - pretty
 testImports: []

--- a/vendor/github.com/giantswarm/versionbundle/glide.yaml
+++ b/vendor/github.com/giantswarm/versionbundle/glide.yaml
@@ -1,5 +1,7 @@
 package: github.com/giantswarm/versionbundle
 import:
+- package: github.com/coreos/go-semver/semver
+  version: v0.2.0
 - package: github.com/giantswarm/microerror
   version: master
 - package: github.com/kylelemons/godebug/pretty

--- a/vendor/github.com/spf13/cobra/README.md
+++ b/vendor/github.com/spf13/cobra/README.md
@@ -224,10 +224,6 @@ func init() {
   viper.SetDefault("license", "apache")
 }
 
-func Execute() {
-  RootCmd.Execute()
-}
-
 func initConfig() {
   // Don't forget to read config either from cfgFile or from home directory!
   if cfgFile != "" {


### PR DESCRIPTION
Tested in `lycan`. 1) New cluster 2) Recreation of master for old cluster 3) Recreation of worker for old cluster

Get latest vendor. k8scloudconfig uses branch "kvm-operator-disable-rbac" which has commit on top of master that disables RBAC (sets AlwaysAllow). 
https://github.com/giantswarm/k8scloudconfig/commit/6fcdf96d070a64106b38f68a45891c7959fe0e20

This is temporary solution proposed by Vaclav and Puja.

To get latest k8scloudconfig in kvm-operator:
- k8scloudconfig: rebase kvm-operator-disable-rbac with latest master branch and push
- kvm-operator: `glide up -v`