### PR TITLE
vendor-k8scc-etcd-localhost

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: e4713821f0bf46fa425f80249a00a1db0fa6a90edacef7b0718078edf35188c8
-updated: 2017-11-02T13:44:17.95794792+01:00
+updated: 2017-11-02T17:54:41.960403569+01:00
 imports:
 - name: github.com/beorn7/perks
   version: 4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9
@@ -48,7 +48,7 @@ imports:
   - spec/kubernetes/networksetup
   - spec/kubernetes/ssh
 - name: github.com/giantswarm/k8scloudconfig
-  version: 78ff383e001e386147e826708d4337cc840a4433
+  version: afd33a7344789be3299ea05a034c09b4fa8518e3
   subpackages:
   - v_0_1_0
 - name: github.com/giantswarm/k8shealthz
@@ -109,7 +109,7 @@ imports:
   - informer
   - tpr
 - name: github.com/giantswarm/versionbundle
-  version: 74ece9fd181fc5ef2a8510cbeb408485f9a0b1a3
+  version: 4d1e771cce94902dc952eed5deef58ebbcbb973f
 - name: github.com/go-kit/kit
   version: a9ca6725cbbea455e61c6bc8a1ed28e81eb3493b
   subpackages:

--- a/vendor/github.com/giantswarm/k8scloudconfig/v_0_1_0/master_template.go
+++ b/vendor/github.com/giantswarm/k8scloudconfig/v_0_1_0/master_template.go
@@ -1942,7 +1942,7 @@ coreos:
       --admission-control=NamespaceLifecycle,LimitRanger,ServiceAccount,ResourceQuota,DefaultStorageClass,PodSecurityPolicy \
       --cloud-provider={{.Cluster.Kubernetes.CloudProvider}} \
       --service-cluster-ip-range={{.Cluster.Kubernetes.API.ClusterIPRange}} \
-      --etcd-servers=https://{{ .Cluster.Etcd.Domain }}:443 \
+      --etcd-servers=https://127.0.0.1:2379 \
       --etcd-cafile=/etc/kubernetes/ssl/etcd/server-ca.pem \
       --etcd-certfile=/etc/kubernetes/ssl/etcd/server-crt.pem \
       --etcd-keyfile=/etc/kubernetes/ssl/etcd/server-key.pem \

--- a/vendor/github.com/giantswarm/versionbundle/bundles.go
+++ b/vendor/github.com/giantswarm/versionbundle/bundles.go
@@ -23,21 +23,6 @@ func (b Bundles) Contain(item Bundle) bool {
 	return false
 }
 
