### PR TITLE
copied cloudconfigv1 package

### DIFF
--- a/service/cloudconfigv2/cloud_config.go
+++ b/service/cloudconfigv2/cloud_config.go
@@ -1,0 +1,111 @@
+package cloudconfigv1
+
+import (
+	"github.com/giantswarm/certificatetpr"
+	clustertprspec "github.com/giantswarm/clustertpr/spec"
+	cloudconfig "github.com/giantswarm/k8scloudconfig"
+	"github.com/giantswarm/kvmtpr"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+)
+
+const (
+	FileOwner      = "root:root"
+	FilePermission = 0700
+)
+
+// Config represents the configuration used to create a cloud config service.
+type Config struct {
+	// Dependencies.
+	Logger micrologger.Logger
+}
+
+// DefaultConfig provides a default configuration to create a new cloud config
+// service by best effort.
+func DefaultConfig() Config {
+	return Config{
+		// Dependencies.
+		Logger: nil,
+	}
+}
+
+// CloudConfig implements the cloud config service interface.
+type CloudConfig struct {
+	// Dependencies.
+	logger micrologger.Logger
+}
+
+// New creates a new configured cloud config service.
+func New(config Config) (*CloudConfig, error) {
+	// Dependencies.
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "logger must not be empty")
+	}
+
+	newCloudConfig := &CloudConfig{
+		// Dependencies.
+		logger: config.Logger,
+	}
+
+	return newCloudConfig, nil
+}
+
+// NewMasterTemplate generates a new worker cloud config template and returns it
+// as a base64 encoded string.
+func (c *CloudConfig) NewMasterTemplate(customObject kvmtpr.CustomObject, certs certificatetpr.AssetsBundle, node clustertprspec.Node) (string, error) {
+	var err error
+
+	// TODO remove defaulting as soon as custom objects are configured.
+	if customObject.Spec.Cluster.Version == "" {
+		customObject.Spec.Cluster.Version = string(cloudconfig.V_1_0_0)
+	}
+	// TODO remove defaulting as soon as custom objects are migrated.
+	if customObject.Spec.Cluster.Version == string(cloudconfig.V_0_1_0) {
+		customObject.Spec.Cluster.Version = string(cloudconfig.V_1_0_0)
+	}
+
+	var template string
+
+	switch customObject.Spec.Cluster.Version {
+	case string(cloudconfig.V_1_0_0):
+		template, err = v_1_0_0MasterTemplate(customObject, certs, node)
+		if err != nil {
+			return "", microerror.Mask(err)
+		}
+
+	default:
+		return "", microerror.Maskf(notFoundError, "k8scloudconfig version '%s'", customObject.Spec.Cluster.Version)
+	}
+
+	return template, nil
+}
+
+// NewWorkerTemplate generates a new worker cloud config template and returns it
+// as a base64 encoded string.
+func (c *CloudConfig) NewWorkerTemplate(customObject kvmtpr.CustomObject, certs certificatetpr.AssetsBundle, node clustertprspec.Node) (string, error) {
+	var err error
+
+	// TODO remove defaulting as soon as custom objects are configured.
+	if customObject.Spec.Cluster.Version == "" {
+		customObject.Spec.Cluster.Version = string(cloudconfig.V_1_0_0)
+	}
+	// TODO remove defaulting as soon as custom objects are migrated.
+	if customObject.Spec.Cluster.Version == string(cloudconfig.V_0_1_0) {
+		customObject.Spec.Cluster.Version = string(cloudconfig.V_1_0_0)
+	}
+
+	var template string
+
+	switch customObject.Spec.Cluster.Version {
+	case string(cloudconfig.V_1_0_0):
+		template, err = v_1_0_0WorkerTemplate(customObject, certs, node)
+		if err != nil {
+			return "", microerror.Mask(err)
+		}
+
+	default:
+		return "", microerror.Maskf(notFoundError, "k8scloudconfig version '%s'", customObject.Spec.Cluster.Version)
+	}
+
+	return template, nil
+}

--- a/service/cloudconfigv2/cloudconfigtest/cloudconfigtest.go
+++ b/service/cloudconfigv2/cloudconfigtest/cloudconfigtest.go
@@ -1,0 +1,20 @@
+package cloudconfigtest
+
+import (
+	"github.com/giantswarm/micrologger/microloggertest"
+
+	"github.com/giantswarm/kvm-operator/service/cloudconfigv1"
+)
+
+func New() *cloudconfigv1.CloudConfig {
+	c := cloudconfigv1.DefaultConfig()
+
+	c.Logger = microloggertest.New()
+
+	newCloudConfig, err := cloudconfigv1.New(c)
+	if err != nil {
+		panic(err)
+	}
+
+	return newCloudConfig
+}

