### PR TITLE
Add service account for guest cluster v3

### DIFF
--- a/service/framework.go
+++ b/service/framework.go
@@ -303,11 +303,11 @@ func newCRDFramework(config Config) (*framework.Framework, error) {
 		resourcesV3 = []framework.Resource{
 			namespaceResource,
 
+			serviceAccountResourceV3,
 			configMapResourceV3,
 			deploymentResourceV3,
 			ingressResource,
 			pvcResource,
-			serviceAccountResourceV3,
 			serviceResource,
 		}
 

--- a/service/framework.go
+++ b/service/framework.go
@@ -34,6 +34,7 @@ import (
 	"github.com/giantswarm/kvm-operator/service/resource/namespacev2"
 	"github.com/giantswarm/kvm-operator/service/resource/podv2"
 	"github.com/giantswarm/kvm-operator/service/resource/pvcv2"
+	"github.com/giantswarm/kvm-operator/service/resource/serviceaccountv3"
 	"github.com/giantswarm/kvm-operator/service/resource/servicev2"
 )
 
@@ -239,6 +240,19 @@ func newCRDFramework(config Config) (*framework.Framework, error) {
 		}
 	}
 
+	var serviceAccountResourceV3 framework.Resource
+	{
+		c := serviceaccountv3.DefaultConfig()
+
+		c.K8sClient = k8sClient
+		c.Logger = config.Logger
+
+		serviceAccountResourceV3, err = serviceaccountv3.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
 	var serviceResource framework.Resource
 	{
 		c := servicev2.DefaultConfig()
@@ -293,6 +307,7 @@ func newCRDFramework(config Config) (*framework.Framework, error) {
 			deploymentResourceV3,
 			ingressResource,
 			pvcResource,
+			serviceAccountResourceV3,
 			serviceResource,
 		}
 

--- a/service/keyv3/key.go
+++ b/service/keyv3/key.go
@@ -179,6 +179,10 @@ func PVCNames(customObject v1alpha1.KVMConfig) []string {
 	return names
 }
 
+func ServiceAccountName(customObject v1alpha1.KVMConfig) string {
+	return ClusterID(customObject)
+}
+
 func StorageType(customObject v1alpha1.KVMConfig) string {
 	return customObject.Spec.KVM.K8sKVM.StorageType
 }

--- a/service/resource/deploymentv3/master_deployment.go
+++ b/service/resource/deploymentv3/master_deployment.go
@@ -106,6 +106,7 @@ func newMasterDeployments(customObject v1alpha1.KVMConfig) ([]*extensionsv1.Depl
 						NodeSelector: map[string]string{
 							"role": keyv3.MasterID,
 						},
+						ServiceAccountName: keyv3.ServiceAccountName(customObject),
 						Volumes: []apiv1.Volume{
 							{
 								Name: "cloud-config",

--- a/service/resource/deploymentv3/node_controller_deployment.go
+++ b/service/resource/deploymentv3/node_controller_deployment.go
@@ -46,6 +46,7 @@ func newNodeControllerDeployment(customObject v1alpha1.KVMConfig) (*extensionsv1
 					},
 				},
 				Spec: apiv1.PodSpec{
+					ServiceAccountName: keyv3.ServiceAccountName(customObject),
 					Containers: []apiv1.Container{
 						{
 							Name:            keyv3.NodeControllerID,

--- a/service/resource/deploymentv3/worker_deployment.go
+++ b/service/resource/deploymentv3/worker_deployment.go
@@ -75,6 +75,7 @@ func newWorkerDeployments(customObject v1alpha1.KVMConfig) ([]*extensionsv1.Depl
 						NodeSelector: map[string]string{
 							"role": keyv3.WorkerID,
 						},
+						ServiceAccountName: keyv3.ServiceAccountName(customObject),
 						Volumes: []apiv1.Volume{
 							{
 								Name: "cloud-config",

--- a/service/resource/serviceaccountv3/create.go
+++ b/service/resource/serviceaccountv3/create.go
@@ -1,0 +1,63 @@
+package serviceaccountv3
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/giantswarm/microerror"
+	apiv1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+
+	"github.com/giantswarm/kvm-operator/service/keyv3"
+)
+
+func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange interface{}) error {
+	customObject, err := keyv3.ToCustomObject(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	serviceAccountToCreate, err := toServiceAccount(createChange)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	// Create the service account in the Kubernetes API.
+	if serviceAccountToCreate != nil {
+		r.logger.LogCtx(ctx, "debug", "creating the service account in the Kubernetes API")
+
+		namespace := keyv3.ClusterNamespace(customObject)
+		_, err := r.k8sClient.CoreV1().ServiceAccounts(namespace).Create(serviceAccountToCreate)
+		if apierrors.IsAlreadyExists(err) {
+		} else if err != nil {
+			return microerror.Mask(err)
+		}
+
+		r.logger.LogCtx(ctx, "debug", "created the service account in the Kubernetes API")
+	} else {
+		r.logger.LogCtx(ctx, "debug", "the service account does not need to be created in the Kubernetes API")
+	}
+
+	return nil
+}
+
+func (r *Resource) newCreateChange(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, error) {
+	currentServiceAccount, err := toServiceAccount(currentState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+	desiredServiceAccount, err := toServiceAccount(desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	r.logger.LogCtx(ctx, "debug", "finding out which service account has to be created")
+
+	var serviceAccountToCreate *apiv1.ServiceAccount
+	if currentServiceAccount == nil {
+		serviceAccountToCreate = desiredServiceAccount
+	}
+
+	r.logger.LogCtx(ctx, "debug", fmt.Sprintf("found out that service account that has to be created"))
+
+	return serviceAccountToCreate, nil
+}

--- a/service/resource/serviceaccountv3/create_test.go
+++ b/service/resource/serviceaccountv3/create_test.go
@@ -1,0 +1,124 @@
+package serviceaccountv3
+
+import (
+	"context"
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/micrologger/microloggertest"
+	apiv1 "k8s.io/api/core/v1"
+	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func Test_Resource_ServiceAccount_newCreateChange(t *testing.T) {
+	testCases := []struct {
+		Obj                    interface{}
+		Cur                    interface{}
+		Des                    interface{}
+		ExpectedServiceAccount *apiv1.ServiceAccount
+	}{
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "my-cluster",
+					},
+				},
+			},
+			Cur: &apiv1.ServiceAccount{
+				TypeMeta: apismetav1.TypeMeta{
+					Kind:       "ServiceAccount",
+					APIVersion: "v1",
+				},
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name: "al9qy",
+					Labels: map[string]string{
+						"cluster":  "al9qy",
+						"customer": "test-customer",
+					},
+				},
+			},
+			Des: &apiv1.ServiceAccount{
+				TypeMeta: apismetav1.TypeMeta{
+					Kind:       "ServiceAccount",
+					APIVersion: "v1",
+				},
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name: "al9qy",
+					Labels: map[string]string{
+						"cluster":  "al9qy",
+						"customer": "test-customer",
+					},
+				},
+			},
+			ExpectedServiceAccount: nil,
+		},
+
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "my-cluster",
+					},
+				},
+			},
+			Cur: nil,
+			Des: &apiv1.ServiceAccount{
+				TypeMeta: apismetav1.TypeMeta{
+					Kind:       "ServiceAccount",
+					APIVersion: "v1",
+				},
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name: "al9qy",
+					Labels: map[string]string{
+						"cluster":  "al9qy",
+						"customer": "test-customer",
+					},
+				},
+			},
+			ExpectedServiceAccount: &apiv1.ServiceAccount{
+				TypeMeta: apismetav1.TypeMeta{
+					Kind:       "ServiceAccount",
+					APIVersion: "v1",
+				},
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name: "al9qy",
+					Labels: map[string]string{
+						"cluster":  "al9qy",
+						"customer": "test-customer",
+					},
+				},
+			},
+		},
+	}
+
+	var err error
+	var newResource *Resource
+	{
+		resourceConfig := DefaultConfig()
+		resourceConfig.K8sClient = fake.NewSimpleClientset()
+		resourceConfig.Logger = microloggertest.New()
+		newResource, err = New(resourceConfig)
+		if err != nil {
+			t.Fatal("expected", nil, "got", err)
+		}
+	}
+
+	for i, tc := range testCases {
+		result, err := newResource.newCreateChange(context.TODO(), tc.Obj, tc.Cur, tc.Des)
+		if err != nil {
+			t.Fatal("case", i+1, "expected", nil, "got", err)
+		}
+		if tc.ExpectedServiceAccount == nil {
+			if tc.ExpectedServiceAccount != result {
+				t.Fatal("case", i+1, "expected", tc.ExpectedServiceAccount, "got", result)
+			}
+		} else {
+			name := result.(*apiv1.ServiceAccount).Name
+			if tc.ExpectedServiceAccount.Name != name {
+				t.Fatal("case", i+1, "expected", tc.ExpectedServiceAccount.Name, "got", name)
+			}
+		}
+	}
+}

