### PR TITLE
Adding configmap and cloudconfig v3

### DIFF
--- a/service/cloudconfigv3/cloud_config.go
+++ b/service/cloudconfigv3/cloud_config.go
@@ -1,0 +1,110 @@
+package cloudconfigv2
+
+import (
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/certs"
+	k8scloudconfig "github.com/giantswarm/k8scloudconfig/v_1_1_0"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+)
+
+const (
+	FileOwner      = "root:root"
+	FilePermission = 0700
+)
+
+// Config represents the configuration used to create a cloud config service.
+type Config struct {
+	// Dependencies.
+	Logger micrologger.Logger
+}
+
+// DefaultConfig provides a default configuration to create a new cloud config
+// service by best effort.
+func DefaultConfig() Config {
+	return Config{
+		// Dependencies.
+		Logger: nil,
+	}
+}
+
+// CloudConfig implements the cloud config service interface.
+type CloudConfig struct {
+	// Dependencies.
+	logger micrologger.Logger
+}
+
+// New creates a new configured cloud config service.
+func New(config Config) (*CloudConfig, error) {
+	// Dependencies.
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "logger must not be empty")
+	}
+
+	newCloudConfig := &CloudConfig{
+		// Dependencies.
+		logger: config.Logger,
+	}
+
+	return newCloudConfig, nil
+}
+
+// NewMasterTemplate generates a new worker cloud config template and returns it
+// as a base64 encoded string.
+func (c *CloudConfig) NewMasterTemplate(customObject v1alpha1.KVMConfig, certs certs.Cluster, node v1alpha1.ClusterNode) (string, error) {
+	var err error
+
+	var params k8scloudconfig.Params
+	{
+		params.Cluster = customObject.Spec.Cluster
+		params.Extension = &masterExtension{
+			certs: certs,
+		}
+		params.Node = node
+	}
+
+	var newCloudConfig *k8scloudconfig.CloudConfig
+	{
+		newCloudConfig, err = k8scloudconfig.NewCloudConfig(k8scloudconfig.MasterTemplate, params)
+		if err != nil {
+			return "", microerror.Mask(err)
+		}
+
+		err = newCloudConfig.ExecuteTemplate()
+		if err != nil {
+			return "", microerror.Mask(err)
+		}
+	}
+
+	return newCloudConfig.Base64(), nil
+}
+
+// NewWorkerTemplate generates a new worker cloud config template and returns it
+// as a base64 encoded string.
+func (c *CloudConfig) NewWorkerTemplate(customObject v1alpha1.KVMConfig, certs certs.Cluster, node v1alpha1.ClusterNode) (string, error) {
+	var err error
+
+	var params k8scloudconfig.Params
+	{
+		params.Cluster = customObject.Spec.Cluster
+		params.Extension = &workerExtension{
+			certs: certs,
+		}
+		params.Node = node
+	}
+
+	var newCloudConfig *k8scloudconfig.CloudConfig
+	{
+		newCloudConfig, err = k8scloudconfig.NewCloudConfig(k8scloudconfig.WorkerTemplate, params)
+		if err != nil {
+			return "", microerror.Mask(err)
+		}
+
+		err = newCloudConfig.ExecuteTemplate()
+		if err != nil {
+			return "", microerror.Mask(err)
+		}
+	}
+
+	return newCloudConfig.Base64(), nil
+}

--- a/service/cloudconfigv3/cloudconfigtest/cloudconfigtest.go
+++ b/service/cloudconfigv3/cloudconfigtest/cloudconfigtest.go
@@ -1,0 +1,20 @@
+package cloudconfigtest
+
+import (
+	"github.com/giantswarm/micrologger/microloggertest"
+
+	"github.com/giantswarm/kvm-operator/service/cloudconfigv2"
+)
+
+func New() *cloudconfigv2.CloudConfig {
+	c := cloudconfigv2.DefaultConfig()
+
+	c.Logger = microloggertest.New()
+
+	newCloudConfig, err := cloudconfigv2.New(c)
+	if err != nil {
+		panic(err)
+	}
+
+	return newCloudConfig
+}

--- a/service/cloudconfigv3/error.go
+++ b/service/cloudconfigv3/error.go
@@ -1,0 +1,17 @@
+package cloudconfigv2
+
+import "github.com/giantswarm/microerror"
+
+var invalidConfigError = microerror.New("invalid config")
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var notFoundError = microerror.New("not found")
+
+// IsNotFound asserts notFoundError.
+func IsNotFound(err error) bool {
+	return microerror.Cause(err) == notFoundError
+}

