### PR TITLE
Create a version bundle with the latest kubernetes version (1.8.4)

### DIFF
--- a/service/version_bundles.go
+++ b/service/version_bundles.go
@@ -74,5 +74,46 @@ func NewVersionBundles() []versionbundle.Bundle {
 			Version:      "0.1.0",
 			WIP:          true,
 		},
+		{
+			Changelogs: []versionbundle.Changelog{
+				{
+					Component:   "kubernetes",
+					Description: "Updated to kubernetes 1.8.4. Fixes a goroutine leak in the k8s api.",
+					Kind:        "changed",
+				},
+			},
+			Components: []versionbundle.Component{
+				{
+					Name:    "calico",
+					Version: "2.6.2",
+				},
+				{
+					Name:    "docker",
+					Version: "1.12.6",
+				},
+				{
+					Name:    "etcd",
+					Version: "3.2.7",
+				},
+				{
+					Name:    "kubedns",
+					Version: "1.14.5",
+				},
+				{
+					Name:    "kubernetes",
+					Version: "1.8.4",
+				},
+				{
+					Name:    "nginx-ingress-controller",
+					Version: "0.9.0",
+				},
+			},
+			Dependencies: []versionbundle.Dependency{},
+			Deprecated:   false,
+			Name:         "kvm-operator",
+			Time:         time.Date(2017, time.December, 12, 10, 00, 0, 0, time.UTC),
+			Version:      "1.0.0",
+			WIP:          false,
+		},
 	}
 }


### PR DESCRIPTION
I create this pull request to discuss which steps should I follow to get the new version bundle working. Firstly, I have created the version bundle itself, but I am not sure how it is selected. In AWs operator I see how resource router gets the resources based on the version of version bundle. For KVM I don't see it clearly. Could you shed some light?