--- a/service/resource/serviceaccountv3/current.go
+++ b/service/resource/serviceaccountv3/current.go
@@ -25,11 +25,14 @@ func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interf
 	currentServiceAccount, err = r.k8sClient.CoreV1().ServiceAccounts(namespace).Get(keyv3.ServiceAccountName(customObject), apismetav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
 		r.logger.LogCtx(ctx, "debug", "did not find the service account in the Kubernetes API")
+		//When service account is not found api still returning non nil value so it can break create/update/delete
+		// and is why force the return value to nil
+		return nil, nil
 	} else if err != nil {
 		return nil, microerror.Mask(err)
+	} else {
+		r.logger.LogCtx(ctx, "debug", "found a service account in the Kubernetes API")
 	}
-
-	r.logger.LogCtx(ctx, "debug", "found a service account in the Kubernetes API")
 
 	return currentServiceAccount, nil
 }

--- a/service/resource/serviceaccountv3/current.go
+++ b/service/resource/serviceaccountv3/current.go
@@ -6,6 +6,7 @@ import (
 	"github.com/giantswarm/microerror"
 	apiv1 "k8s.io/api/core/v1"
 	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 
 	"github.com/giantswarm/kvm-operator/service/keyv3"

--- a/service/resource/serviceaccountv3/current.go
+++ b/service/resource/serviceaccountv3/current.go
@@ -1,0 +1,31 @@
+package serviceaccountv3
+
+import (
+	"context"
+
+	"github.com/giantswarm/microerror"
+	apiv1 "k8s.io/api/core/v1"
+	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/giantswarm/kvm-operator/service/keyv3"
+)
+
+func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interface{}, error) {
+	customObject, err := keyv3.ToCustomObject(obj)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	r.logger.LogCtx(ctx, "debug", "looking for a service account in the Kubernetes API")
+
+	namespace := keyv3.ClusterNamespace(customObject)
+	var currentServiceAccount *apiv1.ServiceAccount
+	currentServiceAccount, err = r.k8sClient.CoreV1().ServiceAccounts(namespace).Get(keyv3.ServiceAccountName(customObject), apismetav1.GetOptions{})
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	r.logger.LogCtx(ctx, "debug", "found a service account in the Kubernetes API")
+
+	return currentServiceAccount, nil
+}