--- a/service/cloudconfigv3/master_template.go
+++ b/service/cloudconfigv3/master_template.go
@@ -1,0 +1,227 @@
+package cloudconfigv2
+
+import (
+	"github.com/giantswarm/certs"
+	k8scloudconfig "github.com/giantswarm/k8scloudconfig/v_1_1_0"
+	"github.com/giantswarm/microerror"
+)
+
+type masterExtension struct {
+	certs certs.Cluster
+}
+
+func (e *masterExtension) Files() ([]k8scloudconfig.FileAsset, error) {
+	filesMeta := []k8scloudconfig.FileMetadata{
+		// Kubernetes API server.
+		{
+			AssetContent: string(e.certs.APIServer.CA),
+			Path:         "/etc/kubernetes/ssl/apiserver-ca.pem",
+			Owner:        FileOwner,
+			Permissions:  FilePermission,
+		},
+		{
+			AssetContent: string(e.certs.APIServer.Crt),
+			Path:         "/etc/kubernetes/ssl/apiserver-crt.pem",
+			Owner:        FileOwner,
+			Permissions:  FilePermission,
+		},
+		{
+			AssetContent: string(e.certs.APIServer.Key),
+			Path:         "/etc/kubernetes/ssl/apiserver-key.pem",
+			Owner:        FileOwner,
+			Permissions:  FilePermission,
+		},
+		// Calico client.
+		{
+			AssetContent: string(e.certs.CalicoClient.CA),
+			Path:         "/etc/kubernetes/ssl/calico/client-ca.pem",
+			Owner:        FileOwner,
+			Permissions:  FilePermission,
+		},
+		{
+			AssetContent: string(e.certs.CalicoClient.Crt),
+			Path:         "/etc/kubernetes/ssl/calico/client-crt.pem",
+			Owner:        FileOwner,
+			Permissions:  FilePermission,
+		},
+		{
+			AssetContent: string(e.certs.CalicoClient.Key),
+			Path:         "/etc/kubernetes/ssl/calico/client-key.pem",
+			Owner:        FileOwner,
+			Permissions:  FilePermission,
+		},
+		// Etcd client.
+		{
+			AssetContent: string(e.certs.EtcdServer.CA),
+			Path:         "/etc/kubernetes/ssl/etcd/client-ca.pem",
+			Owner:        FileOwner,
+			Permissions:  FilePermission,
+		},
+		{
+			AssetContent: string(e.certs.EtcdServer.Crt),
+			Path:         "/etc/kubernetes/ssl/etcd/client-crt.pem",
+			Owner:        FileOwner,
+			Permissions:  FilePermission,
+		},
+		{
+			AssetContent: string(e.certs.EtcdServer.Key),
+			Path:         "/etc/kubernetes/ssl/etcd/client-key.pem",
+			Owner:        FileOwner,
+			Permissions:  FilePermission,
+		},
+		// Etcd server.
+		{
+			AssetContent: string(e.certs.EtcdServer.CA),
+			Path:         "/etc/kubernetes/ssl/etcd/server-ca.pem",
+			Owner:        FileOwner,
+			Permissions:  FilePermission,
+		},
+		{
+			AssetContent: string(e.certs.EtcdServer.Crt),
+			Path:         "/etc/kubernetes/ssl/etcd/server-crt.pem",
+			Owner:        FileOwner,
+			Permissions:  FilePermission,
+		},
+		{
+			AssetContent: string(e.certs.EtcdServer.Key),
+			Path:         "/etc/kubernetes/ssl/etcd/server-key.pem",
+			Owner:        FileOwner,
+			Permissions:  FilePermission,
+		},
+		// Service account.
+		{
+			AssetContent: string(e.certs.ServiceAccount.CA),
+			Path:         "/etc/kubernetes/ssl/service-account-ca.pem",
+			Owner:        FileOwner,
+			Permissions:  FilePermission,
+		},
+		{
+			AssetContent: string(e.certs.ServiceAccount.Crt),
+			Path:         "/etc/kubernetes/ssl/service-account-crt.pem",
+			Owner:        FileOwner,
+			Permissions:  FilePermission,
+		},
+		{
+			AssetContent: string(e.certs.ServiceAccount.Key),
+			Path:         "/etc/kubernetes/ssl/service-account-key.pem",
+			Owner:        FileOwner,
+			Permissions:  FilePermission,
+		},
+		// set_ownership_etcd_data_dir drop-in
+		{
+			AssetContent: set_ownership_etcd_data_dir_dropin,
+			Path:         "/etc/systemd/system/set-ownership-etcd-data-dir.service.d/00-after-mount.conf",
+			Owner:        FileOwner,
+			Permissions:  FilePermission,
+		},
+	}
+
+	var newFiles []k8scloudconfig.FileAsset
+
+	for _, fm := range filesMeta {
+		c, err := k8scloudconfig.RenderAssetContent(fm.AssetContent, nil)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+
+		fileAsset := k8scloudconfig.FileAsset{
+			Metadata: fm,
+			Content:  c,
+		}
+
+		newFiles = append(newFiles, fileAsset)
+	}
+
+	return newFiles, nil
+}
+
+func (e *masterExtension) Units() ([]k8scloudconfig.UnitAsset, error) {
+	unitsMeta := []k8scloudconfig.UnitMetadata{
+		// Mount etcd volume when directory first accessed
+		// This automount is workaround for
+		// https://bugzilla.redhat.com/show_bug.cgi?id=1184122
+		{
+			AssetContent: `[Unit]
+Description=Automount for etcd volume
+[Automount]
+Where=/etc/kubernetes/data/etcd
+[Install]
+WantedBy=multi-user.target
+`,
+			Name:    "etc-kubernetes-data-etcd.automount",
+			Enable:  true,
+			Command: "start",
+		},
+		// Mount for etcd volume activated by automount
+		{
+			AssetContent: `[Unit]
+Description=Mount for etcd volume
+[Mount]
+What=etcdshare
+Where=/etc/kubernetes/data/etcd
+Options=trans=virtio,version=9p2000.L,cache=mmap
+Type=9p
+[Install]
+WantedBy=multi-user.target
+`,
+			Name:   "etc-kubernetes-data-etcd.mount",
+			Enable: false,
+		},
+		{
+			Name:    "iscsid.service",
+			Enable:  true,
+			Command: "start",
+		},
+		{
+			Name:    "multipathd.service",
+			Enable:  true,
+			Command: "start",
+		},
+		{
+			AssetContent: `[Unit]
+Description=Temporary fix for issues with calico-node and kube-proxy after master restart
+Require=k8s-kubelet.service
+After=k8s-kubelet.service
+
+[Service]
+Environment="KUBECONFIG=/etc/kubernetes/config/addons-kubeconfig.yml"
+Environment="KUBECTL=quay.io/giantswarm/docker-kubectl:1dc536ec6dc4597ba46769b3d5d6ce53a7e62038"
+ExecStart=/bin/sh -c "\
+	while [ \"$(/usr/bin/docker run -e KUBECONFIG=${KUBECONFIG} --net=host --rm -v /etc/kubernetes:/etc/kubernetes $KUBECTL get cs | grep Healthy | wc -l)\" -ne \"3\" ]; do sleep 1 && echo 'Waiting for healthy k8s'; done;sleep 30s; \
+	/usr/bin/docker run -e KUBECONFIG=${KUBECONFIG} --net=host --rm -v /etc/kubernetes:/etc/kubernetes $KUBECTL -n kube-system delete pod -l k8s-app=calico-node; \
+	sleep 1m; \
+	/usr/bin/docker run -e KUBECONFIG=${KUBECONFIG} --net=host --rm -v /etc/kubernetes:/etc/kubernetes $KUBECTL -n kube-system delete pod -l k8s-app=kube-proxy; \
+	sleep 1m; \
+	/usr/bin/docker run -e KUBECONFIG=${KUBECONFIG} --net=host --rm -v /etc/kubernetes:/etc/kubernetes $KUBECTL -n kube-system delete pod -l k8s-app=calico-kube-controllers; \
+	/usr/bin/docker run -e KUBECONFIG=${KUBECONFIG} --net=host --rm -v /etc/kubernetes:/etc/kubernetes $KUBECTL -n kube-system delete pod -l k8s-app=kube-dns"
+
+[Install]
+WantedBy=multi-user.target`,
+			Name:    "calico-kube-kill.service",
+			Command: "start",
+			Enable:  true,
+		},
+	}
+
+	var newUnits []k8scloudconfig.UnitAsset
+
+	for _, fm := range unitsMeta {
+		c, err := k8scloudconfig.RenderAssetContent(fm.AssetContent, nil)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+
+		unitAsset := k8scloudconfig.UnitAsset{
+			Metadata: fm,
+			Content:  c,
+		}
+
+		newUnits = append(newUnits, unitAsset)
+	}
+
+	return newUnits, nil
+}
+
+func (e *masterExtension) VerbatimSections() []k8scloudconfig.VerbatimSection {
+	return nil
+}