--- a/service/cloudconfigv2/error.go
+++ b/service/cloudconfigv2/error.go
@@ -1,0 +1,17 @@
+package cloudconfigv1
+
+import "github.com/giantswarm/microerror"
+
+var invalidConfigError = microerror.New("invalid config")
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var notFoundError = microerror.New("not found")
+
+// IsNotFound asserts notFoundError.
+func IsNotFound(err error) bool {
+	return microerror.Cause(err) == notFoundError
+}

--- a/service/cloudconfigv2/template.go
+++ b/service/cloudconfigv2/template.go
@@ -1,0 +1,7 @@
+package cloudconfigv1
+
+const (
+	etcd_data_dir_dropin = `[Unit]
+Before=set-ownership-etcd-data-dir.service
+`
+)

--- a/service/cloudconfigv2/v_1_0_0_master_template.go
+++ b/service/cloudconfigv2/v_1_0_0_master_template.go
@@ -1,0 +1,254 @@
+package cloudconfigv1
+
+import (
+	"github.com/giantswarm/certificatetpr"
+	clustertprspec "github.com/giantswarm/clustertpr/spec"
+	k8scloudconfig "github.com/giantswarm/k8scloudconfig/v_1_0_0"
+	"github.com/giantswarm/kvmtpr"
+	"github.com/giantswarm/microerror"
+)
+
+func v_1_0_0MasterTemplate(customObject kvmtpr.CustomObject, certs certificatetpr.AssetsBundle, node clustertprspec.Node) (string, error) {
+	var err error
+
+	var params k8scloudconfig.Params
+	{
+		params.Cluster = customObject.Spec.Cluster
+		params.Extension = &v_1_0_0MasterExtension{
+			certs: certs,
+		}
+		params.Node = node
+	}
+
+	var newCloudConfig *k8scloudconfig.CloudConfig
+	{
+		newCloudConfig, err = k8scloudconfig.NewCloudConfig(k8scloudconfig.MasterTemplate, params)
+		if err != nil {
+			return "", microerror.Mask(err)
+		}
+
+		err = newCloudConfig.ExecuteTemplate()
+		if err != nil {
+			return "", microerror.Mask(err)
+		}
+	}
+
+	return newCloudConfig.Base64(), nil
+}
+
+type v_1_0_0MasterExtension struct {
+	certs certificatetpr.AssetsBundle
+}
+
+func (e *v_1_0_0MasterExtension) Files() ([]k8scloudconfig.FileAsset, error) {
+	filesMeta := []k8scloudconfig.FileMetadata{
+		// Kubernetes API server.
+		{
+			AssetContent: string(e.certs[certificatetpr.AssetsBundleKey{certificatetpr.APIComponent, certificatetpr.CA}]),
+			Path:         "/etc/kubernetes/ssl/apiserver-ca.pem",
+			Owner:        FileOwner,
+			Permissions:  FilePermission,
+		},
+		{
+			AssetContent: string(e.certs[certificatetpr.AssetsBundleKey{certificatetpr.APIComponent, certificatetpr.Crt}]),
+			Path:         "/etc/kubernetes/ssl/apiserver-crt.pem",
+			Owner:        FileOwner,
+			Permissions:  FilePermission,
+		},
+		{
+			AssetContent: string(e.certs[certificatetpr.AssetsBundleKey{certificatetpr.APIComponent, certificatetpr.Key}]),
+			Path:         "/etc/kubernetes/ssl/apiserver-key.pem",
+			Owner:        FileOwner,
+			Permissions:  FilePermission,
+		},
+		// Calico client.
+		{
+			AssetContent: string(e.certs[certificatetpr.AssetsBundleKey{certificatetpr.CalicoComponent, certificatetpr.CA}]),
+			Path:         "/etc/kubernetes/ssl/calico/client-ca.pem",
+			Owner:        FileOwner,
+			Permissions:  FilePermission,
+		},
+		{
+			AssetContent: string(e.certs[certificatetpr.AssetsBundleKey{certificatetpr.CalicoComponent, certificatetpr.Crt}]),
+			Path:         "/etc/kubernetes/ssl/calico/client-crt.pem",
+			Owner:        FileOwner,
+			Permissions:  FilePermission,
+		},
+		{
+			AssetContent: string(e.certs[certificatetpr.AssetsBundleKey{certificatetpr.CalicoComponent, certificatetpr.Key}]),
+			Path:         "/etc/kubernetes/ssl/calico/client-key.pem",
+			Owner:        FileOwner,
+			Permissions:  FilePermission,
+		},
+		// Etcd client.
+		{
+			AssetContent: string(e.certs[certificatetpr.AssetsBundleKey{certificatetpr.EtcdComponent, certificatetpr.CA}]),
+			Path:         "/etc/kubernetes/ssl/etcd/client-ca.pem",
+			Owner:        FileOwner,
+			Permissions:  FilePermission,
+		},
+		{
+			AssetContent: string(e.certs[certificatetpr.AssetsBundleKey{certificatetpr.EtcdComponent, certificatetpr.Crt}]),
+			Path:         "/etc/kubernetes/ssl/etcd/client-crt.pem",
+			Owner:        FileOwner,
+			Permissions:  FilePermission,
+		},
+		{
+			AssetContent: string(e.certs[certificatetpr.AssetsBundleKey{certificatetpr.EtcdComponent, certificatetpr.Key}]),
+			Path:         "/etc/kubernetes/ssl/etcd/client-key.pem",
+			Owner:        FileOwner,
+			Permissions:  FilePermission,
+		},
+		// Etcd server.
+		{
+			AssetContent: string(e.certs[certificatetpr.AssetsBundleKey{certificatetpr.EtcdComponent, certificatetpr.CA}]),
+			Path:         "/etc/kubernetes/ssl/etcd/server-ca.pem",
+			Owner:        FileOwner,
+			Permissions:  FilePermission,
+		},
+		{
+			AssetContent: string(e.certs[certificatetpr.AssetsBundleKey{certificatetpr.EtcdComponent, certificatetpr.Crt}]),
+			Path:         "/etc/kubernetes/ssl/etcd/server-crt.pem",
+			Owner:        FileOwner,
+			Permissions:  FilePermission,
+		},
+		{
+			AssetContent: string(e.certs[certificatetpr.AssetsBundleKey{certificatetpr.EtcdComponent, certificatetpr.Key}]),
+			Path:         "/etc/kubernetes/ssl/etcd/server-key.pem",
+			Owner:        FileOwner,
+			Permissions:  FilePermission,
+		},
+		// Service account.
+		{
+			AssetContent: string(e.certs[certificatetpr.AssetsBundleKey{certificatetpr.ServiceAccountComponent, certificatetpr.CA}]),
+			Path:         "/etc/kubernetes/ssl/service-account-ca.pem",
+			Owner:        FileOwner,
+			Permissions:  FilePermission,
+		},
+		{
+			AssetContent: string(e.certs[certificatetpr.AssetsBundleKey{certificatetpr.ServiceAccountComponent, certificatetpr.Crt}]),
+			Path:         "/etc/kubernetes/ssl/service-account-crt.pem",
+			Owner:        FileOwner,
+			Permissions:  FilePermission,
+		},
+		{
+			AssetContent: string(e.certs[certificatetpr.AssetsBundleKey{certificatetpr.ServiceAccountComponent, certificatetpr.Key}]),
+			Path:         "/etc/kubernetes/ssl/service-account-key.pem",
+			Owner:        FileOwner,
+			Permissions:  FilePermission,
+		},
+		// etcd_data_dir drop-in
+		{
+			AssetContent: etcd_data_dir_dropin,
+			Path:         "/etc/systemd/system/etc-kubernetes-data-etcd.mount.d/00-before-set-ownership.conf",
+			Owner:        FileOwner,
+			Permissions:  FilePermission,
+		},
+	}
+
+	var newFiles []k8scloudconfig.FileAsset
+
+	for _, fm := range filesMeta {
+		c, err := k8scloudconfig.RenderAssetContent(fm.AssetContent, nil)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+
+		fileAsset := k8scloudconfig.FileAsset{
+			Metadata: fm,
+			Content:  c,
+		}
+
+		newFiles = append(newFiles, fileAsset)
+	}
+
+	return newFiles, nil
+}
+
+func (e *v_1_0_0MasterExtension) Units() ([]k8scloudconfig.UnitAsset, error) {
+	unitsMeta := []k8scloudconfig.UnitMetadata{
+		// Mount etcd volume when directory first accessed
+		// This automount is workaround for
+		// https://bugzilla.redhat.com/show_bug.cgi?id=1184122
+		{
+			AssetContent: `[Unit]
+Description=Automount for etcd volume
+[Automount]
+Where=/etc/kubernetes/data/etcd
+[Install]
+WantedBy=multi-user.target
+`,
+			Name:    "etc-kubernetes-data-etcd.automount",
+			Enable:  true,
+			Command: "start",
+		},
+		// Mount for etcd volume activated by automount
+		{
+			AssetContent: `[Unit]
+Description=Mount for etcd volume
+[Mount]
+What=etcdshare
+Where=/etc/kubernetes/data/etcd
+Options=trans=virtio,version=9p2000.L,cache=mmap
+Type=9p
+[Install]
+WantedBy=multi-user.target
+`,
+			Name:   "etc-kubernetes-data-etcd.mount",
+			Enable: false,
+		},
+		{
+			Name:    "iscsid.service",
+			Enable:  true,
+			Command: "start",
+		},
+		{
+			Name:    "multipathd.service",
+			Enable:  true,
+			Command: "start",
+		},
+		{
+			AssetContent: `[Unit]
+Description=Temporary fix for issues with calico-node and kube-proxy after master restart
+Require=k8s-kubelet.service
+After=k8s-kubelet.service
+
+[Service]
+Environment="KUBECONFIG=/etc/kubernetes/config/addons-kubeconfig.yml"
+Environment="KUBECTL=quay.io/giantswarm/docker-kubectl:1dc536ec6dc4597ba46769b3d5d6ce53a7e62038"
+ExecStart=/bin/sh -c "\
+	while [ \"$(/usr/bin/docker run -e KUBECONFIG=${KUBECONFIG} --net=host --rm -v /etc/kubernetes:/etc/kubernetes $KUBECTL get cs | grep Healthy | wc -l)\" -ne \"3\" ]; do sleep 1 && echo 'Waiting for healthy k8s'; done;sleep 30s; \
+	/usr/bin/docker run -e KUBECONFIG=${KUBECONFIG} --net=host --rm -v /etc/kubernetes:/etc/kubernetes $KUBECTL -n kube-system delete pod -l k8s-app=calico-node; \
+	sleep 1m; \
+	/usr/bin/docker run -e KUBECONFIG=${KUBECONFIG} --net=host --rm -v /etc/kubernetes:/etc/kubernetes $KUBECTL -n kube-system delete pod -l k8s-app=kube-proxy"
+
+[Install]
+WantedBy=multi-user.target`,
+			Name:    "calico-kube-kill.service",
+			Command: "start",
+			Enable:  true,
+		},
+	}
+
+	var newUnits []k8scloudconfig.UnitAsset
+
+	for _, fm := range unitsMeta {
+		c, err := k8scloudconfig.RenderAssetContent(fm.AssetContent, nil)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+
+		unitAsset := k8scloudconfig.UnitAsset{
+			Metadata: fm,
+			Content:  c,
+		}
+
+		newUnits = append(newUnits, unitAsset)
+	}
+
+	return newUnits, nil
+}
+
+func (e *v_1_0_0MasterExtension) VerbatimSections() []k8scloudconfig.VerbatimSection {
+	return nil
+}