--- a/service/resource/serviceaccountv3/current.go
+++ b/service/resource/serviceaccountv3/current.go
@@ -6,6 +6,7 @@ import (
 	"github.com/giantswarm/microerror"
 	apiv1 "k8s.io/api/core/v1"
 	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 
 	"github.com/giantswarm/kvm-operator/service/keyv3"
 )
@@ -21,7 +22,9 @@ func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interf
 	namespace := keyv3.ClusterNamespace(customObject)
 	var currentServiceAccount *apiv1.ServiceAccount
 	currentServiceAccount, err = r.k8sClient.CoreV1().ServiceAccounts(namespace).Get(keyv3.ServiceAccountName(customObject), apismetav1.GetOptions{})
-	if err != nil {
+	if apierrors.IsNotFound(err) {
+		r.logger.LogCtx(ctx, "debug", "did not find the service account in the Kubernetes API")
+	} else if err != nil {
 		return nil, microerror.Mask(err)
 	}
 

--- a/service/resource/serviceaccountv3/delete.go
+++ b/service/resource/serviceaccountv3/delete.go
@@ -1,0 +1,76 @@
+package serviceaccountv3
+
+import (
+	"context"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/operatorkit/framework"
+	apiv1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/giantswarm/kvm-operator/service/keyv3"
+)
+
+func (r *Resource) ApplyDeleteChange(ctx context.Context, obj, deleteChange interface{}) error {
+	customObject, err := keyv3.ToCustomObject(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	serviceAccountToDelete, err := toServiceAccount(deleteChange)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	if serviceAccountToDelete != nil {
+		r.logger.LogCtx(ctx, "debug", "deleting the service account in the Kubernetes API")
+
+		// Delete service account in the Kubernetes API.
+		namespace := keyv3.ClusterNamespace(customObject)
+		err := r.k8sClient.CoreV1().ServiceAccounts(namespace).Delete(serviceAccountToDelete.Name, &apismetav1.DeleteOptions{})
+		if apierrors.IsNotFound(err) {
+		} else if err != nil {
+			return microerror.Mask(err)
+		}
+
+		r.logger.LogCtx(ctx, "debug", "deleted the service account in the Kubernetes API")
+	} else {
+		r.logger.LogCtx(ctx, "debug", "the service account does not need to be deleted from the Kubernetes API")
+	}
+
+	return nil
+}
+
+func (r *Resource) NewDeletePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*framework.Patch, error) {
+	deleteChange, err := r.newDeleteChange(ctx, obj, currentState, desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	patch := framework.NewPatch()
+	patch.SetDeleteChange(deleteChange)
+
+	return patch, nil
+}
+
+func (r *Resource) newDeleteChange(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, error) {
+	currentServiceAccount, err := toServiceAccount(currentState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+	desiredServiceAccount, err := toServiceAccount(desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	r.logger.LogCtx(ctx, "debug", "finding out which service account has to be deleted")
+
+	var serviceAccountToDelete *apiv1.ServiceAccount
+	if currentServiceAccount != nil {
+		serviceAccountToDelete = desiredServiceAccount
+	}
+
+	r.logger.LogCtx(ctx, "debug", "found out service account that has to be deleted")
+
+	return serviceAccountToDelete, nil
+}

--- a/service/resource/serviceaccountv3/delete_test.go
+++ b/service/resource/serviceaccountv3/delete_test.go
@@ -1,0 +1,124 @@
+package serviceaccountv3
+
+import (
+	"context"
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/micrologger/microloggertest"
+	apiv1 "k8s.io/api/core/v1"
+	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func Test_Resource_ServiceAccount_newDeleteChange(t *testing.T) {
+	testCases := []struct {
+		Obj                    interface{}
+		Cur                    interface{}
+		Des                    interface{}
+		ExpectedServiceAccount *apiv1.ServiceAccount
+	}{
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "my-cluster",
+					},
+				},
+			},
+			Cur: &apiv1.ServiceAccount{
+				TypeMeta: apismetav1.TypeMeta{
+					Kind:       "ServiceAccount",
+					APIVersion: "v1",
+				},
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name: "al9qy",
+					Labels: map[string]string{
+						"cluster":  "al9qy",
+						"customer": "test-customer",
+					},
+				},
+			},
+			Des: &apiv1.ServiceAccount{
+				TypeMeta: apismetav1.TypeMeta{
+					Kind:       "ServiceAccount",
+					APIVersion: "v1",
+				},
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name: "al9qy",
+					Labels: map[string]string{
+						"cluster":  "al9qy",
+						"customer": "test-customer",
+					},
+				},
+			},
+			ExpectedServiceAccount: &apiv1.ServiceAccount{
+				TypeMeta: apismetav1.TypeMeta{
+					Kind:       "ServiceAccount",
+					APIVersion: "v1",
+				},
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name: "al9qy",
+					Labels: map[string]string{
+						"cluster":  "al9qy",
+						"customer": "test-customer",
+					},
+				},
+			},
+		},
+
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "my-cluster",
+					},
+				},
+			},
+			Cur: nil,
+			Des: &apiv1.ServiceAccount{
+				TypeMeta: apismetav1.TypeMeta{
+					Kind:       "ServiceAccount",
+					APIVersion: "v1",
+				},
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name: "al9qy",
+					Labels: map[string]string{
+						"cluster":  "al9qy",
+						"customer": "test-customer",
+					},
+				},
+			},
+			ExpectedServiceAccount: nil,
+		},
+	}
+
+	var err error
+	var newResource *Resource
+	{
+		resourceConfig := DefaultConfig()
+		resourceConfig.K8sClient = fake.NewSimpleClientset()
+		resourceConfig.Logger = microloggertest.New()
+		newResource, err = New(resourceConfig)
+		if err != nil {
+			t.Fatal("expected", nil, "got", err)
+		}
+	}
+
+	for i, tc := range testCases {
+		result, err := newResource.newDeleteChange(context.TODO(), tc.Obj, tc.Cur, tc.Des)
+		if err != nil {
+			t.Fatal("case", i+1, "expected", nil, "got", err)
+		}
+		if tc.ExpectedServiceAccount == nil {
+			if tc.ExpectedServiceAccount != result {
+				t.Fatal("case", i+1, "expected", tc.ExpectedServiceAccount, "got", result)
+			}
+		} else {
+			name := result.(*apiv1.ServiceAccount).Name
+			if tc.ExpectedServiceAccount.Name != name {
+				t.Fatal("case", i+1, "expected", tc.ExpectedServiceAccount.Name, "got", name)
+			}
+		}
+	}
+}