--- a/service/cloudconfigv3/template.go
+++ b/service/cloudconfigv3/template.go
@@ -1,0 +1,8 @@
+package cloudconfigv2
+
+const (
+	set_ownership_etcd_data_dir_dropin = `[Unit]
+Requires=etc-kubernetes-data-etcd.mount
+After=etc-kubernetes-data-etcd.mount
+`
+)

--- a/service/cloudconfigv3/worker_template.go
+++ b/service/cloudconfigv3/worker_template.go
@@ -1,0 +1,128 @@
+package cloudconfigv2
+
+import (
+	"github.com/giantswarm/certs"
+	k8scloudconfig "github.com/giantswarm/k8scloudconfig/v_1_1_0"
+	"github.com/giantswarm/microerror"
+)
+
+type workerExtension struct {
+	certs certs.Cluster
+}
+
+func (e *workerExtension) Files() ([]k8scloudconfig.FileAsset, error) {
+	filesMeta := []k8scloudconfig.FileMetadata{
+		// Calico client.
+		{
+			AssetContent: string(e.certs.CalicoClient.CA),
+			Path:         "/etc/kubernetes/ssl/calico/client-ca.pem",
+			Owner:        FileOwner,
+			Permissions:  FilePermission,
+		},
+		{
+			AssetContent: string(e.certs.CalicoClient.Crt),
+			Path:         "/etc/kubernetes/ssl/calico/client-crt.pem",
+			Owner:        FileOwner,
+			Permissions:  FilePermission,
+		},
+		{
+			AssetContent: string(e.certs.CalicoClient.Key),
+			Path:         "/etc/kubernetes/ssl/calico/client-key.pem",
+			Owner:        FileOwner,
+			Permissions:  FilePermission,
+		},
+		// Etcd client.
+		{
+			AssetContent: string(e.certs.EtcdServer.CA),
+			Path:         "/etc/kubernetes/ssl/etcd/client-ca.pem",
+			Owner:        FileOwner,
+			Permissions:  FilePermission,
+		},
+		{
+			AssetContent: string(e.certs.EtcdServer.Crt),
+			Path:         "/etc/kubernetes/ssl/etcd/client-crt.pem",
+			Owner:        FileOwner,
+			Permissions:  FilePermission,
+		},
+		{
+			AssetContent: string(e.certs.EtcdServer.Key),
+			Path:         "/etc/kubernetes/ssl/etcd/client-key.pem",
+			Owner:        FileOwner,
+			Permissions:  FilePermission,
+		},
+		// Kubernetes worker.
+		{
+			AssetContent: string(e.certs.Worker.CA),
+			Path:         "/etc/kubernetes/ssl/worker-ca.pem",
+			Owner:        FileOwner,
+			Permissions:  FilePermission,
+		},
+		{
+			AssetContent: string(e.certs.Worker.Crt),
+			Path:         "/etc/kubernetes/ssl/worker-crt.pem",
+			Owner:        FileOwner,
+			Permissions:  FilePermission,
+		},
+		{
+			AssetContent: string(e.certs.Worker.Key),
+			Path:         "/etc/kubernetes/ssl/worker-key.pem",
+			Owner:        FileOwner,
+			Permissions:  FilePermission,
+		},
+	}
+
+	var newFiles []k8scloudconfig.FileAsset
+
+	for _, fm := range filesMeta {
+		c, err := k8scloudconfig.RenderAssetContent(fm.AssetContent, nil)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+
+		fileAsset := k8scloudconfig.FileAsset{
+			Metadata: fm,
+			Content:  c,
+		}
+
+		newFiles = append(newFiles, fileAsset)
+	}
+
+	return newFiles, nil
+}
+
+func (e *workerExtension) Units() ([]k8scloudconfig.UnitAsset, error) {
+	unitsMeta := []k8scloudconfig.UnitMetadata{
+		{
+			Name:    "iscsid.service",
+			Enable:  true,
+			Command: "start",
+		},
+		{
+			Name:    "multipathd.service",
+			Enable:  true,
+			Command: "start",
+		},
+	}
+
+	var newUnits []k8scloudconfig.UnitAsset
+
+	for _, fm := range unitsMeta {
+		c, err := k8scloudconfig.RenderAssetContent(fm.AssetContent, nil)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+
+		unitAsset := k8scloudconfig.UnitAsset{
+			Metadata: fm,
+			Content:  c,
+		}
+
+		newUnits = append(newUnits, unitAsset)
+	}
+
+	return newUnits, nil
+}
+
+func (e *workerExtension) VerbatimSections() []k8scloudconfig.VerbatimSection {
+	return nil
+}