--- a/service/cloudconfigv2/v_1_0_0_worker_template.go
+++ b/service/cloudconfigv2/v_1_0_0_worker_template.go
@@ -1,0 +1,158 @@
+package cloudconfigv1
+
+import (
+	"github.com/giantswarm/certificatetpr"
+	clustertprspec "github.com/giantswarm/clustertpr/spec"
+	k8scloudconfig "github.com/giantswarm/k8scloudconfig/v_1_0_0"
+	"github.com/giantswarm/kvmtpr"
+	"github.com/giantswarm/microerror"
+)
+
+func v_1_0_0WorkerTemplate(customObject kvmtpr.CustomObject, certs certificatetpr.AssetsBundle, node clustertprspec.Node) (string, error) {
+	var err error
+
+	var params k8scloudconfig.Params
+	{
+		params.Cluster = customObject.Spec.Cluster
+		params.Extension = &v_1_0_0WorkerExtension{
+			certs: certs,
+		}
+		params.Node = node
+	}
+
+	var newCloudConfig *k8scloudconfig.CloudConfig
+	{
+		newCloudConfig, err = k8scloudconfig.NewCloudConfig(k8scloudconfig.WorkerTemplate, params)
+		if err != nil {
+			return "", microerror.Mask(err)
+		}
+
+		err = newCloudConfig.ExecuteTemplate()
+		if err != nil {
+			return "", microerror.Mask(err)
+		}
+	}
+
+	return newCloudConfig.Base64(), nil
+}
+
+type v_1_0_0WorkerExtension struct {
+	certs certificatetpr.AssetsBundle
+}
+
+func (e *v_1_0_0WorkerExtension) Files() ([]k8scloudconfig.FileAsset, error) {
+	filesMeta := []k8scloudconfig.FileMetadata{
+		// Calico client.
+		{
+			AssetContent: string(e.certs[certificatetpr.AssetsBundleKey{certificatetpr.CalicoComponent, certificatetpr.CA}]),
+			Path:         "/etc/kubernetes/ssl/calico/client-ca.pem",
+			Owner:        FileOwner,
+			Permissions:  FilePermission,
+		},
+		{
+			AssetContent: string(e.certs[certificatetpr.AssetsBundleKey{certificatetpr.CalicoComponent, certificatetpr.Crt}]),
+			Path:         "/etc/kubernetes/ssl/calico/client-crt.pem",
+			Owner:        FileOwner,
+			Permissions:  FilePermission,
+		},
+		{
+			AssetContent: string(e.certs[certificatetpr.AssetsBundleKey{certificatetpr.CalicoComponent, certificatetpr.Key}]),
+			Path:         "/etc/kubernetes/ssl/calico/client-key.pem",
+			Owner:        FileOwner,
+			Permissions:  FilePermission,
+		},
+		// Etcd client.
+		{
+			AssetContent: string(e.certs[certificatetpr.AssetsBundleKey{certificatetpr.EtcdComponent, certificatetpr.CA}]),
+			Path:         "/etc/kubernetes/ssl/etcd/client-ca.pem",
+			Owner:        FileOwner,
+			Permissions:  FilePermission,
+		},
+		{
+			AssetContent: string(e.certs[certificatetpr.AssetsBundleKey{certificatetpr.EtcdComponent, certificatetpr.Crt}]),
+			Path:         "/etc/kubernetes/ssl/etcd/client-crt.pem",
+			Owner:        FileOwner,
+			Permissions:  FilePermission,
+		},
+		{
+			AssetContent: string(e.certs[certificatetpr.AssetsBundleKey{certificatetpr.EtcdComponent, certificatetpr.Key}]),
+			Path:         "/etc/kubernetes/ssl/etcd/client-key.pem",
+			Owner:        FileOwner,
+			Permissions:  FilePermission,
+		},
+		// Kubernetes worker.
+		{
+			AssetContent: string(e.certs[certificatetpr.AssetsBundleKey{certificatetpr.WorkerComponent, certificatetpr.CA}]),
+			Path:         "/etc/kubernetes/ssl/worker-ca.pem",
+			Owner:        FileOwner,
+			Permissions:  FilePermission,
+		},
+		{
+			AssetContent: string(e.certs[certificatetpr.AssetsBundleKey{certificatetpr.WorkerComponent, certificatetpr.Crt}]),
+			Path:         "/etc/kubernetes/ssl/worker-crt.pem",
+			Owner:        FileOwner,
+			Permissions:  FilePermission,
+		},
+		{
+			AssetContent: string(e.certs[certificatetpr.AssetsBundleKey{certificatetpr.WorkerComponent, certificatetpr.Key}]),
+			Path:         "/etc/kubernetes/ssl/worker-key.pem",
+			Owner:        FileOwner,
+			Permissions:  FilePermission,
+		},
+	}
+
+	var newFiles []k8scloudconfig.FileAsset
+
+	for _, fm := range filesMeta {
+		c, err := k8scloudconfig.RenderAssetContent(fm.AssetContent, nil)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+
+		fileAsset := k8scloudconfig.FileAsset{
+			Metadata: fm,
+			Content:  c,
+		}
+
+		newFiles = append(newFiles, fileAsset)
+	}
+
+	return newFiles, nil
+}
+
+func (e *v_1_0_0WorkerExtension) Units() ([]k8scloudconfig.UnitAsset, error) {
+	unitsMeta := []k8scloudconfig.UnitMetadata{
+		{
+			Name:    "iscsid.service",
+			Enable:  true,
+			Command: "start",
+		},
+		{
+			Name:    "multipathd.service",
+			Enable:  true,
+			Command: "start",
+		},
+	}
+
+	var newUnits []k8scloudconfig.UnitAsset
+
+	for _, fm := range unitsMeta {
+		c, err := k8scloudconfig.RenderAssetContent(fm.AssetContent, nil)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+
+		unitAsset := k8scloudconfig.UnitAsset{
+			Metadata: fm,
+			Content:  c,
+		}
+
+		newUnits = append(newUnits, unitAsset)
+	}
+
+	return newUnits, nil
+}
+
+func (e *v_1_0_0WorkerExtension) VerbatimSections() []k8scloudconfig.VerbatimSection {
+	return nil
+}


### PR DESCRIPTION
This PR is to introduce another version of the cloudconfig package where we can then use `k8scloudconfig.V_1_1_0` to have the templating for our generated client types but without the experimental encryption. 