### PR TITLE
use annotations for version information instead of labels

### DIFF
--- a/service/resource/deployment/current.go
+++ b/service/resource/deployment/current.go
@@ -49,9 +49,9 @@ func (r *Resource) updateVersionBundleVersionGauge(customObject kvmtpr.CustomObj
 	versionCounts := map[string]float64{}
 
 	for _, d := range deployments {
-		version, ok := d.Labels[VersionBundleVersionLabel]
+		version, ok := d.Annotations[VersionBundleVersionAnnotation]
 		if !ok {
-			r.logger.Log("cluster", key.ClusterID(customObject), "warning", fmt.Sprintf("cannot update current version bundle version metric: label '%s' must not be empty", VersionBundleVersionLabel))
+			r.logger.Log("cluster", key.ClusterID(customObject), "warning", fmt.Sprintf("cannot update current version bundle version metric: annotation '%s' must not be empty", VersionBundleVersionAnnotation))
 			continue
 		} else {
 			count, ok := versionCounts[version]

--- a/service/resource/deployment/master_deployment.go
+++ b/service/resource/deployment/master_deployment.go
@@ -60,12 +60,14 @@ func newMasterDeployments(customObject kvmtpr.CustomObject) ([]*extensionsv1.Dep
 			},
 			ObjectMeta: apismetav1.ObjectMeta{
 				Name: key.DeploymentName(key.MasterID, masterNode.ID),
+				Annotations: map[string]string{
+					VersionBundleVersionAnnotation: key.VersionBundleVersion(customObject),
+				},
 				Labels: map[string]string{
 					"cluster":  key.ClusterID(customObject),
 					"customer": key.ClusterCustomer(customObject),
 					"app":      key.MasterID,
 					"node":     masterNode.ID,
-					VersionBundleVersionLabel: key.VersionBundleVersion(customObject),
 				},
 			},
 			Spec: extensionsv1.DeploymentSpec{

--- a/service/resource/deployment/metric.go
+++ b/service/resource/deployment/metric.go
@@ -5,9 +5,9 @@ import (
 )
 
 const (
-	PrometheusNamespace       = "kvm_operator"
-	PrometheusSubsystem       = "deployment_resource"
-	VersionBundleVersionLabel = "giantswarm.io/version-bundle-version"
+	PrometheusNamespace            = "kvm_operator"
+	PrometheusSubsystem            = "deployment_resource"
+	VersionBundleVersionAnnotation = "giantswarm.io/version-bundle-version"
 )
 
 var versionBundleVersionGauge = prometheus.NewGaugeVec(

--- a/service/resource/deployment/node_controller_deployment.go
+++ b/service/resource/deployment/node_controller_deployment.go
@@ -35,12 +35,14 @@ func newNodeControllerDeployment(customObject kvmtpr.CustomObject) (*extensionsv
 			Template: apiv1.PodTemplateSpec{
 				ObjectMeta: apismetav1.ObjectMeta{
 					GenerateName: key.NodeControllerID,
+					Annotations: map[string]string{
+						VersionBundleVersionAnnotation: key.VersionBundleVersion(customObject),
+					},
 					Labels: map[string]string{
 						"app":      key.NodeControllerID,
 						"cluster":  key.ClusterID(customObject),
 						"customer": key.ClusterCustomer(customObject),
 					},
-					Annotations: map[string]string{},
 				},
 				Spec: apiv1.PodSpec{
 					Containers: []apiv1.Container{

--- a/service/resource/deployment/worker_deployment.go
+++ b/service/resource/deployment/worker_deployment.go
@@ -27,12 +27,14 @@ func newWorkerDeployments(customObject kvmtpr.CustomObject) ([]*extensionsv1.Dep
 			},
 			ObjectMeta: apismetav1.ObjectMeta{
 				Name: key.DeploymentName(key.WorkerID, workerNode.ID),
+				Annotations: map[string]string{
+					VersionBundleVersionAnnotation: key.VersionBundleVersion(customObject),
+				},
 				Labels: map[string]string{
 					"app":      key.WorkerID,
 					"cluster":  key.ClusterID(customObject),
 					"customer": key.ClusterCustomer(customObject),
 					"node":     workerNode.ID,
-					VersionBundleVersionLabel: key.VersionBundleVersion(customObject),
 				},
 			},
 			Spec: extensionsv1.DeploymentSpec{


### PR DESCRIPTION
Thinking about it versions are more like meta information than labels to compose or work with components within our infrastructure. Reading on the Kubernetes docs I got the feeling we should track our version bundle versions rather in annotations than in labels. E.g. I do not see a need to be able to filter deployments by their version bundle version when using our informer. Successfully tested on lycan. 

<img width="527" alt="screen shot 2017-11-17 at 13 04 26" src="https://user-images.githubusercontent.com/552769/32946521-27d1d4d0-cb98-11e7-8dba-59b2b0a35257.png">