--- a/service/resource/configmapv3/create.go
+++ b/service/resource/configmapv3/create.go
@@ -1,0 +1,69 @@
+package configmapv2
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/giantswarm/microerror"
+	apiv1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+
+	"github.com/giantswarm/kvm-operator/service/keyv2"
+)
+
+func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange interface{}) error {
+	customObject, err := keyv2.ToCustomObject(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	configMapsToCreate, err := toConfigMaps(createChange)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	// Create the config maps in the Kubernetes API.
+	if len(configMapsToCreate) != 0 {
+		r.logger.LogCtx(ctx, "debug", "creating the config maps in the Kubernetes API")
+
+		namespace := keyv2.ClusterNamespace(customObject)
+		for _, configMap := range configMapsToCreate {
+			_, err := r.k8sClient.CoreV1().ConfigMaps(namespace).Create(configMap)
+			if apierrors.IsAlreadyExists(err) {
+				// fall through
+			} else if err != nil {
+				return microerror.Mask(err)
+			}
+		}
+
+		r.logger.LogCtx(ctx, "debug", "created the config maps in the Kubernetes API")
+	} else {
+		r.logger.LogCtx(ctx, "debug", "the config maps do not need to be created in the Kubernetes API")
+	}
+
+	return nil
+}
+
+func (r *Resource) newCreateChange(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, error) {
+	currentConfigMaps, err := toConfigMaps(currentState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+	desiredConfigMaps, err := toConfigMaps(desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	r.logger.LogCtx(ctx, "debug", "finding out which config maps have to be created")
+
+	var configMapsToCreate []*apiv1.ConfigMap
+
+	for _, desiredConfigMap := range desiredConfigMaps {
+		if !containsConfigMap(currentConfigMaps, desiredConfigMap) {
+			configMapsToCreate = append(configMapsToCreate, desiredConfigMap)
+		}
+	}
+
+	r.logger.LogCtx(ctx, "debug", fmt.Sprintf("found %d config maps that have to be created", len(configMapsToCreate)))
+
+	return configMapsToCreate, nil
+}

--- a/service/resource/configmapv3/create_test.go
+++ b/service/resource/configmapv3/create_test.go
@@ -1,0 +1,248 @@
+package configmapv2
+
+import (
+	"context"
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/certs/certstest"
+	"github.com/giantswarm/micrologger/microloggertest"
+	apiv1 "k8s.io/api/core/v1"
+	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/giantswarm/kvm-operator/service/cloudconfigv2/cloudconfigtest"
+)
+
+func Test_Resource_CloudConfig_newCreateChange(t *testing.T) {
+	testCases := []struct {
+		Obj                    interface{}
+		CurrentState           interface{}
+		DesiredState           interface{}
+		ExpectedConfigMapNames []string
+	}{
+		// Test 1, in case current state and desired state are empty the create
+		// state should be empty.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState:           []*apiv1.ConfigMap{},
+			DesiredState:           []*apiv1.ConfigMap{},
+			ExpectedConfigMapNames: []string{},
+		},
+
+		// Test 2, in case current state equals desired state the create state
+		// should be empty.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState: []*apiv1.ConfigMap{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "config-map-1",
+					},
+				},
+			},
+			DesiredState: []*apiv1.ConfigMap{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "config-map-1",
+					},
+				},
+			},
+			ExpectedConfigMapNames: []string{},
+		},
+
+		// Test 3, in case current state misses one item of desired state the create
+		// state should contain the missing item of the desired state.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState: []*apiv1.ConfigMap{},
+			DesiredState: []*apiv1.ConfigMap{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "config-map-1",
+					},
+				},
+			},
+			ExpectedConfigMapNames: []string{
+				"config-map-1",
+			},
+		},
+
+		// Test 4, in case current state misses items of desired state the create
+		// state should contain the missing items of the desired state.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState: []*apiv1.ConfigMap{},
+			DesiredState: []*apiv1.ConfigMap{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "config-map-1",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "config-map-2",
+					},
+				},
+			},
+			ExpectedConfigMapNames: []string{
+				"config-map-1",
+				"config-map-2",
+			},
+		},
+
+		// Test 5, in case current state contains one item not being in desired
+		// state the create state should not contain the missing item of the desired
+		// state.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState: []*apiv1.ConfigMap{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "config-map-1",
+					},
+				},
+			},
+			DesiredState:           []*apiv1.ConfigMap{},
+			ExpectedConfigMapNames: []string{},
+		},
+
+		// Test 6, in case current state contains items not being in desired state
+		// the create state should not contain the missing items of the desired
+		// state.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState: []*apiv1.ConfigMap{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "config-map-1",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "config-map-2",
+					},
+				},
+			},
+			DesiredState:           []*apiv1.ConfigMap{},
+			ExpectedConfigMapNames: []string{},
+		},
+
+		// Test 7, in case current state contains some items of desired state the
+		// create state should contain the items being in desired state which are
+		// not in create state.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState: []*apiv1.ConfigMap{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "config-map-1",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "config-map-2",
+					},
+				},
+			},
+			DesiredState: []*apiv1.ConfigMap{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "config-map-1",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "config-map-2",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "config-map-3",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "config-map-4",
+					},
+				},
+			},
+			ExpectedConfigMapNames: []string{
+				"config-map-3",
+				"config-map-4",
+			},
+		},
+	}
+
+	var err error
+	var newResource *Resource
+	{
+		resourceConfig := DefaultConfig()
+		resourceConfig.CertSearcher = certstest.NewSearcher()
+		resourceConfig.CloudConfig = cloudconfigtest.New()
+		resourceConfig.K8sClient = fake.NewSimpleClientset()
+		resourceConfig.Logger = microloggertest.New()
+		newResource, err = New(resourceConfig)
+		if err != nil {
+			t.Fatal("expected", nil, "got", err)
+		}
+	}
+
+	for i, tc := range testCases {
+		result, err := newResource.newCreateChange(context.TODO(), tc.Obj, tc.CurrentState, tc.DesiredState)
+		if err != nil {
+			t.Fatalf("case %d expected %#v got %#v", i+1, nil, err)
+		}
+
+		configMaps, ok := result.([]*apiv1.ConfigMap)
+		if !ok {
+			t.Fatalf("case %d expected %T got %T", i+1, []*apiv1.ConfigMap{}, result)
+		}
+
+		if len(configMaps) != len(tc.ExpectedConfigMapNames) {
+			t.Fatalf("case %d expected %d config maps got %d", i+1, len(tc.ExpectedConfigMapNames), len(configMaps))
+		}
+	}
+}

--- a/service/resource/configmapv3/current.go
+++ b/service/resource/configmapv3/current.go
@@ -1,0 +1,41 @@
+package configmapv2
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/giantswarm/microerror"
+	apiv1 "k8s.io/api/core/v1"
+	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/giantswarm/kvm-operator/service/keyv2"
+)
+
+func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interface{}, error) {
+	customObject, err := keyv2.ToCustomObject(obj)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	r.logger.LogCtx(ctx, "debug", "looking for a list of config maps in the Kubernetes API")
+
+	var currentConfigMaps []*apiv1.ConfigMap
+	{
+		namespace := keyv2.ClusterNamespace(customObject)
+		configMapList, err := r.k8sClient.CoreV1().ConfigMaps(namespace).List(apismetav1.ListOptions{})
+		if err != nil {
+			return nil, microerror.Mask(err)
+		} else {
+			r.logger.LogCtx(ctx, "debug", "found a list of config maps in the Kubernetes API")
+
+			for _, item := range configMapList.Items {
+				c := item
+				currentConfigMaps = append(currentConfigMaps, &c)
+			}
+		}
+	}
+
+	r.logger.LogCtx(ctx, "debug", fmt.Sprintf("found a list of %d config maps in the Kubernetes API", len(currentConfigMaps)))
+
+	return currentConfigMaps, nil
+}

