### PR TITLE
Adds hook for graceful qemu shutdown

### DIFF
--- a/service/resource/deploymentv3/master_deployment.go
+++ b/service/resource/deploymentv3/master_deployment.go
@@ -217,6 +217,13 @@ func newMasterDeployments(customObject v1alpha1.KVMConfig) ([]*extensionsv1.Depl
 										Value: "/cloudconfig/user_data",
 									},
 								},
+								Lifecycle: &apiv1.Lifecycle{
+									PreStop: &apiv1.Handler{
+										Exec: &apiv1.ExecAction{
+											Command: []string{"/qemu-shutdown"},
+										},
+									},
+								},
 								LivenessProbe: &apiv1.Probe{
 									InitialDelaySeconds: keyv3.InitialDelaySeconds,
 									TimeoutSeconds:      keyv3.TimeoutSeconds,

--- a/service/resource/deploymentv3/worker_deployment.go
+++ b/service/resource/deploymentv3/worker_deployment.go
@@ -185,6 +185,13 @@ func newWorkerDeployments(customObject v1alpha1.KVMConfig) ([]*extensionsv1.Depl
 										Value: "/cloudconfig/user_data",
 									},
 								},
+								Lifecycle: &apiv1.Lifecycle{
+									PreStop: &apiv1.Handler{
+										Exec: &apiv1.ExecAction{
+											Command: []string{"/qemu-shutdown"},
+										},
+									},
+								},
 								LivenessProbe: &apiv1.Probe{
 									InitialDelaySeconds: keyv3.InitialDelaySeconds,
 									TimeoutSeconds:      keyv3.TimeoutSeconds,


### PR DESCRIPTION
Adds preStop hook that triggers CoreOS graceful shutdown.

Tested in `geckon`.

Related:
https://github.com/giantswarm/kubernetesd/pull/334
https://github.com/giantswarm/k8s-kvm/pull/16

Fixes: https://github.com/giantswarm/kvm-operator/issues/333