### PR TITLE
Change wip to false. Correct kubernetes version

### DIFF
--- a/service/version_bundles.go
+++ b/service/version_bundles.go
@@ -60,7 +60,7 @@ func NewVersionBundles() []versionbundle.Bundle {
 				},
 				{
 					Name:    "kubernetes",
-					Version: "1.8.1",
+					Version: "1.8.4",
 				},
 				{
 					Name:    "nginx-ingress-controller",
@@ -72,7 +72,7 @@ func NewVersionBundles() []versionbundle.Bundle {
 			Name:         "kvm-operator",
 			Time:         time.Date(2017, time.October, 26, 16, 38, 0, 0, time.UTC),
 			Version:      "0.1.0",
-			WIP:          true,
+			WIP:          false,
 		},
 	}
 }

--- a/service/version_bundles.go
+++ b/service/version_bundles.go
@@ -77,33 +77,8 @@ func NewVersionBundles() []versionbundle.Bundle {
 		{
 			Changelogs: []versionbundle.Changelog{
 				{
-					Component:   "calico",
-					Description: "Calico version updated.",
-					Kind:        "changed",
-				},
-				{
-					Component:   "docker",
-					Description: "Docker version updated.",
-					Kind:        "changed",
-				},
-				{
-					Component:   "etcd",
-					Description: "Etcd version updated.",
-					Kind:        "changed",
-				},
-				{
-					Component:   "kubedns",
-					Description: "KubeDNS version updated.",
-					Kind:        "changed",
-				},
-				{
 					Component:   "kubernetes",
-					Description: "Kubernetes version updated.",
-					Kind:        "changed",
-				},
-				{
-					Component:   "nginx-ingress-controller",
-					Description: "Nginx-ingress-controller version updated.",
+					Description: "Kubernetes version updated. Fixes a memory leak in the Kubernetes API.",
 					Kind:        "changed",
 				},
 			},
@@ -136,8 +111,8 @@ func NewVersionBundles() []versionbundle.Bundle {
 			Dependencies: []versionbundle.Dependency{},
 			Deprecated:   false,
 			Name:         "kvm-operator",
-			Time:         time.Date(2017, time.October, 26, 16, 38, 0, 0, time.UTC),
-			Version:      "0.2.0",
+			Time:         time.Date(2017, time.December, 8, 9, 25, 0, 0, time.UTC),
+			Version:      "1.0.0",
 			WIP:          false,
 		},
 	}

--- a/service/version_bundles.go
+++ b/service/version_bundles.go
@@ -60,6 +60,72 @@ func NewVersionBundles() []versionbundle.Bundle {
 				},
 				{
 					Name:    "kubernetes",
+					Version: "1.8.1",
+				},
+				{
+					Name:    "nginx-ingress-controller",
+					Version: "0.9.0",
+				},
+			},
+			Dependencies: []versionbundle.Dependency{},
+			Deprecated:   true,
+			Name:         "kvm-operator",
+			Time:         time.Date(2017, time.October, 26, 16, 38, 0, 0, time.UTC),
+			Version:      "0.1.0",
+			WIP:          false,
+		},
+		{
+			Changelogs: []versionbundle.Changelog{
+				{
+					Component:   "calico",
+					Description: "Calico version updated.",
+					Kind:        "changed",
+				},
+				{
+					Component:   "docker",
+					Description: "Docker version updated.",
+					Kind:        "changed",
+				},
+				{
+					Component:   "etcd",
+					Description: "Etcd version updated.",
+					Kind:        "changed",
+				},
+				{
+					Component:   "kubedns",
+					Description: "KubeDNS version updated.",
+					Kind:        "changed",
+				},
+				{
+					Component:   "kubernetes",
+					Description: "Kubernetes version updated.",
+					Kind:        "changed",
+				},
+				{
+					Component:   "nginx-ingress-controller",
+					Description: "Nginx-ingress-controller version updated.",
+					Kind:        "changed",
+				},
+			},
+			Components: []versionbundle.Component{
+				{
+					Name:    "calico",
+					Version: "2.6.2",
+				},
+				{
+					Name:    "docker",
+					Version: "1.12.6",
+				},
+				{
+					Name:    "etcd",
+					Version: "3.2.7",
+				},
+				{
+					Name:    "kubedns",
+					Version: "1.14.5",
+				},
+				{
+					Name:    "kubernetes",
 					Version: "1.8.4",
 				},
 				{
@@ -71,7 +137,7 @@ func NewVersionBundles() []versionbundle.Bundle {
 			Deprecated:   false,
 			Name:         "kvm-operator",
 			Time:         time.Date(2017, time.October, 26, 16, 38, 0, 0, time.UTC),
-			Version:      "0.1.0",
+			Version:      "0.2.0",
 			WIP:          false,
 		},
 	}


### PR DESCRIPTION
So we can make an official release. AFAIK KVM installation also make 1.8.4 clusters now, so correcting that.