--- a/service/resource/configmapv3/delete.go
+++ b/service/resource/configmapv3/delete.go
@@ -1,0 +1,108 @@
+package configmapv2
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/operatorkit/framework"
+	apiv1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/giantswarm/kvm-operator/service/keyv2"
+)
+
+func (r *Resource) ApplyDeleteChange(ctx context.Context, obj, deleteChange interface{}) error {
+	customObject, err := keyv2.ToCustomObject(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	configMapsToDelete, err := toConfigMaps(deleteChange)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	if len(configMapsToDelete) != 0 {
+		r.logger.LogCtx(ctx, "debug", "deleting the config maps in the Kubernetes API")
+
+		// Create the config maps in the Kubernetes API.
+		namespace := keyv2.ClusterNamespace(customObject)
+		for _, configMap := range configMapsToDelete {
+			err := r.k8sClient.CoreV1().ConfigMaps(namespace).Delete(configMap.Name, &apismetav1.DeleteOptions{})
+			if apierrors.IsNotFound(err) {
+				// fall through
+			} else if err != nil {
+				return microerror.Mask(err)
+			}
+		}
+
+		r.logger.LogCtx(ctx, "debug", "deleted the config maps in the Kubernetes API")
+	} else {
+		r.logger.LogCtx(ctx, "debug", "the config maps do not need to be deleted from the Kubernetes API")
+	}
+
+	return nil
+}
+
+func (r *Resource) NewDeletePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*framework.Patch, error) {
+	delete, err := r.newDeleteChangeForDeletePatch(ctx, obj, currentState, desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	patch := framework.NewPatch()
+	patch.SetDeleteChange(delete)
+
+	return patch, nil
+}
+
+func (r *Resource) newDeleteChangeForDeletePatch(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, error) {
+	currentConfigMaps, err := toConfigMaps(currentState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+	desiredConfigMaps, err := toConfigMaps(desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	r.logger.LogCtx(ctx, "debug", "finding out which config maps have to be deleted")
+
+	var configMapsToDelete []*apiv1.ConfigMap
+
+	for _, currentConfigMap := range currentConfigMaps {
+		if containsConfigMap(desiredConfigMaps, currentConfigMap) {
+			configMapsToDelete = append(configMapsToDelete, currentConfigMap)
+		}
+	}
+
+	r.logger.LogCtx(ctx, "debug", fmt.Sprintf("found %d config maps that have to be deleted", len(configMapsToDelete)))
+
+	return configMapsToDelete, nil
+}
+
+func (r *Resource) newDeleteChangeForUpdatePatch(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, error) {
+	currentConfigMaps, err := toConfigMaps(currentState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+	desiredConfigMaps, err := toConfigMaps(desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	r.logger.LogCtx(ctx, "debug", "finding out which config maps have to be deleted")
+
+	var configMapsToDelete []*apiv1.ConfigMap
+
+	for _, currentConfigMap := range currentConfigMaps {
+		if !containsConfigMap(desiredConfigMaps, currentConfigMap) {
+			configMapsToDelete = append(configMapsToDelete, currentConfigMap)
+		}
+	}
+
+	r.logger.LogCtx(ctx, "debug", fmt.Sprintf("found %d config maps that have to be deleted", len(configMapsToDelete)))
+
+	return configMapsToDelete, nil
+}

--- a/service/resource/configmapv3/delete_test.go
+++ b/service/resource/configmapv3/delete_test.go
@@ -1,0 +1,294 @@
+package configmapv2
+
+import (
+	"context"
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/certs/certstest"
+	"github.com/giantswarm/micrologger/microloggertest"
+	apiv1 "k8s.io/api/core/v1"
+	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/giantswarm/kvm-operator/service/cloudconfigv2/cloudconfigtest"
+)
+
+func Test_Resource_CloudConfig_newDeleteChange(t *testing.T) {
+	testCases := []struct {
+		Obj                    interface{}
+		CurrentState           interface{}
+		DesiredState           interface{}
+		ExpectedConfigMapNames []string
+	}{
+		// Test 1, in case current state and desired state are empty the delete
+		// state should be empty.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState:           []*apiv1.ConfigMap{},
+			DesiredState:           []*apiv1.ConfigMap{},
+			ExpectedConfigMapNames: []string{},
+		},
+
+		// Test 2, in case current state has one item and equals desired state the
+		// delete state should equal the current state.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState: []*apiv1.ConfigMap{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "config-map-1",
+					},
+				},
+			},
+			DesiredState: []*apiv1.ConfigMap{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "config-map-1",
+					},
+				},
+			},
+			ExpectedConfigMapNames: []string{
+				"config-map-1",
+			},
+		},
+
+		// Test 3, in case current state misses one item of desired state the delete
+		// state should not contain the missing item of the desired state.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState: []*apiv1.ConfigMap{},
+			DesiredState: []*apiv1.ConfigMap{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "config-map-1",
+					},
+				},
+			},
+			ExpectedConfigMapNames: []string{},
+		},
+
+		// Test 4, in case current state misses items of desired state the delete
+		// state should not contain the missing items of the desired state.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState: []*apiv1.ConfigMap{},
+			DesiredState: []*apiv1.ConfigMap{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "config-map-1",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "config-map-2",
+					},
+				},
+			},
+			ExpectedConfigMapNames: []string{},
+		},
+
+		// Test 5, in case current state contains one item and desired state is
+		// empty the delete state should be empty.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState: []*apiv1.ConfigMap{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "config-map-1",
+					},
+				},
+			},
+			DesiredState:           []*apiv1.ConfigMap{},
+			ExpectedConfigMapNames: []string{},
+		},
+
+		// Test 6, in case current state contains items and desired state is empty
+		// the delete state should be empty.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState: []*apiv1.ConfigMap{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "config-map-1",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "config-map-2",
+					},
+				},
+			},
+			DesiredState:           []*apiv1.ConfigMap{},
+			ExpectedConfigMapNames: []string{},
+		},
+
+		// Test 7, in case all items of current state are in desired state and
+		// desired state contains more items not being in current state the create
+		// state should contain all items being in current state.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState: []*apiv1.ConfigMap{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "config-map-1",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "config-map-2",
+					},
+				},
+			},
+			DesiredState: []*apiv1.ConfigMap{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "config-map-1",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "config-map-2",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "config-map-3",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "config-map-4",
+					},
+				},
+			},
+			ExpectedConfigMapNames: []string{
+				"config-map-1",
+				"config-map-2",
+			},
+		},
+
+		// Test 8, in case all items of desired state are in current state and
+		// current state contains more items not being in desired state the create
+		// state should contain all items being in desired state.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState: []*apiv1.ConfigMap{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "config-map-1",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "config-map-2",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "config-map-3",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "config-map-4",
+					},
+				},
+			},
+			DesiredState: []*apiv1.ConfigMap{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "config-map-1",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "config-map-2",
+					},
+				},
+			},
+			ExpectedConfigMapNames: []string{
+				"config-map-1",
+				"config-map-2",
+			},
+		},
+	}
+
+	var err error
+	var newResource *Resource
+	{
+		resourceConfig := DefaultConfig()
+		resourceConfig.CertSearcher = certstest.NewSearcher()
+		resourceConfig.CloudConfig = cloudconfigtest.New()
+		resourceConfig.K8sClient = fake.NewSimpleClientset()
+		resourceConfig.Logger = microloggertest.New()
+		newResource, err = New(resourceConfig)
+		if err != nil {
+			t.Fatal("expected", nil, "got", err)
+		}
+	}
+
+	for i, tc := range testCases {
+		result, err := newResource.newDeleteChangeForDeletePatch(context.TODO(), tc.Obj, tc.CurrentState, tc.DesiredState)
+		if err != nil {
+			t.Fatalf("case %d expected %#v got %#v", i+1, nil, err)
+		}
+
+		configMaps, ok := result.([]*apiv1.ConfigMap)
+		if !ok {
+			t.Fatalf("case %d expected %T got %T", i+1, []*apiv1.ConfigMap{}, result)
+		}
+
+		if len(configMaps) != len(tc.ExpectedConfigMapNames) {
+			t.Fatalf("case %d expected %d config maps got %d", i+1, len(tc.ExpectedConfigMapNames), len(configMaps))
+		}
+	}
+}