-func (b Bundles) Copy() Bundles {
-	raw, err := json.Marshal(b)
-	if err != nil {
-		panic(err)
-	}
-
-	var copy Bundles
-	err = json.Unmarshal(raw, &copy)
-	if err != nil {
-		panic(err)
-	}
-
-	return copy
-}
-
 func (b Bundles) Validate() error {
 	if len(b) == 0 {
 		return microerror.Maskf(invalidBundlesError, "version bundles must not be empty")
@@ -47,8 +32,8 @@ func (b Bundles) Validate() error {
 		return microerror.Maskf(invalidBundlesError, "version bundle versions must be unique")
 	}
 
-	b1 := b.Copy()
-	b2 := b.Copy()
+	b1 := CopyBundles(b)
+	b2 := CopyBundles(b)
 	sort.Sort(SortBundlesByTime(b1))
 	sort.Sort(SortBundlesByVersion(b2))
 	if !reflect.DeepEqual(b1, b2) {
@@ -70,6 +55,21 @@ func (b Bundles) Validate() error {
 	}
 
 	return nil
+}
+
+func CopyBundles(bundles []Bundle) []Bundle {
+	raw, err := json.Marshal(bundles)
+	if err != nil {
+		panic(err)
+	}
+
+	var copy []Bundle
+	err = json.Unmarshal(raw, &copy)
+	if err != nil {
+		panic(err)
+	}
+
+	return copy
 }
 
 func (b Bundles) hasDuplicatedVersions() bool {

--- a/vendor/github.com/giantswarm/versionbundle/bundles_test.go
+++ b/vendor/github.com/giantswarm/versionbundle/bundles_test.go
@@ -381,8 +381,8 @@ func Test_Bundles_Copy(t *testing.T) {
 		},
 	}
 
-	b1 := Bundles(bundles).Copy()
-	b2 := Bundles(bundles).Copy()
+	b1 := CopyBundles(bundles)
+	b2 := CopyBundles(bundles)
 
 	sort.Sort(SortBundlesByTime(b1))
 	sort.Sort(SortBundlesByVersion(b2))

--- a/vendor/github.com/giantswarm/versionbundle/distribution.go
+++ b/vendor/github.com/giantswarm/versionbundle/distribution.go
@@ -1,0 +1,70 @@
+package versionbundle
+
+import (
+	"fmt"
+
+	"github.com/coreos/go-semver/semver"
+	"github.com/giantswarm/microerror"
+)
+
+type DistributionConfig struct {
+	Bundles []Bundle
+}
+
+func DefaultDistributionConfig() DistributionConfig {
+	return DistributionConfig{
+		Bundles: nil,
+	}
+}
+
+type Distribution struct {
+	bundles []Bundle
+	version string
+}
+
+func NewDistribution(config DistributionConfig) (Distribution, error) {
+	if len(config.Bundles) == 0 {
+		return Distribution{}, microerror.Maskf(invalidConfigError, "config.Bundles must not be empty")
+	}
+
+	version, err := aggregateDistributionVersion(config.Bundles)
+	if err != nil {
+		return Distribution{}, microerror.Maskf(invalidConfigError, err.Error())
+	}
+
+	d := Distribution{
+		bundles: config.Bundles,
+		version: version,
+	}
+
+	return d, nil
+}
+
+func (d Distribution) Bundles() []Bundle {
+	return CopyBundles(d.bundles)
+}
+
+func (d Distribution) Version() string {
+	return d.version
+}
+
+func aggregateDistributionVersion(bundles []Bundle) (string, error) {
+	var major int64
+	var minor int64
+	var patch int64
+
+	for _, b := range bundles {
+		v, err := semver.NewVersion(b.Version)
+		if err != nil {
+			return "", microerror.Mask(err)
+		}
+
+		major += v.Major
+		minor += v.Minor
+		patch += v.Patch
+	}
+
+	version := fmt.Sprintf("%d.%d.%d", major, minor, patch)
+
+	return version, nil
+}

--- a/vendor/github.com/giantswarm/versionbundle/distribution_test.go
+++ b/vendor/github.com/giantswarm/versionbundle/distribution_test.go
@@ -1,0 +1,261 @@
+package versionbundle
+
+import (
+	"testing"
+	"time"
+)
+
+func Test_Distribution_Version(t *testing.T) {
+	testCases := []struct {
+		Bundles         []Bundle
+		ExpectedVersion string
+		ErrorMatcher    func(err error) bool
+	}{
+		// Test 0 ensures creating a distribution with a nil slice of bundles throws
+		// an error when creating a new distribution type.
+		{
+			Bundles:         nil,
+			ExpectedVersion: "",
+			ErrorMatcher:    IsInvalidConfig,
+		},
+
+		// Test 1 is the same as 0 but with an empty list of bundles.
+		{
+			Bundles:         []Bundle{},
+			ExpectedVersion: "",
+			ErrorMatcher:    IsInvalidConfig,
+		},
+
+		// Test 2 ensures computing the distribution version when having a list of
+		// one bundle given works as expected.
+		{
+			Bundles: []Bundle{
+				{
+					Changelogs: []Changelog{},
+					Components: []Component{
+						{
+							Name:    "calico",
+							Version: "1.1.0",
+						},
+						{
+							Name:    "kube-dns",
+							Version: "1.0.0",
+						},
+					},
+					Dependencies: []Dependency{
+						{
+							Name:    "kubernetes",
+							Version: "<= 1.7.x",
+						},
+					},
+					Deprecated: false,
+					Name:       "kubernetes-operator",
+					Time:       time.Unix(10, 5),
+					Version:    "0.0.1",
+					WIP:        false,
+				},
+			},
+			ExpectedVersion: "0.0.1",
+			ErrorMatcher:    nil,
+		},
+
+		// Test 3 is the same as 2 but with a different version.
+		{
+			Bundles: []Bundle{
+				{
+					Changelogs: []Changelog{},
+					Components: []Component{
+						{
+							Name:    "calico",
+							Version: "1.1.0",
+						},
+						{
+							Name:    "kube-dns",
+							Version: "1.0.0",
+						},
+					},
+					Dependencies: []Dependency{
+						{
+							Name:    "kubernetes",
+							Version: "<= 1.7.x",
+						},
+					},
+					Deprecated: false,
+					Name:       "kubernetes-operator",
+					Time:       time.Unix(10, 5),
+					Version:    "11.4.1",
+					WIP:        false,
+				},
+			},
+			ExpectedVersion: "11.4.1",
+			ErrorMatcher:    nil,
+		},
+
+		// Test 4 ensures computing the distribution version when having a list of
+		// two bundles given works as expected.
+		{
+			Bundles: []Bundle{
+				{
+					Changelogs: []Changelog{
+						{
+							Component:   "calico",
+							Description: "Calico version updated.",
+							Kind:        "changed",
+						},
+						{
+							Component:   "kubernetes",
+							Description: "Kubernetes version requirements changed due to calico update.",
+							Kind:        "changed",
+						},
+					},
+					Components: []Component{
+						{
+							Name:    "calico",
+							Version: "1.1.0",
+						},
+						{
+							Name:    "kube-dns",
+							Version: "1.0.0",
+						},
+					},
+					Dependencies: []Dependency{
+						{
+							Name:    "kubernetes",
+							Version: "<= 1.7.x",
+						},
+					},
+					Deprecated: false,
+					Name:       "kubernetes-operator",
+					Time:       time.Unix(10, 5),
+					Version:    "0.1.0",
+					WIP:        false,
+				},
+				{
+					Changelogs: []Changelog{
+						{
+							Component:   "etcd",
+							Description: "Etcd version updated.",
+							Kind:        "changed",
+						},
+						{
+							Component:   "kubernetes",
+							Description: "Kubernetes version updated.",
+							Kind:        "changed",
+						},
+					},
+					Components: []Component{
+						{
+							Name:    "etcd",
+							Version: "3.2.0",
+						},
+						{
+							Name:    "kubernetes",
+							Version: "1.7.1",
+						},
+					},
+					Dependencies: []Dependency{},
+					Name:         "cloud-config-operator",
+					Deprecated:   false,
+					Time:         time.Unix(20, 15),
+					Version:      "0.2.0",
+					WIP:          false,
+				},
+			},
+			ExpectedVersion: "0.3.0",
+			ErrorMatcher:    nil,
+		},
+
+		// Test 5 is the same as 4 but with a different version.
+		{
+			Bundles: []Bundle{
+				{
+					Changelogs: []Changelog{
+						{
+							Component:   "calico",
+							Description: "Calico version updated.",
+							Kind:        "changed",
+						},
+						{
+							Component:   "kubernetes",
+							Description: "Kubernetes version requirements changed due to calico update.",
+							Kind:        "changed",
+						},
+					},
+					Components: []Component{
+						{
+							Name:    "calico",
+							Version: "1.1.0",
+						},
+						{
+							Name:    "kube-dns",
+							Version: "1.0.0",
+						},
+					},
+					Dependencies: []Dependency{
+						{
+							Name:    "kubernetes",
+							Version: "<= 1.7.x",
+						},
+					},
+					Deprecated: false,
+					Name:       "kubernetes-operator",
+					Time:       time.Unix(10, 5),
+					Version:    "5.0.1",
+					WIP:        false,
+				},
+				{
+					Changelogs: []Changelog{
+						{
+							Component:   "etcd",
+							Description: "Etcd version updated.",
+							Kind:        "changed",
+						},
+						{
+							Component:   "kubernetes",
+							Description: "Kubernetes version updated.",
+							Kind:        "changed",
+						},
+					},
+					Components: []Component{
+						{
+							Name:    "etcd",
+							Version: "3.2.0",
+						},
+						{
+							Name:    "kubernetes",
+							Version: "1.7.1",
+						},
+					},
+					Dependencies: []Dependency{},
+					Name:         "cloud-config-operator",
+					Deprecated:   false,
+					Time:         time.Unix(20, 15),
+					Version:      "12.2.77",
+					WIP:          false,
+				},
+			},
+			ExpectedVersion: "17.2.78",
+			ErrorMatcher:    nil,
+		},
+	}
+
+	for i, tc := range testCases {
+		config := DefaultDistributionConfig()
+
+		config.Bundles = tc.Bundles
+
+		d, err := NewDistribution(config)
+		if tc.ErrorMatcher != nil {
+			if !tc.ErrorMatcher(err) {
+				t.Fatalf("test %d expected %#v got %#v", i, true, false)
+			}
+		} else if err != nil {
+			t.Fatalf("test %d expected %#v got %#v", i, nil, err)
+		}
+
+		v := d.Version()
+		if v != tc.ExpectedVersion {
+			t.Fatalf("test %d expected %s got %s", i, tc.ExpectedVersion, v)
+		}
+	}
+}

--- a/vendor/github.com/giantswarm/versionbundle/error.go
+++ b/vendor/github.com/giantswarm/versionbundle/error.go
@@ -46,6 +46,13 @@ func IsInvalidComponent(err error) bool {
 	return microerror.Cause(err) == invalidComponentError
 }
 
+var invalidConfigError = microerror.New("invalid config")
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
 var invalidDependencyError = microerror.New("invalid dependency")
 
 // IsInvalidDependency asserts invalidDependencyError.


### PR DESCRIPTION
vendor k8scc changes that will let k8s-api use localhost to reach etcd

towards https://github.com/giantswarm/giantswarm/issues/1905

https://github.com/giantswarm/kvm-operator/blob/f95eee072e551f50973f4291e0018a76432c0c1c/vendor/github.com/giantswarm/k8scloudconfig/v_0_1_0/master_template.go#L1941