--- a/service/resource/serviceaccountv3/desired.go
+++ b/service/resource/serviceaccountv3/desired.go
@@ -1,0 +1,43 @@
+package serviceaccountv3
+
+import (
+	"context"
+
+	"github.com/giantswarm/microerror"
+	apiv1 "k8s.io/api/core/v1"
+	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/giantswarm/kvm-operator/service/keyv3"
+)
+
+func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interface{}, error) {
+	customObject, err := keyv3.ToCustomObject(obj)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	r.logger.LogCtx(ctx, "debug", "computing the new service account")
+
+	serviceAccount := &apiv1.ServiceAccount{
+		TypeMeta: apismetav1.TypeMeta{
+			Kind:       "ServiceAccount",
+			APIVersion: "v1",
+		},
+		ObjectMeta: apismetav1.ObjectMeta{
+			Name:      keyv3.ServiceAccountName(customObject),
+			Namespace: keyv3.ClusterID(customObject),
+			Labels: map[string]string{
+				"cluster-id":  keyv3.ClusterID(customObject),
+				"customer-id": keyv3.ClusterCustomer(customObject),
+			},
+		},
+	}
+
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	r.logger.LogCtx(ctx, "debug", "computed the new service account")
+
+	return serviceAccount, nil
+}

--- a/service/resource/serviceaccountv3/desired.go
+++ b/service/resource/serviceaccountv3/desired.go
@@ -33,10 +33,6 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interf
 		},
 	}
 