--- a/service/resource/configmapv3/desired.go
+++ b/service/resource/configmapv3/desired.go
@@ -1,0 +1,95 @@
+package configmapv2
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/microerror"
+	apiv1 "k8s.io/api/core/v1"
+	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/giantswarm/kvm-operator/service/keyv2"
+)
+
+func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interface{}, error) {
+	customObject, err := keyv2.ToCustomObject(obj)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	r.logger.LogCtx(ctx, "debug", "computing the new config maps")
+
+	configMaps, err := r.newConfigMaps(customObject)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	r.logger.LogCtx(ctx, "debug", fmt.Sprintf("computed the %d new config maps", len(configMaps)))
+
+	return configMaps, nil
+}
+
+func (r *Resource) newConfigMaps(customObject v1alpha1.KVMConfig) ([]*apiv1.ConfigMap, error) {
+	var configMaps []*apiv1.ConfigMap
+
+	certs, err := r.certSearcher.SearchCluster(keyv2.ClusterID(customObject))
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	for _, node := range customObject.Spec.Cluster.Masters {
+		template, err := r.cloudConfig.NewMasterTemplate(customObject, certs, node)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+
+		configMap, err := r.newConfigMap(customObject, template, node, keyv2.MasterID)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+
+		configMaps = append(configMaps, configMap)
+	}
+
+	for _, node := range customObject.Spec.Cluster.Workers {
+		template, err := r.cloudConfig.NewWorkerTemplate(customObject, certs, node)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+
+		configMap, err := r.newConfigMap(customObject, template, node, keyv2.WorkerID)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+
+		configMaps = append(configMaps, configMap)
+	}
+
+	return configMaps, nil
+}
+
+// newConfigMap creates a new Kubernetes configmap using the provided
+// information. customObject is used for name and label creation. params serves
+// as structure being injected into the template execution to interpolate
+// variables. prefix can be either "master" or "worker" and is used to prefix
+// the configmap name.
+func (r *Resource) newConfigMap(customObject v1alpha1.KVMConfig, template string, node v1alpha1.ClusterNode, prefix string) (*apiv1.ConfigMap, error) {
+	var newConfigMap *apiv1.ConfigMap
+	{
+		newConfigMap = &apiv1.ConfigMap{
+			ObjectMeta: apismetav1.ObjectMeta{
+				Name: keyv2.ConfigMapName(customObject, node, prefix),
+				Labels: map[string]string{
+					"cluster":  keyv2.ClusterID(customObject),
+					"customer": keyv2.ClusterCustomer(customObject),
+				},
+			},
+			Data: map[string]string{
+				KeyUserData: template,
+			},
+		}
+	}
+
+	return newConfigMap, nil
+}

--- a/service/resource/configmapv3/desired_test.go
+++ b/service/resource/configmapv3/desired_test.go
@@ -1,0 +1,143 @@
+package configmapv2
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/certs/certstest"
+	"github.com/giantswarm/micrologger/microloggertest"
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/giantswarm/kvm-operator/service/cloudconfigv2/cloudconfigtest"
+)
+
+func Test_Resource_CloudConfig_GetDesiredState(t *testing.T) {
+	testCases := []struct {
+		Obj                 interface{}
+		ExpectedMasterCount int
+		ExpectedWorkerCount int
+	}{
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+						Masters: []v1alpha1.ClusterNode{
+							{},
+						},
+						Workers: []v1alpha1.ClusterNode{
+							{},
+						},
+					},
+				},
+			},
+			ExpectedMasterCount: 1,
+			ExpectedWorkerCount: 1,
+		},
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+						Masters: []v1alpha1.ClusterNode{
+							{},
+						},
+						Workers: []v1alpha1.ClusterNode{
+							{},
+							{},
+							{},
+						},
+					},
+				},
+			},
+			ExpectedMasterCount: 1,
+			ExpectedWorkerCount: 3,
+		},
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+						Masters: []v1alpha1.ClusterNode{
+							{},
+							{},
+							{},
+						},
+						Workers: []v1alpha1.ClusterNode{
+							{},
+							{},
+							{},
+						},
+					},
+				},
+			},
+			ExpectedMasterCount: 3,
+			ExpectedWorkerCount: 3,
+		},
+	}
+
+	var err error
+	var newResource *Resource
+	{
+		resourceConfig := DefaultConfig()
+		resourceConfig.CertSearcher = certstest.NewSearcher()
+		resourceConfig.CloudConfig = cloudconfigtest.New()
+		resourceConfig.K8sClient = fake.NewSimpleClientset()
+		resourceConfig.Logger = microloggertest.New()
+		newResource, err = New(resourceConfig)
+		if err != nil {
+			t.Fatal("expected", nil, "got", err)
+		}
+	}
+
+	for i, tc := range testCases {
+		result, err := newResource.GetDesiredState(context.TODO(), tc.Obj)
+		if err != nil {
+			t.Fatalf("case %d expected %#v got %#v", i+1, nil, err)
+		}
+
+		configMaps, ok := result.([]*apiv1.ConfigMap)
+		if !ok {
+			t.Fatalf("case %d expected %T got %T", i+1, []*apiv1.ConfigMap{}, result)
+		}
+
+		if testGetMasterCount(configMaps) != tc.ExpectedMasterCount {
+			t.Fatalf("case %d expected %d master nodes got %d", i+1, tc.ExpectedMasterCount, testGetMasterCount(configMaps))
+		}
+
+		if testGetWorkerCount(configMaps) != tc.ExpectedWorkerCount {
+			t.Fatalf("case %d expected %d worker nodes got %d", i+1, tc.ExpectedWorkerCount, testGetWorkerCount(configMaps))
+		}
+
+		if len(configMaps) != tc.ExpectedMasterCount+tc.ExpectedWorkerCount {
+			t.Fatalf("case %d expected %d nodes got %d", i+1, tc.ExpectedMasterCount+tc.ExpectedWorkerCount, len(configMaps))
+		}
+	}
+}
+
+func testGetMasterCount(configMaps []*apiv1.ConfigMap) int {
+	var count int
+
+	for _, c := range configMaps {
+		if strings.HasPrefix(c.Name, "master-") {
+			count++
+		}
+	}
+
+	return count
+}
+
+func testGetWorkerCount(configMaps []*apiv1.ConfigMap) int {
+	var count int
+
+	for _, c := range configMaps {
+		if strings.HasPrefix(c.Name, "worker-") {
+			count++
+		}
+	}
+
+	return count
+}

