### PR TITLE
specify CPU/memory limits on k8s-kvm container

### DIFF
--- a/service/keyv3/error.go
+++ b/service/keyv3/error.go
@@ -1,4 +1,4 @@
-package keyv2
+package keyv3
 
 import "github.com/giantswarm/microerror"
 

--- a/service/keyv3/key.go
+++ b/service/keyv3/key.go
@@ -38,7 +38,7 @@ const (
 
 	K8SKVMHealthDocker = "quay.io/giantswarm/k8s-kvm-health:ddf211dfed52086ade32ab8c45e44eb0273319ef"
 
-	// default memory for k8s-kvm container.
+	// defaultWorkerMemory represents the extra memory to add due to qemu overhead.
 	defaultWorkerMemory = "1G"
 )
 

--- a/service/keyv3/key_test.go
+++ b/service/keyv3/key_test.go
@@ -1,4 +1,4 @@
-package keyv2
+package keyv3
 
 import (
 	"net"

--- a/service/resource/deploymentv3/create.go
+++ b/service/resource/deploymentv3/create.go
@@ -1,4 +1,4 @@
-package deploymentv2
+package deploymentv3
 
 import (
 	"context"
@@ -8,11 +8,11 @@ import (
 	"k8s.io/api/extensions/v1beta1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 
-	"github.com/giantswarm/kvm-operator/service/keyv2"
+	"github.com/giantswarm/kvm-operator/service/keyv3"
 )
 
 func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange interface{}) error {
-	customObject, err := keyv2.ToCustomObject(obj)
+	customObject, err := keyv3.ToCustomObject(obj)
 	if err != nil {
 		return microerror.Mask(err)
 	}
@@ -24,7 +24,7 @@ func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange inte
 	if len(deploymentsToCreate) != 0 {
 		r.logger.LogCtx(ctx, "debug", "creating the deployments in the Kubernetes API")
 
-		namespace := keyv2.ClusterNamespace(customObject)
+		namespace := keyv3.ClusterNamespace(customObject)
 		for _, deployment := range deploymentsToCreate {
 			_, err := r.k8sClient.Extensions().Deployments(namespace).Create(deployment)
 			if apierrors.IsAlreadyExists(err) {

--- a/service/resource/deploymentv3/create_test.go
+++ b/service/resource/deploymentv3/create_test.go
@@ -1,4 +1,4 @@
-package deploymentv2
+package deploymentv3
 
 import (
 	"context"

--- a/service/resource/deploymentv3/current.go
+++ b/service/resource/deploymentv3/current.go
@@ -1,4 +1,4 @@
-package deploymentv2
+package deploymentv3
 
 import (
 	"context"
@@ -11,11 +11,11 @@ import (
 	"k8s.io/api/extensions/v1beta1"
 	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/giantswarm/kvm-operator/service/keyv2"
+	"github.com/giantswarm/kvm-operator/service/keyv3"
 )
 
 func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interface{}, error) {
-	customObject, err := keyv2.ToCustomObject(obj)
+	customObject, err := keyv3.ToCustomObject(obj)
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}
@@ -24,7 +24,7 @@ func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interf
 
 	var currentDeployments []*v1beta1.Deployment
 	{
-		namespace := keyv2.ClusterNamespace(customObject)
+		namespace := keyv3.ClusterNamespace(customObject)
 		deploymentList, err := r.k8sClient.Extensions().Deployments(namespace).List(apismetav1.ListOptions{})
 		if err != nil {
 			return nil, microerror.Mask(err)

--- a/service/resource/deploymentv3/delete.go
+++ b/service/resource/deploymentv3/delete.go
@@ -1,4 +1,4 @@
-package deploymentv2
+package deploymentv3
 
 import (
 	"context"
@@ -10,11 +10,11 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/giantswarm/kvm-operator/service/keyv2"
+	"github.com/giantswarm/kvm-operator/service/keyv3"
 )
 
 func (r *Resource) ApplyDeleteChange(ctx context.Context, obj, deleteChange interface{}) error {
-	customObject, err := keyv2.ToCustomObject(obj)
+	customObject, err := keyv3.ToCustomObject(obj)
 	if err != nil {
 		return microerror.Mask(err)
 	}
@@ -26,7 +26,7 @@ func (r *Resource) ApplyDeleteChange(ctx context.Context, obj, deleteChange inte
 	if len(deploymentsToDelete) != 0 {
 		r.logger.LogCtx(ctx, "debug", "deleting the deployments in the Kubernetes API")
 
-		namespace := keyv2.ClusterNamespace(customObject)
+		namespace := keyv3.ClusterNamespace(customObject)
 		for _, deployment := range deploymentsToDelete {
 			err := r.k8sClient.Extensions().Deployments(namespace).Delete(deployment.Name, newDeleteOptions())
 			if apierrors.IsNotFound(err) {

--- a/service/resource/deploymentv3/delete_test.go
+++ b/service/resource/deploymentv3/delete_test.go
@@ -1,4 +1,4 @@
-package deploymentv2
+package deploymentv3
 
 import (
 	"context"

--- a/service/resource/deploymentv3/desired.go
+++ b/service/resource/deploymentv3/desired.go
@@ -1,4 +1,4 @@
-package deploymentv2
+package deploymentv3
 
 import (
 	"context"
@@ -7,11 +7,11 @@ import (
 	"github.com/giantswarm/microerror"
 	"k8s.io/api/extensions/v1beta1"
 
-	"github.com/giantswarm/kvm-operator/service/keyv2"
+	"github.com/giantswarm/kvm-operator/service/keyv3"
 )
 
 func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interface{}, error) {
-	customObject, err := keyv2.ToCustomObject(obj)
+	customObject, err := keyv3.ToCustomObject(obj)
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}
@@ -33,7 +33,7 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interf
 		}
 		deployments = append(deployments, workerDeployments...)
 
-		if keyv2.HasNodeController(customObject) {
+		if keyv3.HasNodeController(customObject) {
 			nodeControllerDeployment, err := newNodeControllerDeployment(customObject)
 			if err != nil {
 				return nil, microerror.Mask(err)

--- a/service/resource/deploymentv3/desired_test.go
+++ b/service/resource/deploymentv3/desired_test.go
@@ -42,10 +42,10 @@ func Test_Resource_Deployment_GetDesiredState(t *testing.T) {
 							StorageType: "hostPath",
 						},
 						Masters: []v1alpha1.KVMConfigSpecKVMNode{
-							{CPUs: 1, Memory: "1Gi"},
+							{CPUs: 1, Memory: "1G"},
 						},
 						Workers: []v1alpha1.KVMConfigSpecKVMNode{
-							{CPUs: 4, Memory: "8.2G"},
+							{CPUs: 4, Memory: "8G"},
 						},
 					},
 				},
@@ -57,7 +57,11 @@ func Test_Resource_Deployment_GetDesiredState(t *testing.T) {
 				{
 					Requests: apiv1.ResourceList{
 						apiv1.ResourceCPU:    resource.MustParse("1"),
-						apiv1.ResourceMemory: resource.MustParse("1Gi"),
+						apiv1.ResourceMemory: resource.MustParse("2G"),
+					},
+					Limits: apiv1.ResourceList{
+						apiv1.ResourceCPU:    resource.MustParse("1"),
+						apiv1.ResourceMemory: resource.MustParse("2G"),
 					},
 				},
 			},
@@ -65,7 +69,11 @@ func Test_Resource_Deployment_GetDesiredState(t *testing.T) {
 				{
 					Requests: apiv1.ResourceList{
 						apiv1.ResourceCPU:    resource.MustParse("4"),
-						apiv1.ResourceMemory: resource.MustParse("8.2G"),
+						apiv1.ResourceMemory: resource.MustParse("9G"),
+					},
+					Limits: apiv1.ResourceList{
+						apiv1.ResourceCPU:    resource.MustParse("4"),
+						apiv1.ResourceMemory: resource.MustParse("9G"),
 					},
 				},
 			},
@@ -92,7 +100,7 @@ func Test_Resource_Deployment_GetDesiredState(t *testing.T) {
 							StorageType: "hostPath",
 						},
 						Masters: []v1alpha1.KVMConfigSpecKVMNode{
-							{CPUs: 1, Memory: "1Gi"},
+							{CPUs: 1, Memory: "1G"},
 						},
 						NodeController: v1alpha1.KVMConfigSpecKVMNodeController{
 							Docker: v1alpha1.KVMConfigSpecKVMNodeControllerDocker{
@@ -100,9 +108,9 @@ func Test_Resource_Deployment_GetDesiredState(t *testing.T) {
 							},
 						},
 						Workers: []v1alpha1.KVMConfigSpecKVMNode{
-							{CPUs: 4, Memory: "8.2G"},
-							{CPUs: 4, Memory: "8.2G"},
-							{CPUs: 4, Memory: "8.2G"},
+							{CPUs: 4, Memory: "8G"},
+							{CPUs: 4, Memory: "8G"},
+							{CPUs: 4, Memory: "8G"},
 						},
 					},
 				},
@@ -114,7 +122,11 @@ func Test_Resource_Deployment_GetDesiredState(t *testing.T) {
 				{
 					Requests: apiv1.ResourceList{
 						apiv1.ResourceCPU:    resource.MustParse("1"),
-						apiv1.ResourceMemory: resource.MustParse("1Gi"),
+						apiv1.ResourceMemory: resource.MustParse("2G"),
+					},
+					Limits: apiv1.ResourceList{
+						apiv1.ResourceCPU:    resource.MustParse("1"),
+						apiv1.ResourceMemory: resource.MustParse("2G"),
 					},
 				},
 			},
@@ -122,19 +134,31 @@ func Test_Resource_Deployment_GetDesiredState(t *testing.T) {
 				{
 					Requests: apiv1.ResourceList{
 						apiv1.ResourceCPU:    resource.MustParse("4"),
-						apiv1.ResourceMemory: resource.MustParse("8.2G"),
+						apiv1.ResourceMemory: resource.MustParse("9G"),
+					},
+					Limits: apiv1.ResourceList{
+						apiv1.ResourceCPU:    resource.MustParse("4"),
+						apiv1.ResourceMemory: resource.MustParse("9G"),
 					},
 				},
 				{
 					Requests: apiv1.ResourceList{
 						apiv1.ResourceCPU:    resource.MustParse("4"),
-						apiv1.ResourceMemory: resource.MustParse("8.2G"),
+						apiv1.ResourceMemory: resource.MustParse("9G"),
+					},
+					Limits: apiv1.ResourceList{
+						apiv1.ResourceCPU:    resource.MustParse("4"),
+						apiv1.ResourceMemory: resource.MustParse("9G"),
 					},
 				},
 				{
 					Requests: apiv1.ResourceList{
 						apiv1.ResourceCPU:    resource.MustParse("4"),
-						apiv1.ResourceMemory: resource.MustParse("8.2G"),
+						apiv1.ResourceMemory: resource.MustParse("9G"),
+					},
+					Limits: apiv1.ResourceList{
+						apiv1.ResourceCPU:    resource.MustParse("4"),
+						apiv1.ResourceMemory: resource.MustParse("9G"),
 					},
 				},
 			},
@@ -163,9 +187,9 @@ func Test_Resource_Deployment_GetDesiredState(t *testing.T) {
 							StorageType: "hostPath",
 						},
 						Masters: []v1alpha1.KVMConfigSpecKVMNode{
-							{CPUs: 1, Memory: "1Gi"},
-							{CPUs: 1, Memory: "1Gi"},
-							{CPUs: 1, Memory: "1Gi"},
+							{CPUs: 1, Memory: "1G"},
+							{CPUs: 1, Memory: "1G"},
+							{CPUs: 1, Memory: "1G"},
 						},
 						NodeController: v1alpha1.KVMConfigSpecKVMNodeController{
 							Docker: v1alpha1.KVMConfigSpecKVMNodeControllerDocker{
@@ -173,9 +197,9 @@ func Test_Resource_Deployment_GetDesiredState(t *testing.T) {
 							},
 						},
 						Workers: []v1alpha1.KVMConfigSpecKVMNode{
-							{CPUs: 4, Memory: "8.2G"},
-							{CPUs: 4, Memory: "8.2G"},
-							{CPUs: 4, Memory: "8.2G"},
+							{CPUs: 4, Memory: "8G"},
+							{CPUs: 4, Memory: "8G"},
+							{CPUs: 4, Memory: "8G"},
 						},
 					},
 				},
@@ -187,19 +211,31 @@ func Test_Resource_Deployment_GetDesiredState(t *testing.T) {
 				{
 					Requests: apiv1.ResourceList{
 						apiv1.ResourceCPU:    resource.MustParse("1"),
-						apiv1.ResourceMemory: resource.MustParse("1Gi"),
+						apiv1.ResourceMemory: resource.MustParse("2G"),
+					},
+					Limits: apiv1.ResourceList{
+						apiv1.ResourceCPU:    resource.MustParse("1"),
+						apiv1.ResourceMemory: resource.MustParse("2G"),
 					},
 				},
 				{
 					Requests: apiv1.ResourceList{
 						apiv1.ResourceCPU:    resource.MustParse("1"),
-						apiv1.ResourceMemory: resource.MustParse("1Gi"),
+						apiv1.ResourceMemory: resource.MustParse("2G"),
+					},
+					Limits: apiv1.ResourceList{
+						apiv1.ResourceCPU:    resource.MustParse("1"),
+						apiv1.ResourceMemory: resource.MustParse("2G"),
 					},
 				},
 				{
 					Requests: apiv1.ResourceList{
 						apiv1.ResourceCPU:    resource.MustParse("1"),
-						apiv1.ResourceMemory: resource.MustParse("1Gi"),
+						apiv1.ResourceMemory: resource.MustParse("2G"),
+					},
+					Limits: apiv1.ResourceList{
+						apiv1.ResourceCPU:    resource.MustParse("1"),
+						apiv1.ResourceMemory: resource.MustParse("2G"),
 					},
 				},
 			},
@@ -207,19 +243,31 @@ func Test_Resource_Deployment_GetDesiredState(t *testing.T) {
 				{
 					Requests: apiv1.ResourceList{
 						apiv1.ResourceCPU:    resource.MustParse("4"),
-						apiv1.ResourceMemory: resource.MustParse("8.2G"),
+						apiv1.ResourceMemory: resource.MustParse("9G"),
+					},
+					Limits: apiv1.ResourceList{
+						apiv1.ResourceCPU:    resource.MustParse("4"),
+						apiv1.ResourceMemory: resource.MustParse("9G"),
 					},
 				},
 				{
 					Requests: apiv1.ResourceList{
 						apiv1.ResourceCPU:    resource.MustParse("4"),
-						apiv1.ResourceMemory: resource.MustParse("8.2G"),
+						apiv1.ResourceMemory: resource.MustParse("9G"),
+					},
+					Limits: apiv1.ResourceList{
+						apiv1.ResourceCPU:    resource.MustParse("4"),
+						apiv1.ResourceMemory: resource.MustParse("9G"),
 					},
 				},
 				{
 					Requests: apiv1.ResourceList{
 						apiv1.ResourceCPU:    resource.MustParse("4"),
-						apiv1.ResourceMemory: resource.MustParse("8.2G"),
+						apiv1.ResourceMemory: resource.MustParse("9G"),
+					},
+					Limits: apiv1.ResourceList{
+						apiv1.ResourceCPU:    resource.MustParse("4"),
+						apiv1.ResourceMemory: resource.MustParse("9G"),
 					},
 				},
 			},
@@ -262,11 +310,11 @@ func Test_Resource_Deployment_GetDesiredState(t *testing.T) {
 		}
 
 		if !reflect.DeepEqual(testGetK8sMasterKVMResources(deployments), tc.ExpectedMastersResources) {
-			t.Fatalf("case %d expected %#v got %#v", i+1, testGetK8sMasterKVMResources(deployments), tc.ExpectedMastersResources)
+			t.Fatalf("case %d expected %#v got %#v", i+1, tc.ExpectedMastersResources, testGetK8sMasterKVMResources(deployments))
 		}
 
 		if !reflect.DeepEqual(testGetK8sWorkerKVMResources(deployments), tc.ExpectedWorkersResources) {
-			t.Fatalf("case %d expected %#v got %#v", i+1, testGetK8sWorkerKVMResources(deployments), tc.ExpectedWorkersResources)
+			t.Fatalf("case %d expected %#v got %#v", i+1, tc.ExpectedWorkersResources, testGetK8sWorkerKVMResources(deployments))
 		}
 	}
 }

--- a/service/resource/deploymentv3/desired_test.go
+++ b/service/resource/deploymentv3/desired_test.go
@@ -1,4 +1,4 @@
-package deploymentv2
+package deploymentv3
 
 import (
 	"context"

--- a/service/resource/deploymentv3/error.go
+++ b/service/resource/deploymentv3/error.go
@@ -1,4 +1,4 @@
-package deploymentv2
+package deploymentv3
 
 import "github.com/giantswarm/microerror"
 

--- a/service/resource/deploymentv3/master_deployment.go
+++ b/service/resource/deploymentv3/master_deployment.go
@@ -7,6 +7,7 @@ import (
 	"github.com/giantswarm/microerror"
 	apiv1 "k8s.io/api/core/v1"
 	extensionsv1 "k8s.io/api/extensions/v1beta1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
@@ -232,6 +233,10 @@ func newMasterDeployments(customObject v1alpha1.KVMConfig) ([]*extensionsv1.Depl
 								},
 								Resources: apiv1.ResourceRequirements{
 									Requests: apiv1.ResourceList{
+										apiv1.ResourceCPU:    cpuQuantity,
+										apiv1.ResourceMemory: memoryQuantity,
+									},
+									Limits: map[apiv1.ResourceName]resource.Quantity{
 										apiv1.ResourceCPU:    cpuQuantity,
 										apiv1.ResourceMemory: memoryQuantity,
 									},

--- a/service/resource/deploymentv3/master_pod_affinity.go
+++ b/service/resource/deploymentv3/master_pod_affinity.go
@@ -1,11 +1,11 @@
-package deploymentv2
+package deploymentv3
 
 import (
 	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
 	apiv1 "k8s.io/api/core/v1"
 	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/giantswarm/kvm-operator/service/keyv2"
+	"github.com/giantswarm/kvm-operator/service/keyv3"
 )
 
 func newMasterPodAfinity(customObject v1alpha1.KVMConfig) *apiv1.Affinity {
@@ -27,7 +27,7 @@ func newMasterPodAfinity(customObject v1alpha1.KVMConfig) *apiv1.Affinity {
 					},
 					TopologyKey: "kubernetes.io/hostname",
 					Namespaces: []string{
-						keyv2.ClusterID(customObject),
+						keyv3.ClusterID(customObject),
 					},
 				},
 			},

--- a/service/resource/deploymentv3/metric.go
+++ b/service/resource/deploymentv3/metric.go
@@ -1,4 +1,4 @@
-package deploymentv2
+package deploymentv3
 
 import (
 	"github.com/prometheus/client_golang/prometheus"

--- a/service/resource/deploymentv3/node_controller_deployment.go
+++ b/service/resource/deploymentv3/node_controller_deployment.go
@@ -1,4 +1,4 @@
-package deploymentv2
+package deploymentv3
 
 import (
 	"fmt"
@@ -9,7 +9,7 @@ import (
 	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
-	"github.com/giantswarm/kvm-operator/service/keyv2"
+	"github.com/giantswarm/kvm-operator/service/keyv3"
 )
 
 func newNodeControllerDeployment(customObject v1alpha1.KVMConfig) (*extensionsv1.Deployment, error) {
@@ -21,11 +21,11 @@ func newNodeControllerDeployment(customObject v1alpha1.KVMConfig) (*extensionsv1
 			APIVersion: "extensions/v1beta",
 		},
 		ObjectMeta: apismetav1.ObjectMeta{
-			Name: keyv2.NodeControllerID,
+			Name: keyv3.NodeControllerID,
 			Labels: map[string]string{
-				"cluster":  keyv2.ClusterID(customObject),
-				"customer": keyv2.ClusterCustomer(customObject),
-				"app":      keyv2.NodeControllerID,
+				"cluster":  keyv3.ClusterID(customObject),
+				"customer": keyv3.ClusterCustomer(customObject),
+				"app":      keyv3.NodeControllerID,
 			},
 		},
 		Spec: extensionsv1.DeploymentSpec{
@@ -35,30 +35,30 @@ func newNodeControllerDeployment(customObject v1alpha1.KVMConfig) (*extensionsv1
 			Replicas: &replicas,
 			Template: apiv1.PodTemplateSpec{
 				ObjectMeta: apismetav1.ObjectMeta{
-					GenerateName: keyv2.NodeControllerID,
+					GenerateName: keyv3.NodeControllerID,
 					Annotations: map[string]string{
-						VersionBundleVersionAnnotation: keyv2.VersionBundleVersion(customObject),
+						VersionBundleVersionAnnotation: keyv3.VersionBundleVersion(customObject),
 					},
 					Labels: map[string]string{
-						"app":      keyv2.NodeControllerID,
-						"cluster":  keyv2.ClusterID(customObject),
-						"customer": keyv2.ClusterCustomer(customObject),
+						"app":      keyv3.NodeControllerID,
+						"cluster":  keyv3.ClusterID(customObject),
+						"customer": keyv3.ClusterCustomer(customObject),
 					},
 				},
 				Spec: apiv1.PodSpec{
 					Containers: []apiv1.Container{
 						{
-							Name:            keyv2.NodeControllerID,
+							Name:            keyv3.NodeControllerID,
 							Image:           customObject.Spec.KVM.NodeController.Docker.Image,
 							ImagePullPolicy: apiv1.PullIfNotPresent,
 							Args: []string{
-								fmt.Sprintf("-cluster-api=%s", keyv2.ClusterAPIEndpoint(customObject)),
-								fmt.Sprintf("-cluster-id=%s", keyv2.ClusterID(customObject)),
+								fmt.Sprintf("-cluster-api=%s", keyv3.ClusterAPIEndpoint(customObject)),
+								fmt.Sprintf("-cluster-id=%s", keyv3.ClusterID(customObject)),
 							},
 							Env: []apiv1.EnvVar{
 								{
 									Name:  "PROVIDER_HOST_CLUSTER_NAMESPACE",
-									Value: keyv2.ClusterID(customObject),
+									Value: keyv3.ClusterID(customObject),
 								},
 							},
 							LivenessProbe: &apiv1.Probe{
@@ -69,7 +69,7 @@ func newNodeControllerDeployment(customObject v1alpha1.KVMConfig) (*extensionsv1
 								SuccessThreshold:    1,
 								Handler: apiv1.Handler{
 									HTTPGet: &apiv1.HTTPGetAction{
-										Path: keyv2.HealthEndpoint,
+										Path: keyv3.HealthEndpoint,
 										Port: intstr.IntOrString{IntVal: 8080},
 									},
 								},

--- a/service/resource/deploymentv3/resource.go
+++ b/service/resource/deploymentv3/resource.go
@@ -1,4 +1,4 @@
-package deploymentv2
+package deploymentv3
 
 import (
 	"reflect"

--- a/service/resource/deploymentv3/update.go
+++ b/service/resource/deploymentv3/update.go
@@ -1,4 +1,4 @@
-package deploymentv2
+package deploymentv3
 
 import (
 	"context"
@@ -9,12 +9,12 @@ import (
 	"github.com/giantswarm/operatorkit/framework/context/updateallowedcontext"
 	"k8s.io/api/extensions/v1beta1"
 
-	"github.com/giantswarm/kvm-operator/service/keyv2"
+	"github.com/giantswarm/kvm-operator/service/keyv3"
 	"github.com/giantswarm/kvm-operator/service/messagecontext"
 )
 
 func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateChange interface{}) error {
-	customObject, err := keyv2.ToCustomObject(obj)
+	customObject, err := keyv3.ToCustomObject(obj)
 	if err != nil {
 		return microerror.Mask(err)
 	}
@@ -26,7 +26,7 @@ func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateChange inte
 	if len(deploymentsToUpdate) != 0 {
 		r.logger.LogCtx(ctx, "debug", "updating the deployments in the Kubernetes API")
 
-		namespace := keyv2.ClusterNamespace(customObject)
+		namespace := keyv3.ClusterNamespace(customObject)
 		for _, deployment := range deploymentsToUpdate {
 			_, err := r.k8sClient.Extensions().Deployments(namespace).Update(deployment)
 			if err != nil {

--- a/service/resource/deploymentv3/update_test.go
+++ b/service/resource/deploymentv3/update_test.go
@@ -1,4 +1,4 @@
-package deploymentv2
+package deploymentv3
 
 import (
 	"context"

--- a/service/resource/deploymentv3/worker_deployment.go
+++ b/service/resource/deploymentv3/worker_deployment.go
@@ -1,4 +1,4 @@
-package deploymentv2
+package deploymentv3
 
 import (
 	"fmt"
@@ -11,7 +11,7 @@ import (
 	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
-	"github.com/giantswarm/kvm-operator/service/keyv2"
+	"github.com/giantswarm/kvm-operator/service/keyv3"
 )
 
 func newWorkerDeployments(customObject v1alpha1.KVMConfig) ([]*extensionsv1.Deployment, error) {
@@ -23,12 +23,12 @@ func newWorkerDeployments(customObject v1alpha1.KVMConfig) ([]*extensionsv1.Depl
 	for i, workerNode := range customObject.Spec.Cluster.Workers {
 		capabilities := customObject.Spec.KVM.Workers[i]
 
-		cpuQuantity, err := keyv2.CPUQuantity(capabilities)
+		cpuQuantity, err := keyv3.CPUQuantity(capabilities)
 		if err != nil {
 			return nil, microerror.Maskf(err, "creating CPU quantity")
 		}
 
-		memoryQuantity, err := keyv2.MemoryQuantity(capabilities)
+		memoryQuantity, err := keyv3.MemoryQuantity(capabilities)
 		if err != nil {
 			return nil, microerror.Maskf(err, "creating memory quantity")
 		}
@@ -39,14 +39,14 @@ func newWorkerDeployments(customObject v1alpha1.KVMConfig) ([]*extensionsv1.Depl
 				APIVersion: "extensions/v1beta",
 			},
 			ObjectMeta: apismetav1.ObjectMeta{
-				Name: keyv2.DeploymentName(keyv2.WorkerID, workerNode.ID),
+				Name: keyv3.DeploymentName(keyv3.WorkerID, workerNode.ID),
 				Annotations: map[string]string{
-					VersionBundleVersionAnnotation: keyv2.VersionBundleVersion(customObject),
+					VersionBundleVersionAnnotation: keyv3.VersionBundleVersion(customObject),
 				},
 				Labels: map[string]string{
-					"app":      keyv2.WorkerID,
-					"cluster":  keyv2.ClusterID(customObject),
-					"customer": keyv2.ClusterCustomer(customObject),
+					"app":      keyv3.WorkerID,
+					"cluster":  keyv3.ClusterID(customObject),
+					"customer": keyv3.ClusterCustomer(customObject),
 					"node":     workerNode.ID,
 				},
 			},
@@ -57,11 +57,11 @@ func newWorkerDeployments(customObject v1alpha1.KVMConfig) ([]*extensionsv1.Depl
 				Replicas: &replicas,
 				Template: apiv1.PodTemplateSpec{
 					ObjectMeta: apismetav1.ObjectMeta{
-						Name: keyv2.WorkerID,
+						Name: keyv3.WorkerID,
 						Labels: map[string]string{
-							"cluster":  keyv2.ClusterID(customObject),
-							"customer": keyv2.ClusterCustomer(customObject),
-							"app":      keyv2.WorkerID,
+							"cluster":  keyv3.ClusterID(customObject),
+							"customer": keyv3.ClusterCustomer(customObject),
+							"app":      keyv3.WorkerID,
 							"node":     workerNode.ID,
 						},
 						Annotations: map[string]string{},
@@ -70,7 +70,7 @@ func newWorkerDeployments(customObject v1alpha1.KVMConfig) ([]*extensionsv1.Depl
 						Affinity:    newWorkerPodAfinity(customObject),
 						HostNetwork: true,
 						NodeSelector: map[string]string{
-							"role": keyv2.WorkerID,
+							"role": keyv3.WorkerID,
 						},
 						Volumes: []apiv1.Volume{
 							{
@@ -78,7 +78,7 @@ func newWorkerDeployments(customObject v1alpha1.KVMConfig) ([]*extensionsv1.Depl
 								VolumeSource: apiv1.VolumeSource{
 									ConfigMap: &apiv1.ConfigMapVolumeSource{
 										LocalObjectReference: apiv1.LocalObjectReference{
-											Name: keyv2.ConfigMapName(customObject, workerNode, keyv2.WorkerID),
+											Name: keyv3.ConfigMapName(customObject, workerNode, keyv3.WorkerID),
 										},
 									},
 								},
@@ -101,7 +101,7 @@ func newWorkerDeployments(customObject v1alpha1.KVMConfig) ([]*extensionsv1.Depl
 								Name: "flannel",
 								VolumeSource: apiv1.VolumeSource{
 									HostPath: &apiv1.HostPathVolumeSource{
-										Path: keyv2.FlannelEnvPathPrefix,
+										Path: keyv3.FlannelEnvPathPrefix,
 									},
 								},
 							},
@@ -114,9 +114,9 @@ func newWorkerDeployments(customObject v1alpha1.KVMConfig) ([]*extensionsv1.Depl
 								Command: []string{
 									"/bin/sh",
 									"-c",
-									"/opt/k8s-endpoint-updater update --provider.bridge.name=" + keyv2.NetworkBridgeName(customObject) +
-										" --service.kubernetes.cluster.namespace=" + keyv2.ClusterNamespace(customObject) +
-										" --service.kubernetes.cluster.service=" + keyv2.WorkerID +
+									"/opt/k8s-endpoint-updater update --provider.bridge.name=" + keyv3.NetworkBridgeName(customObject) +
+										" --service.kubernetes.cluster.namespace=" + keyv3.ClusterNamespace(customObject) +
+										" --service.kubernetes.cluster.service=" + keyv3.WorkerID +
 										" --service.kubernetes.inCluster=true" +
 										" --service.kubernetes.pod.name=${POD_NAME}",
 								},
@@ -143,7 +143,7 @@ func newWorkerDeployments(customObject v1alpha1.KVMConfig) ([]*extensionsv1.Depl
 									Privileged: &privileged,
 								},
 								Args: []string{
-									keyv2.WorkerID,
+									keyv3.WorkerID,
 								},
 								Env: []apiv1.EnvVar{
 									{
@@ -165,11 +165,11 @@ func newWorkerDeployments(customObject v1alpha1.KVMConfig) ([]*extensionsv1.Depl
 									},
 									{
 										Name:  "NETWORK_BRIDGE_NAME",
-										Value: keyv2.NetworkBridgeName(customObject),
+										Value: keyv3.NetworkBridgeName(customObject),
 									},
 									{
 										Name:  "NETWORK_TAP_NAME",
-										Value: keyv2.NetworkTapName(customObject),
+										Value: keyv3.NetworkTapName(customObject),
 									},
 									{
 										Name: "MEMORY",
@@ -178,7 +178,7 @@ func newWorkerDeployments(customObject v1alpha1.KVMConfig) ([]*extensionsv1.Depl
 									},
 									{
 										Name:  "ROLE",
-										Value: keyv2.WorkerID,
+										Value: keyv3.WorkerID,
 									},
 									{
 										Name:  "CLOUD_CONFIG_PATH",
@@ -186,16 +186,16 @@ func newWorkerDeployments(customObject v1alpha1.KVMConfig) ([]*extensionsv1.Depl
 									},
 								},
 								LivenessProbe: &apiv1.Probe{
-									InitialDelaySeconds: keyv2.InitialDelaySeconds,
-									TimeoutSeconds:      keyv2.TimeoutSeconds,
-									PeriodSeconds:       keyv2.PeriodSeconds,
-									FailureThreshold:    keyv2.FailureThreshold,
-									SuccessThreshold:    keyv2.SuccessThreshold,
+									InitialDelaySeconds: keyv3.InitialDelaySeconds,
+									TimeoutSeconds:      keyv3.TimeoutSeconds,
+									PeriodSeconds:       keyv3.PeriodSeconds,
+									FailureThreshold:    keyv3.FailureThreshold,
+									SuccessThreshold:    keyv3.SuccessThreshold,
 									Handler: apiv1.Handler{
 										HTTPGet: &apiv1.HTTPGetAction{
-											Path: keyv2.HealthEndpoint,
-											Port: intstr.IntOrString{IntVal: keyv2.LivenessPort(customObject)},
-											Host: keyv2.ProbeHost,
+											Path: keyv3.HealthEndpoint,
+											Port: intstr.IntOrString{IntVal: keyv3.LivenessPort(customObject)},
+											Host: keyv3.ProbeHost,
 										},
 									},
 								},
@@ -222,16 +222,16 @@ func newWorkerDeployments(customObject v1alpha1.KVMConfig) ([]*extensionsv1.Depl
 							},
 							{
 								Name:            "k8s-kvm-health",
-								Image:           keyv2.K8SKVMHealthDocker,
+								Image:           keyv3.K8SKVMHealthDocker,
 								ImagePullPolicy: apiv1.PullAlways,
 								Env: []apiv1.EnvVar{
 									{
 										Name:  "LISTEN_ADDRESS",
-										Value: keyv2.HealthListenAddress(customObject),
+										Value: keyv3.HealthListenAddress(customObject),
 									},
 									{
 										Name:  "NETWORK_ENV_FILE_PATH",
-										Value: keyv2.NetworkEnvFilePath(customObject),
+										Value: keyv3.NetworkEnvFilePath(customObject),
 									},
 								},
 								SecurityContext: &apiv1.SecurityContext{
@@ -240,7 +240,7 @@ func newWorkerDeployments(customObject v1alpha1.KVMConfig) ([]*extensionsv1.Depl
 								VolumeMounts: []apiv1.VolumeMount{
 									{
 										Name:      "flannel",
-										MountPath: keyv2.FlannelEnvPathPrefix,
+										MountPath: keyv3.FlannelEnvPathPrefix,
 									},
 								},
 							},

--- a/service/resource/deploymentv3/worker_deployment.go
+++ b/service/resource/deploymentv3/worker_deployment.go
@@ -204,6 +204,10 @@ func newWorkerDeployments(customObject v1alpha1.KVMConfig) ([]*extensionsv1.Depl
 										apiv1.ResourceCPU:    cpuQuantity,
 										apiv1.ResourceMemory: memoryQuantity,
 									},
+									Limits: map[apiv1.ResourceName]resource.Quantity{
+										apiv1.ResourceCPU:    cpuQuantity,
+										apiv1.ResourceMemory: memoryQuantity,
+									},
 								},
 								VolumeMounts: []apiv1.VolumeMount{
 									{

--- a/service/resource/deploymentv3/worker_pod_affinity.go
+++ b/service/resource/deploymentv3/worker_pod_affinity.go
@@ -1,11 +1,11 @@
-package deploymentv2
+package deploymentv3
 
 import (
 	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
 	apiv1 "k8s.io/api/core/v1"
 	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/giantswarm/kvm-operator/service/keyv2"
+	"github.com/giantswarm/kvm-operator/service/keyv3"
 )
 
 func newWorkerPodAfinity(customObject v1alpha1.KVMConfig) *apiv1.Affinity {
@@ -27,7 +27,7 @@ func newWorkerPodAfinity(customObject v1alpha1.KVMConfig) *apiv1.Affinity {
 					},
 					TopologyKey: "kubernetes.io/hostname",
 					Namespaces: []string{
-						keyv2.ClusterID(customObject),
+						keyv3.ClusterID(customObject),
 					},
 				},
 			},


### PR DESCRIPTION
Towards https://github.com/giantswarm/kvm-operator/issues/259

As suggested in the issue includes `limits` settings (equal to `requests` to ensure `guaranteed` QoS class) and adds 1G to the `requests` and `limits` memory settings.

The tests have been adapted to check for the new limit entries and the increased values, the expectations have been set to easy-to-compare values.