-	if err != nil {
-		return nil, microerror.Mask(err)
-	}
-
 	r.logger.LogCtx(ctx, "debug", "computed the new service account")
 
 	return serviceAccount, nil

--- a/service/resource/serviceaccountv3/desired_test.go
+++ b/service/resource/serviceaccountv3/desired_test.go
@@ -1,0 +1,62 @@
+package serviceaccountv3
+
+import (
+	"context"
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/micrologger/microloggertest"
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func Test_Resource_ServiceAccount_GetDesiredState(t *testing.T) {
+	testCases := []struct {
+		Obj          interface{}
+		ExpectedName string
+	}{
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			ExpectedName: "al9qy",
+		},
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "my-cluster",
+					},
+				},
+			},
+			ExpectedName: "my-cluster",
+		},
+	}
+
+	var err error
+	var newResource *Resource
+	{
+		resourceConfig := DefaultConfig()
+		resourceConfig.K8sClient = fake.NewSimpleClientset()
+		resourceConfig.Logger = microloggertest.New()
+		newResource, err = New(resourceConfig)
+		if err != nil {
+			t.Fatal("expected", nil, "got", err)
+		}
+	}
+
+	for i, tc := range testCases {
+		result, err := newResource.GetDesiredState(context.TODO(), tc.Obj)
+		if err != nil {
+			t.Fatal("case", i+1, "expected", nil, "got", err)
+		}
+		name := result.(*apiv1.ServiceAccount).Name
+		if tc.ExpectedName != name {
+			t.Fatalf("case %d expected %#v got %#v", i+1, tc.ExpectedName, name)
+		}
+	}
+}