--- a/service/resource/configmapv3/error.go
+++ b/service/resource/configmapv3/error.go
@@ -1,0 +1,24 @@
+package configmapv2
+
+import "github.com/giantswarm/microerror"
+
+var invalidConfigError = microerror.New("invalid config")
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var notFoundError = microerror.New("not found")
+
+// IsNotFound asserts notFoundError.
+func IsNotFound(err error) bool {
+	return microerror.Cause(err) == notFoundError
+}
+
+var wrongTypeError = microerror.New("wrong type")
+
+// IsWrongTypeError asserts wrongTypeError.
+func IsWrongTypeError(err error) bool {
+	return microerror.Cause(err) == wrongTypeError
+}

--- a/service/resource/configmapv3/resource.go
+++ b/service/resource/configmapv3/resource.go
@@ -1,0 +1,123 @@
+package configmapv2
+
+import (
+	"reflect"
+
+	"github.com/giantswarm/certs"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/giantswarm/operatorkit/framework"
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/giantswarm/kvm-operator/service/cloudconfigv2"
+)
+
+const (
+	KeyUserData = "user_data"
+	// Name is the identifier of the resource.
+	Name = "configmapv2"
+)
+
+// Config represents the configuration used to create a new config map resource.
+type Config struct {
+	// Dependencies.
+	CertSearcher certs.Interface
+	CloudConfig  *cloudconfigv2.CloudConfig
+	K8sClient    kubernetes.Interface
+	Logger       micrologger.Logger
+}
+
+// DefaultConfig provides a default configuration to create a new config map
+// resource by best effort.
+func DefaultConfig() Config {
+	return Config{
+		// Dependencies.
+		CertSearcher: nil,
+		CloudConfig:  nil,
+		K8sClient:    nil,
+		Logger:       nil,
+	}
+}
+
+// Resource implements the config map resource.
+type Resource struct {
+	// Dependencies.
+	certSearcher certs.Interface
+	cloudConfig  *cloudconfigv2.CloudConfig
+	k8sClient    kubernetes.Interface
+	logger       micrologger.Logger
+}
+
+// New creates a new configured config map resource.
+func New(config Config) (*Resource, error) {
+	// Dependencies.
+	if config.CertSearcher == nil {
+		return nil, microerror.Maskf(invalidConfigError, "config.CertSearcher must not be empty")
+	}
+	if config.CloudConfig == nil {
+		return nil, microerror.Maskf(invalidConfigError, "config.CloudConfig must not be empty")
+	}
+	if config.K8sClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "config.K8sClient must not be empty")
+	}
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "config.Logger must not be empty")
+	}
+
+	newService := &Resource{
+		// Dependencies.
+		certSearcher: config.CertSearcher,
+		cloudConfig:  config.CloudConfig,
+		k8sClient:    config.K8sClient,
+		logger: config.Logger.With(
+			"resource", Name,
+		),
+	}
+
+	return newService, nil
+}
+
+func (r *Resource) Name() string {
+	return Name
+}
+
+func (r *Resource) Underlying() framework.Resource {
+	return r
+}
+
+func containsConfigMap(list []*apiv1.ConfigMap, item *apiv1.ConfigMap) bool {
+	_, err := getConfigMapByName(list, item.Name)
+	if err != nil {
+		return false
+	}
+
+	return true
+}
+
+func getConfigMapByName(list []*apiv1.ConfigMap, name string) (*apiv1.ConfigMap, error) {
+	for _, l := range list {
+		if l.Name == name {
+			return l, nil
+		}
+	}
+
+	return nil, microerror.Mask(notFoundError)
+}
+
+func isConfigMapModified(a, b *apiv1.ConfigMap) bool {
+	return !reflect.DeepEqual(a.Data, b.Data)
+}
+
+func toConfigMaps(v interface{}) ([]*apiv1.ConfigMap, error) {
+	if v == nil {
+		return nil, nil
+	}
+
+	configMaps, ok := v.([]*apiv1.ConfigMap)
+	if !ok {
+		return nil, microerror.Maskf(wrongTypeError, "expected '%T', got '%T'", []*apiv1.ConfigMap{}, v)
+	}
+
+	return configMaps, nil
+}

