### PR TITLE
Add rbac and psp files 

### DIFF
--- a/helm/kvm-operator-chart/templates/deployment.yaml
+++ b/helm/kvm-operator-chart/templates/deployment.yaml
@@ -22,6 +22,7 @@ spec:
           items:
           - key: config.yml
             path: config.yml
+      serviceAccountName: kvm-operator
       containers:
       - name: kvm-operator
         image: quay.io/giantswarm/kvm-operator:[[ .SHA ]]

--- a/helm/kvm-operator-chart/templates/psp.yaml
+++ b/helm/kvm-operator-chart/templates/psp.yaml
@@ -1,0 +1,20 @@
+apiVersion: extensions/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: kvm-operator-psp
+spec:
+  privileged: false
+  fsGroup:
+    rule: RunAsAny
+  runAsUser:
+    rule: RunAsAny
+  seLinux:
+    rule: RunAsAny
+  supplementalGroups:
+    rule: RunAsAny
+  volumes:
+    - 'secret'
+    - 'configMap'
+  hostNetwork: false
+  hostIPC: false
+  hostPID: false

--- a/helm/kvm-operator-chart/templates/rbac.yaml
+++ b/helm/kvm-operator-chart/templates/rbac.yaml
@@ -1,0 +1,126 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: kvm-operator
+rules:
+  - apiGroups:
+      - apiextensions.k8s.io
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - "*"
+  - apiGroups:
+      - extensions
+    resources:
+      - thirdpartyresources
+    verbs:
+      - "*"
+  - apiGroups:
+      - extensions
+    resources:
+      - deployments
+      - ingresses
+    verbs:
+      - "*"
+  - apiGroups:
+      - core.giantswarm.io
+    resources:
+      - storageconfigs
+    verbs:
+      - "*"
+  - apiGroups:
+      - provider.giantswarm.io
+    resources:
+      - kvmconfigs
+    verbs:
+      - "*"
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+    verbs:
+      - get
+      - create
+      - delete
+      - list
+  - apiGroups:
+      - ""
+    resources:
+      - persistentvolumeclaims
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - endpoints
+      - services
+    verbs:
+      - get 
+      - list
+      - watch
+      - create
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - watch
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - get
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - "*"
+  - nonResourceURLs:
+      - "/"
+      - "/healthz"
+    verbs:
+      - get
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: kvm-operator
+subjects:
+  - kind: ServiceAccount
+    name: kvm-operator
+    namespace: giantswarm
+roleRef:
+  kind: ClusterRole
+  name: kvm-operator
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: kvm-operator-psp
+rules:
+  - apiGroups:
+      - extensions
+    resources:
+      - podsecuritypolicies
+    verbs:
+      - use
+    resourceNames:
+      - kvm-operator-psp
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: kvm-operator-psp
+subjects:
+  - kind: ServiceAccount
+    name: kvm-operator
+    namespace: giantswarm
+roleRef:
+  kind: ClusterRole
+  name: kvm-operator-psp
+  apiGroup: rbac.authorization.k8s.io

--- a/helm/kvm-operator-chart/templates/rbac.yaml
+++ b/helm/kvm-operator-chart/templates/rbac.yaml
@@ -39,6 +39,7 @@ rules:
     resources:
       - namespaces
       - clusterrolebindings
+      - serviceaccounts
     verbs:
       - get
       - create

--- a/helm/kvm-operator-chart/templates/rbac.yaml
+++ b/helm/kvm-operator-chart/templates/rbac.yaml
@@ -38,6 +38,7 @@ rules:
       - ""
     resources:
       - namespaces
+      - clusterrolebindings
     verbs:
       - get
       - create

--- a/helm/kvm-operator-chart/templates/service-account.yaml
+++ b/helm/kvm-operator-chart/templates/service-account.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kvm-operator
+  namespace: giantswarm


### PR DESCRIPTION
Add service account, cluster roles, cluster role bindings and pod security policies for kvm operator.  Modify deployment to use the newer service account

(split part of https://github.com/giantswarm/kvm-operator/pull/332)