### PR TITLE
framework: skip v* suffixes in variable names

### DIFF
--- a/service/framework/kvmconfigv2/resources.go
+++ b/service/framework/kvmconfigv2/resources.go
@@ -58,13 +58,13 @@ func NewResources(config ResourcesConfig) ([]framework.Resource, error) {
 		return nil, microerror.Maskf(invalidConfigError, "config.Name must not be empty")
 	}
 
-	var ccServiceV2 *cloudconfigv2.CloudConfig
+	var cloudConfig *cloudconfigv2.CloudConfig
 	{
 		c := cloudconfigv2.DefaultConfig()
 
 		c.Logger = config.Logger
 
-		ccServiceV2, err = cloudconfigv2.New(c)
+		cloudConfig, err = cloudconfigv2.New(c)
 		if err != nil {
 			return nil, microerror.Mask(err)
 		}
@@ -83,42 +83,42 @@ func NewResources(config ResourcesConfig) ([]framework.Resource, error) {
 		}
 	}
 
-	var serviceAccountResourceV2 framework.Resource
+	var serviceAccountResource framework.Resource
 	{
 		c := serviceaccountv2.DefaultConfig()
 
 		c.K8sClient = config.K8sClient
 		c.Logger = config.Logger
 
-		serviceAccountResourceV2, err = serviceaccountv2.New(c)
+		serviceAccountResource, err = serviceaccountv2.New(c)
 		if err != nil {
 			return nil, microerror.Mask(err)
 		}
 	}
 
-	var configMapResourceV2 framework.Resource
+	var configMapResource framework.Resource
 	{
 		c := configmapv2.DefaultConfig()
 
 		c.CertSearcher = config.CertsSearcher
-		c.CloudConfig = ccServiceV2
+		c.CloudConfig = cloudConfig
 		c.K8sClient = config.K8sClient
 		c.Logger = config.Logger
 
-		configMapResourceV2, err = configmapv2.New(c)
+		configMapResource, err = configmapv2.New(c)
 		if err != nil {
 			return nil, microerror.Mask(err)
 		}
 	}
 
-	var deploymentResourceV2 framework.Resource
+	var deploymentResource framework.Resource
 	{
 		c := deploymentv2.DefaultConfig()
 
 		c.K8sClient = config.K8sClient
 		c.Logger = config.Logger
 
-		deploymentResourceV2, err = deploymentv2.New(c)
+		deploymentResource, err = deploymentv2.New(c)
 		if err != nil {
 			return nil, microerror.Mask(err)
 		}
@@ -165,9 +165,9 @@ func NewResources(config ResourcesConfig) ([]framework.Resource, error) {
 
 	resources := []framework.Resource{
 		namespaceResource,
-		serviceAccountResourceV2,
-		configMapResourceV2,
-		deploymentResourceV2,
+		serviceAccountResource,
+		configMapResource,
+		deploymentResource,
 		ingressResource,
 		pvcResource,
 		serviceResource,

--- a/service/framework/kvmconfigv3/resources.go
+++ b/service/framework/kvmconfigv3/resources.go
@@ -54,13 +54,13 @@ func NewResources(config ResourcesConfig) ([]framework.Resource, error) {
 		return nil, microerror.Maskf(invalidConfigError, "config.Name must not be empty")
 	}
 
-	var ccServiceV3 *cloudconfigv3.CloudConfig
+	var cloudConfig *cloudconfigv3.CloudConfig
 	{
 		c := cloudconfigv3.DefaultConfig()
 
 		c.Logger = config.Logger
 
-		ccServiceV3, err = cloudconfigv3.New(c)
+		cloudConfig, err = cloudconfigv3.New(c)
 		if err != nil {
 			return nil, microerror.Mask(err)
 		}
@@ -79,43 +79,43 @@ func NewResources(config ResourcesConfig) ([]framework.Resource, error) {
 		}
 	}
 
-	var serviceAccountResourceV3 framework.Resource
+	var serviceAccountResource framework.Resource
 	{
 		c := serviceaccountv3.DefaultConfig()
 
 		c.K8sClient = config.K8sClient
 		c.Logger = config.Logger
 
-		serviceAccountResourceV3, err = serviceaccountv3.New(c)
+		serviceAccountResource, err = serviceaccountv3.New(c)
 		if err != nil {
 			return nil, microerror.Mask(err)
 		}
 	}
 
-	var configMapResourceV3 framework.Resource
+	var configMapResource framework.Resource
 	{
 		c := configmapv3.DefaultConfig()
 
 		c.CertSearcher = config.CertsSearcher
-		c.CloudConfig = ccServiceV3
+		c.CloudConfig = cloudConfig
 		c.K8sClient = config.K8sClient
 		c.KeyWatcher = config.RandomkeysSearcher
 		c.Logger = config.Logger
 
-		configMapResourceV3, err = configmapv3.New(c)
+		configMapResource, err = configmapv3.New(c)
 		if err != nil {
 			return nil, microerror.Mask(err)
 		}
 	}
 
-	var deploymentResourceV3 framework.Resource
+	var deploymentResource framework.Resource
 	{
 		c := deploymentv3.DefaultConfig()
 
 		c.K8sClient = config.K8sClient
 		c.Logger = config.Logger
 
-		deploymentResourceV3, err = deploymentv3.New(c)
+		deploymentResource, err = deploymentv3.New(c)
 		if err != nil {
 			return nil, microerror.Mask(err)
 		}
@@ -162,9 +162,9 @@ func NewResources(config ResourcesConfig) ([]framework.Resource, error) {
 
 	resources := []framework.Resource{
 		namespaceResource,
-		serviceAccountResourceV3,
-		configMapResourceV3,
-		deploymentResourceV3,
+		serviceAccountResource,
+		configMapResource,
+		deploymentResource,
 		ingressResource,
 		pvcResource,
 		serviceResource,


### PR DESCRIPTION
Since everything is sitting in a separate package we don't need that
anymore.