--- a/service/resource/serviceaccountv3/error.go
+++ b/service/resource/serviceaccountv3/error.go
@@ -1,0 +1,24 @@
+package serviceaccountv3
+
+import "github.com/giantswarm/microerror"
+
+var invalidConfigError = microerror.New("invalid config")
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var notFoundError = microerror.New("not found")
+
+// IsNotFound asserts notFoundError.
+func IsNotFound(err error) bool {
+	return microerror.Cause(err) == notFoundError
+}
+
+var wrongTypeError = microerror.New("wrong type")
+
+// IsWrongTypeError asserts wrongTypeError.
+func IsWrongTypeError(err error) bool {
+	return microerror.Cause(err) == wrongTypeError
+}

--- a/service/resource/serviceaccountv3/resource.go
+++ b/service/resource/serviceaccountv3/resource.go
@@ -1,0 +1,77 @@
+package serviceaccountv3
+
+import (
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/giantswarm/operatorkit/framework"
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	// Name is the identifier of the resource.
+	Name = "serviceaccountv3"
+)
+
+// Config represents the configuration used to create a new cloud config resource.
+type Config struct {
+	// Dependencies.
+	K8sClient kubernetes.Interface
+	Logger    micrologger.Logger
+}
+
+// DefaultConfig provides a default configuration to create a new config map
+// resource by best effort.
+func DefaultConfig() Config {
+	return Config{
+		K8sClient: nil,
+		Logger:    nil,
+	}
+}
+
+// Resource implements the config map resource.
+type Resource struct {
+	// Dependencies.
+	k8sClient kubernetes.Interface
+	logger    micrologger.Logger
+}
+
+// New creates a new configured config map resource.
+func New(config Config) (*Resource, error) {
+	if config.K8sClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "config.K8sClient must not be empty")
+	}
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "config.Logger must not be empty")
+	}
+
+	newService := &Resource{
+		k8sClient: config.K8sClient,
+		logger: config.Logger.With(
+			"resource", Name,
+		),
+	}
+
+	return newService, nil
+}
+
+func (r *Resource) Name() string {
+	return Name
+}
+
+func (r *Resource) Underlying() framework.Resource {
+	return r
+}
+
+func toServiceAccount(v interface{}) (*apiv1.ServiceAccount, error) {
+	if v == nil {
+		return nil, nil
+	}
+
+	serviceAccount, ok := v.(*apiv1.ServiceAccount)
+	if !ok {
+		return nil, microerror.Maskf(wrongTypeError, "expected '%T', got '%T'", apiv1.ServiceAccount{}, v)
+	}
+
+	return serviceAccount, nil
+}

--- a/service/resource/serviceaccountv3/update.go
+++ b/service/resource/serviceaccountv3/update.go
@@ -1,0 +1,34 @@
+package serviceaccountv3
+
+import (
+	"context"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/operatorkit/framework"
+)
+
+func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateChange interface{}) error {
+	return nil
+}
+
+func (r *Resource) NewUpdatePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*framework.Patch, error) {
+	create, err := r.newCreateChange(ctx, obj, currentState, desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	update, err := r.newUpdateChange(ctx, obj, currentState, desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	patch := framework.NewPatch()
+	patch.SetCreateChange(create)
+	patch.SetUpdateChange(update)
+
+	return patch, nil
+}
+
+func (r *Resource) newUpdateChange(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, error) {
+	return nil, nil
+}


### PR DESCRIPTION
Towards [#2296](https://github.com/giantswarm/giantswarm/issues/2296)

When a guest cluster is created, KVM operator creates three deployments (worker, master, node-controller) that should have a service account and a role bound to be able to manage resources.

Should I consider something special to check for version 3? right now is a mirror of v2

(split part of https://github.com/giantswarm/kvm-operator/pull/332)