--- a/service/resource/configmapv3/update.go
+++ b/service/resource/configmapv3/update.go
@@ -1,0 +1,102 @@
+package configmapv2
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/operatorkit/framework"
+	apiv1 "k8s.io/api/core/v1"
+
+	"github.com/giantswarm/kvm-operator/service/keyv2"
+	"github.com/giantswarm/kvm-operator/service/messagecontext"
+)
+
+func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateChange interface{}) error {
+	customObject, err := keyv2.ToCustomObject(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	configMapsToUpdate, err := toConfigMaps(updateChange)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	if len(configMapsToUpdate) != 0 {
+		r.logger.LogCtx(ctx, "debug", "updating the config maps in the Kubernetes API")
+
+		// Create the config maps in the Kubernetes API.
+		namespace := keyv2.ClusterNamespace(customObject)
+		for _, configMap := range configMapsToUpdate {
+			_, err := r.k8sClient.CoreV1().ConfigMaps(namespace).Update(configMap)
+			if err != nil {
+				return microerror.Mask(err)
+			}
+		}
+
+		r.logger.LogCtx(ctx, "debug", "updated the config maps in the Kubernetes API")
+	} else {
+		r.logger.LogCtx(ctx, "debug", "the config maps do not need to be updated in the Kubernetes API")
+	}
+
+	return nil
+}
+
+func (r *Resource) NewUpdatePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*framework.Patch, error) {
+	create, err := r.newCreateChange(ctx, obj, currentState, desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+	delete, err := r.newDeleteChangeForUpdatePatch(ctx, obj, currentState, desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+	update, err := r.newUpdateChange(ctx, obj, currentState, desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	patch := framework.NewPatch()
+	patch.SetCreateChange(create)
+	patch.SetDeleteChange(delete)
+	patch.SetUpdateChange(update)
+
+	return patch, nil
+}
+
+func (r *Resource) newUpdateChange(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, error) {
+	currentConfigMaps, err := toConfigMaps(currentState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+	desiredConfigMaps, err := toConfigMaps(desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	var configMapsToUpdate []*apiv1.ConfigMap
+	{
+		r.logger.LogCtx(ctx, "debug", "finding out which config maps have to be updated")
+
+		for _, currentConfigMap := range currentConfigMaps {
+			desiredConfigMap, err := getConfigMapByName(desiredConfigMaps, currentConfigMap.Name)
+			if IsNotFound(err) {
+				continue
+			} else if err != nil {
+				return nil, microerror.Mask(err)
+			}
+
+			if isConfigMapModified(desiredConfigMap, currentConfigMap) {
+				m, ok := messagecontext.FromContext(ctx)
+				if ok {
+					m.ConfigMapNames = append(m.ConfigMapNames, desiredConfigMap.Name)
+				}
+				configMapsToUpdate = append(configMapsToUpdate, desiredConfigMap)
+			}
+		}
+
+		r.logger.LogCtx(ctx, "debug", fmt.Sprintf("found %d config maps that have to be updated", len(configMapsToUpdate)))
+	}
+
+	return configMapsToUpdate, nil
+}

--- a/service/resource/configmapv3/update_test.go
+++ b/service/resource/configmapv3/update_test.go
@@ -1,0 +1,239 @@
+package configmapv2
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/certs/certstest"
+	"github.com/giantswarm/micrologger/microloggertest"
+	apiv1 "k8s.io/api/core/v1"
+	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/giantswarm/kvm-operator/service/cloudconfigv2/cloudconfigtest"
+	"github.com/giantswarm/kvm-operator/service/messagecontext"
+)
+
+func Test_Resource_CloudConfig_newUpdateChange(t *testing.T) {
+	testCases := []struct {
+		Ctx                                  context.Context
+		Obj                                  interface{}
+		CurrentState                         interface{}
+		DesiredState                         interface{}
+		ExpectedConfigMapsToUpdate           []*apiv1.ConfigMap
+		ExpectedMessageContextConfigMapNames []string
+	}{
+		// Test 1, in case current state and desired state are empty the update
+		// state should be empty.
+		{
+			Ctx: context.TODO(),
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState:                         []*apiv1.ConfigMap{},
+			DesiredState:                         []*apiv1.ConfigMap{},
+			ExpectedConfigMapsToUpdate:           nil,
+			ExpectedMessageContextConfigMapNames: nil,
+		},
+
+		// Test 2, in case current state and desired state are equal the update
+		// state should be empty.
+		{
+			Ctx: context.TODO(),
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState: []*apiv1.ConfigMap{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "config-map-1",
+					},
+					Data: map[string]string{
+						"key1": "val1",
+					},
+				},
+			},
+			DesiredState: []*apiv1.ConfigMap{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "config-map-1",
+					},
+					Data: map[string]string{
+						"key1": "val1",
+					},
+				},
+			},
+			ExpectedConfigMapsToUpdate:           nil,
+			ExpectedMessageContextConfigMapNames: nil,
+		},
+
+		// Test 3, in case current state contains two items and desired state is
+		// contains the same state but one object is modified internally the update
+		// state should contain the the modified item from the current state.
+		{
+			Ctx: context.TODO(),
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState: []*apiv1.ConfigMap{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "config-map-1",
+					},
+					Data: map[string]string{
+						"key1": "val1",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "config-map-2",
+					},
+					Data: map[string]string{
+						"key2": "val2-modified",
+					},
+				},
+			},
+			DesiredState: []*apiv1.ConfigMap{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "config-map-1",
+					},
+					Data: map[string]string{
+						"key1": "val1",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "config-map-2",
+					},
+					Data: map[string]string{
+						"key2": "val2",
+					},
+				},
+			},
+			ExpectedConfigMapsToUpdate: []*apiv1.ConfigMap{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "config-map-2",
+					},
+					Data: map[string]string{
+						"key2": "val2",
+					},
+				},
+			},
+			ExpectedMessageContextConfigMapNames: nil,
+		},
+
+		// Test 4, same as 3 but ensuring the right config map names are written to
+		// the message context.
+		{
+			Ctx: messagecontext.NewContext(context.Background(), messagecontext.NewMessage()),
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState: []*apiv1.ConfigMap{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "config-map-1",
+					},
+					Data: map[string]string{
+						"key1": "val1",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "config-map-2",
+					},
+					Data: map[string]string{
+						"key2": "val2-modified",
+					},
+				},
+			},
+			DesiredState: []*apiv1.ConfigMap{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "config-map-1",
+					},
+					Data: map[string]string{
+						"key1": "val1",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "config-map-2",
+					},
+					Data: map[string]string{
+						"key2": "val2",
+					},
+				},
+			},
+			ExpectedConfigMapsToUpdate: []*apiv1.ConfigMap{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "config-map-2",
+					},
+					Data: map[string]string{
+						"key2": "val2",
+					},
+				},
+			},
+			ExpectedMessageContextConfigMapNames: []string{
+				"config-map-2",
+			},
+		},
+	}
+
+	var err error
+	var newResource *Resource
+	{
+		resourceConfig := DefaultConfig()
+		resourceConfig.CertSearcher = certstest.NewSearcher()
+		resourceConfig.CloudConfig = cloudconfigtest.New()
+		resourceConfig.K8sClient = fake.NewSimpleClientset()
+		resourceConfig.Logger = microloggertest.New()
+		newResource, err = New(resourceConfig)
+		if err != nil {
+			t.Fatal("expected", nil, "got", err)
+		}
+	}
+
+	for i, tc := range testCases {
+		updateState, err := newResource.newUpdateChange(tc.Ctx, tc.Obj, tc.CurrentState, tc.DesiredState)
+		if err != nil {
+			t.Fatalf("case %d expected %#v got %#v", i+1, nil, err)
+		}
+
+		configMapsToUpdate, ok := updateState.([]*apiv1.ConfigMap)
+		if !ok {
+			t.Fatalf("case %d expected %T got %T", i+1, []*apiv1.ConfigMap{}, updateState)
+		}
+		if !reflect.DeepEqual(configMapsToUpdate, tc.ExpectedConfigMapsToUpdate) {
+			t.Fatalf("case %d expected %#v got %#v", i+1, tc.ExpectedConfigMapsToUpdate, configMapsToUpdate)
+		}
+
+		m, ok := messagecontext.FromContext(tc.Ctx)
+		if ok {
+			if !reflect.DeepEqual(m.ConfigMapNames, tc.ExpectedMessageContextConfigMapNames) {
+				t.Fatalf("case %d expected %#v got %#v", i+1, tc.ExpectedMessageContextConfigMapNames, m.ConfigMapNames)
+			}
+		}
+	}
+}


### PR DESCRIPTION
In order to add new version in kvm-operator, this PR start the work by duplicating the cloudconfig and config map