### PR TITLE
kvmconfig/v3: use only v3 resources

### DIFF
--- a/service/kvmconfig/v3/resource/ingress/api_ingress.go
+++ b/service/kvmconfig/v3/resource/ingress/api_ingress.go
@@ -6,7 +6,7 @@ import (
 	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
-	"github.com/giantswarm/kvm-operator/service/kvmconfig/v2/key"
+	"github.com/giantswarm/kvm-operator/service/kvmconfig/v3/key"
 )
 
 func newAPIIngress(customObject v1alpha1.KVMConfig) *extensionsv1.Ingress {

--- a/service/kvmconfig/v3/resource/ingress/api_ingress.go
+++ b/service/kvmconfig/v3/resource/ingress/api_ingress.go
@@ -1,0 +1,59 @@
+package ingress
+
+import (
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	extensionsv1 "k8s.io/api/extensions/v1beta1"
+	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+
+	"github.com/giantswarm/kvm-operator/service/kvmconfig/v2/key"
+)
+
+func newAPIIngress(customObject v1alpha1.KVMConfig) *extensionsv1.Ingress {
+	ingress := &extensionsv1.Ingress{
+		TypeMeta: apismetav1.TypeMeta{
+			Kind:       "Ingress",
+			APIVersion: "extensions/v1beta",
+		},
+		ObjectMeta: apismetav1.ObjectMeta{
+			Name: APIID,
+			Labels: map[string]string{
+				"cluster":  key.ClusterID(customObject),
+				"customer": key.ClusterCustomer(customObject),
+				"app":      key.MasterID,
+			},
+			Annotations: map[string]string{
+				"ingress.kubernetes.io/ssl-passthrough": "true",
+			},
+		},
+		Spec: extensionsv1.IngressSpec{
+			TLS: []extensionsv1.IngressTLS{
+				{
+					Hosts: []string{
+						customObject.Spec.Cluster.Kubernetes.API.Domain,
+					},
+				},
+			},
+			Rules: []extensionsv1.IngressRule{
+				{
+					Host: customObject.Spec.Cluster.Kubernetes.API.Domain,
+					IngressRuleValue: extensionsv1.IngressRuleValue{
+						HTTP: &extensionsv1.HTTPIngressRuleValue{
+							Paths: []extensionsv1.HTTPIngressPath{
+								{
+									Path: "/",
+									Backend: extensionsv1.IngressBackend{
+										ServiceName: key.MasterID,
+										ServicePort: intstr.FromInt(customObject.Spec.Cluster.Kubernetes.API.SecurePort),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	return ingress
+}

--- a/service/kvmconfig/v3/resource/ingress/create.go
+++ b/service/kvmconfig/v3/resource/ingress/create.go
@@ -8,7 +8,7 @@ import (
 	"k8s.io/api/extensions/v1beta1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 
-	"github.com/giantswarm/kvm-operator/service/kvmconfig/v2/key"
+	"github.com/giantswarm/kvm-operator/service/kvmconfig/v3/key"
 )
 
 func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange interface{}) error {

--- a/service/kvmconfig/v3/resource/ingress/create.go
+++ b/service/kvmconfig/v3/resource/ingress/create.go
@@ -1,0 +1,68 @@
+package ingress
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/giantswarm/microerror"
+	"k8s.io/api/extensions/v1beta1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+
+	"github.com/giantswarm/kvm-operator/service/kvmconfig/v2/key"
+)
+
+func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange interface{}) error {
+	customObject, err := key.ToCustomObject(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	ingressesToCreate, err := toIngresses(createChange)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	if len(ingressesToCreate) != 0 {
+		r.logger.LogCtx(ctx, "debug", "creating the ingresses in the Kubernetes API")
+
+		namespace := key.ClusterNamespace(customObject)
+		for _, ingress := range ingressesToCreate {
+			_, err := r.k8sClient.Extensions().Ingresses(namespace).Create(ingress)
+			if apierrors.IsAlreadyExists(err) {
+				// fall through
+			} else if err != nil {
+				return microerror.Mask(err)
+			}
+		}
+
+		r.logger.LogCtx(ctx, "debug", "created the ingresses in the Kubernetes API")
+	} else {
+		r.logger.LogCtx(ctx, "debug", "the ingresses do not need to be created in the Kubernetes API")
+	}
+
+	return nil
+}
+
+func (r *Resource) newCreateChange(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, error) {
+	currentIngresses, err := toIngresses(currentState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+	desiredIngresses, err := toIngresses(desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	r.logger.LogCtx(ctx, "debug", "finding out which ingresses have to be created")
+
+	var ingressesToCreate []*v1beta1.Ingress
+
+	for _, desiredIngress := range desiredIngresses {
+		if !containsIngress(currentIngresses, desiredIngress) {
+			ingressesToCreate = append(ingressesToCreate, desiredIngress)
+		}
+	}
+
+	r.logger.LogCtx(ctx, "debug", fmt.Sprintf("found %d ingresses that have to be created", len(ingressesToCreate)))
+
+	return ingressesToCreate, nil
+}

--- a/service/kvmconfig/v3/resource/ingress/create_test.go
+++ b/service/kvmconfig/v3/resource/ingress/create_test.go
@@ -1,0 +1,243 @@
+package ingress
+
+import (
+	"context"
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/micrologger/microloggertest"
+	"k8s.io/api/extensions/v1beta1"
+	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func Test_Resource_Ingress_newCreateChange(t *testing.T) {
+	testCases := []struct {
+		Obj                  interface{}
+		CurrentState         interface{}
+		DesiredState         interface{}
+		ExpectedIngressNames []string
+	}{
+		// Test 1, in case current state and desired state are empty the create
+		// state should be empty.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState:         []*v1beta1.Ingress{},
+			DesiredState:         []*v1beta1.Ingress{},
+			ExpectedIngressNames: []string{},
+		},
+
+		// Test 2, in case current state equals desired state the create state
+		// should be empty.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState: []*v1beta1.Ingress{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "ingress-1",
+					},
+				},
+			},
+			DesiredState: []*v1beta1.Ingress{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "ingress-1",
+					},
+				},
+			},
+			ExpectedIngressNames: []string{},
+		},
+
+		// Test 3, in case current state misses one item of desired state the create
+		// state should contain the missing item of the desired state.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState: []*v1beta1.Ingress{},
+			DesiredState: []*v1beta1.Ingress{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "ingress-1",
+					},
+				},
+			},
+			ExpectedIngressNames: []string{
+				"ingress-1",
+			},
+		},
+
+		// Test 4, in case current state misses items of desired state the create
+		// state should contain the missing items of the desired state.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState: []*v1beta1.Ingress{},
+			DesiredState: []*v1beta1.Ingress{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "ingress-1",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "ingress-2",
+					},
+				},
+			},
+			ExpectedIngressNames: []string{
+				"ingress-1",
+				"ingress-2",
+			},
+		},
+
+		// Test 5, in case current state contains one item not being in desired
+		// state the create state should not contain the missing item of the desired
+		// state.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState: []*v1beta1.Ingress{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "ingress-1",
+					},
+				},
+			},
+			DesiredState:         []*v1beta1.Ingress{},
+			ExpectedIngressNames: []string{},
+		},
+
+		// Test 6, in case current state contains items not being in desired state
+		// the create state should not contain the missing items of the desired
+		// state.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState: []*v1beta1.Ingress{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "ingress-1",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "ingress-2",
+					},
+				},
+			},
+			DesiredState:         []*v1beta1.Ingress{},
+			ExpectedIngressNames: []string{},
+		},
+
+		// Test 7, in case current state contains some items of desired state the
+		// create state should contain the items being in desired state which are
+		// not in create state.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState: []*v1beta1.Ingress{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "ingress-1",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "ingress-2",
+					},
+				},
+			},
+			DesiredState: []*v1beta1.Ingress{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "ingress-1",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "ingress-2",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "ingress-3",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "ingress-4",
+					},
+				},
+			},
+			ExpectedIngressNames: []string{
+				"ingress-3",
+				"ingress-4",
+			},
+		},
+	}
+
+	var err error
+	var newResource *Resource
+	{
+		resourceConfig := DefaultConfig()
+		resourceConfig.K8sClient = fake.NewSimpleClientset()
+		resourceConfig.Logger = microloggertest.New()
+		newResource, err = New(resourceConfig)
+		if err != nil {
+			t.Fatal("expected", nil, "got", err)
+		}
+	}
+
+	for i, tc := range testCases {
+		result, err := newResource.newCreateChange(context.TODO(), tc.Obj, tc.CurrentState, tc.DesiredState)
+		if err != nil {
+			t.Fatalf("case %d expected %#v got %#v", i+1, nil, err)
+		}
+
+		configMaps, ok := result.([]*v1beta1.Ingress)
+		if !ok {
+			t.Fatalf("case %d expected %T got %T", i+1, []*v1beta1.Ingress{}, result)
+		}
+
+		if len(configMaps) != len(tc.ExpectedIngressNames) {
+			t.Fatalf("case %d expected %d config maps got %d", i+1, len(tc.ExpectedIngressNames), len(configMaps))
+		}
+	}
+}

--- a/service/kvmconfig/v3/resource/ingress/current.go
+++ b/service/kvmconfig/v3/resource/ingress/current.go
@@ -1,0 +1,47 @@
+package ingress
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/giantswarm/microerror"
+	"k8s.io/api/extensions/v1beta1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/giantswarm/kvm-operator/service/kvmconfig/v2/key"
+)
+
+func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interface{}, error) {
+	customObject, err := key.ToCustomObject(obj)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	r.logger.LogCtx(ctx, "debug", "looking for ingresses in the Kubernetes API")
+
+	var ingresses []*v1beta1.Ingress
+
+	namespace := key.ClusterNamespace(customObject)
+	ingressNames := []string{
+		APIID,
+		EtcdID,
+	}
+
+	for _, name := range ingressNames {
+		manifest, err := r.k8sClient.Extensions().Ingresses(namespace).Get(name, apismetav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			r.logger.LogCtx(ctx, "debug", "did not find a ingress in the Kubernetes API")
+			// fall through
+		} else if err != nil {
+			return nil, microerror.Mask(err)
+		} else {
+			r.logger.LogCtx(ctx, "debug", "found a ingress in the Kubernetes API")
+			ingresses = append(ingresses, manifest)
+		}
+	}
+
+	r.logger.LogCtx(ctx, "debug", fmt.Sprintf("found %d ingresses in the Kubernetes API", len(ingresses)))
+
+	return ingresses, nil
+}

--- a/service/kvmconfig/v3/resource/ingress/current.go
+++ b/service/kvmconfig/v3/resource/ingress/current.go
@@ -9,7 +9,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/giantswarm/kvm-operator/service/kvmconfig/v2/key"
+	"github.com/giantswarm/kvm-operator/service/kvmconfig/v3/key"
 )
 
 func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interface{}, error) {

--- a/service/kvmconfig/v3/resource/ingress/delete.go
+++ b/service/kvmconfig/v3/resource/ingress/delete.go
@@ -10,7 +10,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/giantswarm/kvm-operator/service/kvmconfig/v2/key"
+	"github.com/giantswarm/kvm-operator/service/kvmconfig/v3/key"
 )
 
 func (r *Resource) ApplyDeleteChange(ctx context.Context, obj, deleteChange interface{}) error {

--- a/service/kvmconfig/v3/resource/ingress/delete.go
+++ b/service/kvmconfig/v3/resource/ingress/delete.go
@@ -1,0 +1,82 @@
+package ingress
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/operatorkit/framework"
+	"k8s.io/api/extensions/v1beta1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/giantswarm/kvm-operator/service/kvmconfig/v2/key"
+)
+
+func (r *Resource) ApplyDeleteChange(ctx context.Context, obj, deleteChange interface{}) error {
+	customObject, err := key.ToCustomObject(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	ingressesToDelete, err := toIngresses(deleteChange)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	if len(ingressesToDelete) != 0 {
+		r.logger.LogCtx(ctx, "debug", "deleting the ingresses in the Kubernetes API")
+
+		namespace := key.ClusterNamespace(customObject)
+		for _, ingress := range ingressesToDelete {
+			err := r.k8sClient.Extensions().Ingresses(namespace).Delete(ingress.Name, &apismetav1.DeleteOptions{})
+			if apierrors.IsNotFound(err) {
+				// fall through
+			} else if err != nil {
+				return microerror.Mask(err)
+			}
+		}
+
+		r.logger.LogCtx(ctx, "debug", "deleted the ingresses in the Kubernetes API")
+	} else {
+		r.logger.LogCtx(ctx, "debug", "the ingresses do not need to be deleted from the Kubernetes API")
+	}
+
+	return nil
+}
+
+func (r *Resource) NewDeletePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*framework.Patch, error) {
+	delete, err := r.newDeleteChange(ctx, obj, currentState, desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	patch := framework.NewPatch()
+	patch.SetDeleteChange(delete)
+
+	return patch, nil
+}
+
+func (r *Resource) newDeleteChange(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, error) {
+	currentIngresses, err := toIngresses(currentState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+	desiredIngresses, err := toIngresses(desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	r.logger.LogCtx(ctx, "debug", "finding out which ingresses have to be deleted")
+
+	var ingressesToDelete []*v1beta1.Ingress
+
+	for _, currentIngress := range currentIngresses {
+		if containsIngress(desiredIngresses, currentIngress) {
+			ingressesToDelete = append(ingressesToDelete, currentIngress)
+		}
+	}
+
+	r.logger.LogCtx(ctx, "debug", fmt.Sprintf("found %d ingresses that have to be deleted", len(ingressesToDelete)))
+
+	return ingressesToDelete, nil
+}

--- a/service/kvmconfig/v3/resource/ingress/delete_test.go
+++ b/service/kvmconfig/v3/resource/ingress/delete_test.go
@@ -1,0 +1,289 @@
+package ingress
+
+import (
+	"context"
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/micrologger/microloggertest"
+	"k8s.io/api/extensions/v1beta1"
+	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func Test_Resource_Ingress_newDeleteChange(t *testing.T) {
+	testCases := []struct {
+		Obj                  interface{}
+		CurrentState         interface{}
+		DesiredState         interface{}
+		ExpectedIngressNames []string
+	}{
+		// Test 1, in case current state and desired state are empty the delete
+		// state should be empty.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState:         []*v1beta1.Ingress{},
+			DesiredState:         []*v1beta1.Ingress{},
+			ExpectedIngressNames: []string{},
+		},
+
+		// Test 2, in case current state has one item and equals desired state the
+		// delete state should equal the current state.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState: []*v1beta1.Ingress{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "ingress-1",
+					},
+				},
+			},
+			DesiredState: []*v1beta1.Ingress{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "ingress-1",
+					},
+				},
+			},
+			ExpectedIngressNames: []string{
+				"ingress-1",
+			},
+		},
+
+		// Test 3, in case current state misses one item of desired state the delete
+		// state should not contain the missing item of the desired state.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState: []*v1beta1.Ingress{},
+			DesiredState: []*v1beta1.Ingress{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "ingress-1",
+					},
+				},
+			},
+			ExpectedIngressNames: []string{},
+		},
+
+		// Test 4, in case current state misses items of desired state the delete
+		// state should not contain the missing items of the desired state.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState: []*v1beta1.Ingress{},
+			DesiredState: []*v1beta1.Ingress{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "ingress-1",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "ingress-2",
+					},
+				},
+			},
+			ExpectedIngressNames: []string{},
+		},
+
+		// Test 5, in case current state contains one item and desired state is
+		// empty the delete state should be empty.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState: []*v1beta1.Ingress{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "ingress-1",
+					},
+				},
+			},
+			DesiredState:         []*v1beta1.Ingress{},
+			ExpectedIngressNames: []string{},
+		},
+
+		// Test 6, in case current state contains items and desired state is empty
+		// the delete state should be empty.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState: []*v1beta1.Ingress{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "ingress-1",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "ingress-2",
+					},
+				},
+			},
+			DesiredState:         []*v1beta1.Ingress{},
+			ExpectedIngressNames: []string{},
+		},
+
+		// Test 7, in case all items of current state are in desired state and
+		// desired state contains more items not being in current state the create
+		// state should contain all items being in current state.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState: []*v1beta1.Ingress{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "ingress-1",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "ingress-2",
+					},
+				},
+			},
+			DesiredState: []*v1beta1.Ingress{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "ingress-1",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "ingress-2",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "ingress-3",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "ingress-4",
+					},
+				},
+			},
+			ExpectedIngressNames: []string{
+				"ingress-1",
+				"ingress-2",
+			},
+		},
+
+		// Test 8, in case all items of desired state are in current state and
+		// current state contains more items not being in desired state the create
+		// state should contain all items being in desired state.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState: []*v1beta1.Ingress{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "ingress-1",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "ingress-2",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "ingress-3",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "ingress-4",
+					},
+				},
+			},
+			DesiredState: []*v1beta1.Ingress{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "ingress-1",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "ingress-2",
+					},
+				},
+			},
+			ExpectedIngressNames: []string{
+				"ingress-1",
+				"ingress-2",
+			},
+		},
+	}
+
+	var err error
+	var newResource *Resource
+	{
+		resourceConfig := DefaultConfig()
+		resourceConfig.K8sClient = fake.NewSimpleClientset()
+		resourceConfig.Logger = microloggertest.New()
+		newResource, err = New(resourceConfig)
+		if err != nil {
+			t.Fatal("expected", nil, "got", err)
+		}
+	}
+
+	for i, tc := range testCases {
+		result, err := newResource.newDeleteChange(context.TODO(), tc.Obj, tc.CurrentState, tc.DesiredState)
+		if err != nil {
+			t.Fatalf("case %d expected %#v got %#v", i+1, nil, err)
+		}
+
+		configMaps, ok := result.([]*v1beta1.Ingress)
+		if !ok {
+			t.Fatalf("case %d expected %T got %T", i+1, []*v1beta1.Ingress{}, result)
+		}
+
+		if len(configMaps) != len(tc.ExpectedIngressNames) {
+			t.Fatalf("case %d expected %d config maps got %d", i+1, len(tc.ExpectedIngressNames), len(configMaps))
+		}
+	}
+}

--- a/service/kvmconfig/v3/resource/ingress/desired.go
+++ b/service/kvmconfig/v3/resource/ingress/desired.go
@@ -7,7 +7,7 @@ import (
 	"github.com/giantswarm/microerror"
 	"k8s.io/api/extensions/v1beta1"
 
-	"github.com/giantswarm/kvm-operator/service/kvmconfig/v2/key"
+	"github.com/giantswarm/kvm-operator/service/kvmconfig/v3/key"
 )
 
 func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interface{}, error) {

--- a/service/kvmconfig/v3/resource/ingress/desired.go
+++ b/service/kvmconfig/v3/resource/ingress/desired.go
@@ -1,0 +1,29 @@
+package ingress
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/giantswarm/microerror"
+	"k8s.io/api/extensions/v1beta1"
+
+	"github.com/giantswarm/kvm-operator/service/kvmconfig/v2/key"
+)
+
+func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interface{}, error) {
+	customObject, err := key.ToCustomObject(obj)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	r.logger.LogCtx(ctx, "debug", "computing the new ingresses")
+
+	var ingresses []*v1beta1.Ingress
+
+	ingresses = append(ingresses, newAPIIngress(customObject))
+	ingresses = append(ingresses, newEtcdIngress(customObject))
+
+	r.logger.LogCtx(ctx, "debug", fmt.Sprintf("computed the %d new ingresses", len(ingresses)))
+
+	return ingresses, nil
+}

--- a/service/kvmconfig/v3/resource/ingress/desired_test.go
+++ b/service/kvmconfig/v3/resource/ingress/desired_test.go
@@ -1,0 +1,145 @@
+package ingress
+
+import (
+	"context"
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/micrologger/microloggertest"
+	"k8s.io/api/extensions/v1beta1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func Test_Resource_Ingress_GetDesiredState(t *testing.T) {
+	testCases := []struct {
+		Obj               interface{}
+		ExpectedAPICount  int
+		ExpectedEtcdCount int
+	}{
+		// Test 1 ensures there is one ingress for master and worker each when there
+		// is one master and one worker node in the custom object.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+						Masters: []v1alpha1.ClusterNode{
+							{},
+						},
+						Workers: []v1alpha1.ClusterNode{
+							{},
+						},
+					},
+				},
+			},
+			ExpectedAPICount:  1,
+			ExpectedEtcdCount: 1,
+		},
+
+		// Test 2 ensures there is one ingress for master and worker each when there
+		// is one master and three worker nodes in the custom object.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+						Masters: []v1alpha1.ClusterNode{
+							{},
+						},
+						Workers: []v1alpha1.ClusterNode{
+							{},
+							{},
+							{},
+						},
+					},
+				},
+			},
+			ExpectedAPICount:  1,
+			ExpectedEtcdCount: 1,
+		},
+
+		// Test 3 ensures there is one ingress for master and worker each when there
+		// are three master and three worker nodes in the custom object.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+						Masters: []v1alpha1.ClusterNode{
+							{},
+							{},
+							{},
+						},
+						Workers: []v1alpha1.ClusterNode{
+							{},
+							{},
+							{},
+						},
+					},
+				},
+			},
+			ExpectedAPICount:  1,
+			ExpectedEtcdCount: 1,
+		},
+	}
+
+	var err error
+	var newResource *Resource
+	{
+		resourceConfig := DefaultConfig()
+		resourceConfig.K8sClient = fake.NewSimpleClientset()
+		resourceConfig.Logger = microloggertest.New()
+		newResource, err = New(resourceConfig)
+		if err != nil {
+			t.Fatal("expected", nil, "got", err)
+		}
+	}
+
+	for i, tc := range testCases {
+		result, err := newResource.GetDesiredState(context.TODO(), tc.Obj)
+		if err != nil {
+			t.Fatalf("case %d expected %#v got %#v", i+1, nil, err)
+		}
+
+		ingresses, ok := result.([]*v1beta1.Ingress)
+		if !ok {
+			t.Fatalf("case %d expected %T got %T", i+1, []*v1beta1.Ingress{}, result)
+		}
+
+		if testGetAPICount(ingresses) != tc.ExpectedAPICount {
+			t.Fatalf("case %d expected %d master nodes got %d", i+1, tc.ExpectedAPICount, testGetAPICount(ingresses))
+		}
+
+		if testGetEtcdCount(ingresses) != tc.ExpectedEtcdCount {
+			t.Fatalf("case %d expected %d worker nodes got %d", i+1, tc.ExpectedEtcdCount, testGetEtcdCount(ingresses))
+		}
+
+		if len(ingresses) != tc.ExpectedAPICount+tc.ExpectedEtcdCount {
+			t.Fatalf("case %d expected %d nodes got %d", i+1, tc.ExpectedAPICount+tc.ExpectedEtcdCount, len(ingresses))
+		}
+	}
+}
+
+func testGetAPICount(ingresses []*v1beta1.Ingress) int {
+	var count int
+
+	for _, i := range ingresses {
+		if i.Name == "api" {
+			count++
+		}
+	}
+
+	return count
+}
+
+func testGetEtcdCount(ingresses []*v1beta1.Ingress) int {
+	var count int
+
+	for _, i := range ingresses {
+		if i.Name == "etcd" {
+			count++
+		}
+	}
+
+	return count
+}

--- a/service/kvmconfig/v3/resource/ingress/error.go
+++ b/service/kvmconfig/v3/resource/ingress/error.go
@@ -1,0 +1,17 @@
+package ingress
+
+import "github.com/giantswarm/microerror"
+
+var invalidConfigError = microerror.New("invalid config")
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var wrongTypeError = microerror.New("wrong type")
+
+// IsWrongTypeError asserts wrongTypeError.
+func IsWrongTypeError(err error) bool {
+	return microerror.Cause(err) == wrongTypeError
+}

--- a/service/kvmconfig/v3/resource/ingress/etcd_ingress.go
+++ b/service/kvmconfig/v3/resource/ingress/etcd_ingress.go
@@ -1,0 +1,59 @@
+package ingress
+
+import (
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	extensionsv1 "k8s.io/api/extensions/v1beta1"
+	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+
+	"github.com/giantswarm/kvm-operator/service/kvmconfig/v2/key"
+)
+
+func newEtcdIngress(customObject v1alpha1.KVMConfig) *extensionsv1.Ingress {
+	ingress := &extensionsv1.Ingress{
+		TypeMeta: apismetav1.TypeMeta{
+			Kind:       "Ingress",
+			APIVersion: "extensions/v1beta",
+		},
+		ObjectMeta: apismetav1.ObjectMeta{
+			Name: EtcdID,
+			Labels: map[string]string{
+				"cluster":  key.ClusterID(customObject),
+				"customer": key.ClusterCustomer(customObject),
+				"app":      key.MasterID,
+			},
+			Annotations: map[string]string{
+				"ingress.kubernetes.io/ssl-passthrough": "true",
+			},
+		},
+		Spec: extensionsv1.IngressSpec{
+			TLS: []extensionsv1.IngressTLS{
+				{
+					Hosts: []string{
+						customObject.Spec.Cluster.Etcd.Domain,
+					},
+				},
+			},
+			Rules: []extensionsv1.IngressRule{
+				{
+					Host: customObject.Spec.Cluster.Etcd.Domain,
+					IngressRuleValue: extensionsv1.IngressRuleValue{
+						HTTP: &extensionsv1.HTTPIngressRuleValue{
+							Paths: []extensionsv1.HTTPIngressPath{
+								{
+									Path: "/",
+									Backend: extensionsv1.IngressBackend{
+										ServiceName: key.MasterID,
+										ServicePort: intstr.FromInt(2379),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	return ingress
+}

--- a/service/kvmconfig/v3/resource/ingress/etcd_ingress.go
+++ b/service/kvmconfig/v3/resource/ingress/etcd_ingress.go
@@ -6,7 +6,7 @@ import (
 	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
-	"github.com/giantswarm/kvm-operator/service/kvmconfig/v2/key"
+	"github.com/giantswarm/kvm-operator/service/kvmconfig/v3/key"
 )
 
 func newEtcdIngress(customObject v1alpha1.KVMConfig) *extensionsv1.Ingress {

--- a/service/kvmconfig/v3/resource/ingress/resource.go
+++ b/service/kvmconfig/v3/resource/ingress/resource.go
@@ -1,0 +1,92 @@
+package ingress
+
+import (
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/giantswarm/operatorkit/framework"
+	"k8s.io/api/extensions/v1beta1"
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	APIID  = "api"
+	EtcdID = "etcd"
+	// Name is the identifier of the resource.
+	Name = "ingressv2"
+)
+
+// Config represents the configuration used to create a new ingress resource.
+type Config struct {
+	// Dependencies.
+	K8sClient kubernetes.Interface
+	Logger    micrologger.Logger
+}
+
+// DefaultConfig provides a default configuration to create a new ingress
+// resource by best effort.
+func DefaultConfig() Config {
+	return Config{
+		// Dependencies.
+		K8sClient: nil,
+		Logger:    nil,
+	}
+}
+
+// Resource implements the ingress resource.
+type Resource struct {
+	// Dependencies.
+	k8sClient kubernetes.Interface
+	logger    micrologger.Logger
+}
+
+// New creates a new configured ingress resource.
+func New(config Config) (*Resource, error) {
+	// Dependencies.
+	if config.K8sClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "config.K8sClient must not be empty")
+	}
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "config.Logger must not be empty")
+	}
+
+	newResource := &Resource{
+		// Dependencies.
+		k8sClient: config.K8sClient,
+		logger: config.Logger.With(
+			"resource", Name,
+		),
+	}
+
+	return newResource, nil
+}
+
+func (r *Resource) Name() string {
+	return Name
+}
+
+func (r *Resource) Underlying() framework.Resource {
+	return r
+}
+
+func containsIngress(list []*v1beta1.Ingress, item *v1beta1.Ingress) bool {
+	for _, l := range list {
+		if l.Name == item.Name {
+			return true
+		}
+	}
+
+	return false
+}
+
+func toIngresses(v interface{}) ([]*v1beta1.Ingress, error) {
+	if v == nil {
+		return nil, nil
+	}
+
+	ingresses, ok := v.([]*v1beta1.Ingress)
+	if !ok {
+		return nil, microerror.Maskf(wrongTypeError, "expected '%T', got '%T'", []*v1beta1.Ingress{}, v)
+	}
+
+	return ingresses, nil
+}

--- a/service/kvmconfig/v3/resource/ingress/update.go
+++ b/service/kvmconfig/v3/resource/ingress/update.go
@@ -1,0 +1,34 @@
+package ingress
+
+import (
+	"context"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/operatorkit/framework"
+)
+
+func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateChange interface{}) error {
+	return nil
+}
+
+func (r *Resource) NewUpdatePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*framework.Patch, error) {
+	create, err := r.newCreateChange(ctx, obj, currentState, desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	update, err := r.newUpdateChange(ctx, obj, currentState, desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	patch := framework.NewPatch()
+	patch.SetCreateChange(create)
+	patch.SetUpdateChange(update)
+
+	return patch, nil
+}
+
+func (r *Resource) newUpdateChange(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, error) {
+	return nil, nil
+}

--- a/service/kvmconfig/v3/resource/namespace/create.go
+++ b/service/kvmconfig/v3/resource/namespace/create.go
@@ -1,0 +1,55 @@
+package namespace
+
+import (
+	"context"
+
+	"github.com/giantswarm/microerror"
+	apiv1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+)
+
+func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange interface{}) error {
+	namespaceToCreate, err := toNamespace(createChange)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	if namespaceToCreate != nil {
+		r.logger.LogCtx(ctx, "debug", "creating the namespace in the Kubernetes API")
+
+		_, err = r.k8sClient.CoreV1().Namespaces().Create(namespaceToCreate)
+		if apierrors.IsAlreadyExists(err) {
+			// fall through
+		} else if err != nil {
+			return microerror.Mask(err)
+		}
+
+		r.logger.LogCtx(ctx, "debug", "created the namespace in the Kubernetes API")
+	} else {
+		r.logger.LogCtx(ctx, "debug", "the namespace does not need to be created in the Kubernetes API")
+	}
+
+	return nil
+}
+
+func (r *Resource) newCreateChange(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, error) {
+	currentNamespace, err := toNamespace(currentState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+	desiredNamespace, err := toNamespace(desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	r.logger.LogCtx(ctx, "debug", "finding out if the namespace has to be created")
+
+	var namespaceToCreate *apiv1.Namespace
+	if currentNamespace == nil {
+		namespaceToCreate = desiredNamespace
+	}
+
+	r.logger.LogCtx(ctx, "debug", "found out if the namespace has to be created")
+
+	return namespaceToCreate, nil
+}

--- a/service/kvmconfig/v3/resource/namespace/create_test.go
+++ b/service/kvmconfig/v3/resource/namespace/create_test.go
@@ -1,0 +1,124 @@
+package namespace
+
+import (
+	"context"
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/micrologger/microloggertest"
+	apiv1 "k8s.io/api/core/v1"
+	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func Test_Resource_Namespace_newCreateChange(t *testing.T) {
+	testCases := []struct {
+		Obj               interface{}
+		Cur               interface{}
+		Des               interface{}
+		ExpectedNamespace *apiv1.Namespace
+	}{
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "foobar",
+					},
+				},
+			},
+			Cur: &apiv1.Namespace{
+				TypeMeta: apismetav1.TypeMeta{
+					Kind:       "Namespace",
+					APIVersion: "v1",
+				},
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name: "al9qy",
+					Labels: map[string]string{
+						"cluster":  "al9qy",
+						"customer": "test-customer",
+					},
+				},
+			},
+			Des: &apiv1.Namespace{
+				TypeMeta: apismetav1.TypeMeta{
+					Kind:       "Namespace",
+					APIVersion: "v1",
+				},
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name: "al9qy",
+					Labels: map[string]string{
+						"cluster":  "al9qy",
+						"customer": "test-customer",
+					},
+				},
+			},
+			ExpectedNamespace: nil,
+		},
+
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "foobar",
+					},
+				},
+			},
+			Cur: nil,
+			Des: &apiv1.Namespace{
+				TypeMeta: apismetav1.TypeMeta{
+					Kind:       "Namespace",
+					APIVersion: "v1",
+				},
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name: "al9qy",
+					Labels: map[string]string{
+						"cluster":  "al9qy",
+						"customer": "test-customer",
+					},
+				},
+			},
+			ExpectedNamespace: &apiv1.Namespace{
+				TypeMeta: apismetav1.TypeMeta{
+					Kind:       "Namespace",
+					APIVersion: "v1",
+				},
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name: "al9qy",
+					Labels: map[string]string{
+						"cluster":  "al9qy",
+						"customer": "test-customer",
+					},
+				},
+			},
+		},
+	}
+
+	var err error
+	var newResource *Resource
+	{
+		resourceConfig := DefaultConfig()
+		resourceConfig.K8sClient = fake.NewSimpleClientset()
+		resourceConfig.Logger = microloggertest.New()
+		newResource, err = New(resourceConfig)
+		if err != nil {
+			t.Fatal("expected", nil, "got", err)
+		}
+	}
+
+	for i, tc := range testCases {
+		result, err := newResource.newCreateChange(context.TODO(), tc.Obj, tc.Cur, tc.Des)
+		if err != nil {
+			t.Fatal("case", i+1, "expected", nil, "got", err)
+		}
+		if tc.ExpectedNamespace == nil {
+			if tc.ExpectedNamespace != result {
+				t.Fatal("case", i+1, "expected", tc.ExpectedNamespace, "got", result)
+			}
+		} else {
+			name := result.(*apiv1.Namespace).Name
+			if tc.ExpectedNamespace.Name != name {
+				t.Fatal("case", i+1, "expected", tc.ExpectedNamespace.Name, "got", name)
+			}
+		}
+	}
+}

--- a/service/kvmconfig/v3/resource/namespace/current.go
+++ b/service/kvmconfig/v3/resource/namespace/current.go
@@ -1,0 +1,53 @@
+package namespace
+
+import (
+	"context"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/operatorkit/framework/context/reconciliationcanceledcontext"
+	apiv1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/giantswarm/kvm-operator/service/kvmconfig/v2/key"
+)
+
+func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interface{}, error) {
+	customObject, err := key.ToCustomObject(obj)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	r.logger.LogCtx(ctx, "debug", "looking for the namespace in the Kubernetes API")
+
+	// Lookup the current state of the namespace.
+	var namespace *apiv1.Namespace
+	{
+		manifest, err := r.k8sClient.CoreV1().Namespaces().Get(key.ClusterNamespace(customObject), apismetav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			r.logger.LogCtx(ctx, "debug", "did not find the namespace in the Kubernetes API")
+			// fall through
+		} else if err != nil {
+			return nil, microerror.Mask(err)
+		} else {
+			r.logger.LogCtx(ctx, "debug", "found the namespace in the Kubernetes API")
+			namespace = manifest
+		}
+	}
+
+	// In case the namespace is already terminating we do not need to do any
+	// further work. Then we cancel the reconciliation to prevent the current and
+	// any further resource from being processed.
+	if namespace != nil && namespace.Status.Phase == "Terminating" {
+		r.logger.LogCtx(ctx, "debug", "namespace is in state 'Terminating'")
+
+		reconciliationcanceledcontext.SetCanceled(ctx)
+		if reconciliationcanceledcontext.IsCanceled(ctx) {
+			r.logger.LogCtx(ctx, "debug", "canceling reconciliation for custom object")
+
+			return nil, nil
+		}
+	}
+
+	return namespace, nil
+}

--- a/service/kvmconfig/v3/resource/namespace/current.go
+++ b/service/kvmconfig/v3/resource/namespace/current.go
@@ -9,7 +9,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/giantswarm/kvm-operator/service/kvmconfig/v2/key"
+	"github.com/giantswarm/kvm-operator/service/kvmconfig/v3/key"
 )
 
 func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interface{}, error) {

--- a/service/kvmconfig/v3/resource/namespace/current_test.go
+++ b/service/kvmconfig/v3/resource/namespace/current_test.go
@@ -1,0 +1,52 @@
+package namespace
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/micrologger/microloggertest"
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func Test_Resource_Namespace_GetCurrentState(t *testing.T) {
+	testCases := []struct {
+		Obj               interface{}
+		ExpectedNamespace *apiv1.Namespace
+	}{
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			ExpectedNamespace: nil,
+		},
+	}
+
+	var err error
+	var newResource *Resource
+	{
+		resourceConfig := DefaultConfig()
+		resourceConfig.K8sClient = fake.NewSimpleClientset()
+		resourceConfig.Logger = microloggertest.New()
+		newResource, err = New(resourceConfig)
+		if err != nil {
+			t.Fatal("expected", nil, "got", err)
+		}
+	}
+
+	for i, tc := range testCases {
+		result, err := newResource.GetCurrentState(context.TODO(), tc.Obj)
+		if err != nil {
+			t.Fatal("case", i+1, "expected", nil, "got", err)
+		}
+		if !reflect.DeepEqual(tc.ExpectedNamespace, result) {
+			t.Fatalf("case %d expected %#v got %#v", i+1, tc.ExpectedNamespace, result)
+		}
+	}
+}

--- a/service/kvmconfig/v3/resource/namespace/delete.go
+++ b/service/kvmconfig/v3/resource/namespace/delete.go
@@ -1,0 +1,69 @@
+package namespace
+
+import (
+	"context"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/operatorkit/framework"
+	apiv1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func (r *Resource) ApplyDeleteChange(ctx context.Context, obj, deleteChange interface{}) error {
+	namespaceToDelete, err := toNamespace(deleteChange)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	if namespaceToDelete != nil {
+		r.logger.LogCtx(ctx, "debug", "deleting the namespace in the Kubernetes API")
+
+		err = r.k8sClient.CoreV1().Namespaces().Delete(namespaceToDelete.Name, &apismetav1.DeleteOptions{})
+		if apierrors.IsNotFound(err) {
+			// fall through
+		} else if err != nil {
+			return microerror.Mask(err)
+		}
+
+		r.logger.LogCtx(ctx, "debug", "deleted the namespace in the Kubernetes API")
+	} else {
+		r.logger.LogCtx(ctx, "debug", "the namespace does not need to be deleted from the Kubernetes API")
+	}
+
+	return nil
+}
+
+func (r *Resource) NewDeletePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*framework.Patch, error) {
+	delete, err := r.newDeleteChange(ctx, obj, currentState, desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	patch := framework.NewPatch()
+	patch.SetDeleteChange(delete)
+
+	return patch, nil
+}
+
+func (r *Resource) newDeleteChange(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, error) {
+	currentNamespace, err := toNamespace(currentState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+	desiredNamespace, err := toNamespace(desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	r.logger.LogCtx(ctx, "debug", "finding out if the namespace has to be deleted")
+
+	var namespaceToDelete *apiv1.Namespace
+	if currentNamespace != nil {
+		namespaceToDelete = desiredNamespace
+	}
+
+	r.logger.LogCtx(ctx, "debug", "found out if the namespace has to be deleted")
+
+	return namespaceToDelete, nil
+}

--- a/service/kvmconfig/v3/resource/namespace/delete_test.go
+++ b/service/kvmconfig/v3/resource/namespace/delete_test.go
@@ -1,0 +1,124 @@
+package namespace
+
+import (
+	"context"
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/micrologger/microloggertest"
+	apiv1 "k8s.io/api/core/v1"
+	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func Test_Resource_Namespace_newDeleteChange(t *testing.T) {
+	testCases := []struct {
+		Obj               interface{}
+		Cur               interface{}
+		Des               interface{}
+		ExpectedNamespace *apiv1.Namespace
+	}{
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "foobar",
+					},
+				},
+			},
+			Cur: &apiv1.Namespace{
+				TypeMeta: apismetav1.TypeMeta{
+					Kind:       "Namespace",
+					APIVersion: "v1",
+				},
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name: "al9qy",
+					Labels: map[string]string{
+						"cluster":  "al9qy",
+						"customer": "test-customer",
+					},
+				},
+			},
+			Des: &apiv1.Namespace{
+				TypeMeta: apismetav1.TypeMeta{
+					Kind:       "Namespace",
+					APIVersion: "v1",
+				},
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name: "al9qy",
+					Labels: map[string]string{
+						"cluster":  "al9qy",
+						"customer": "test-customer",
+					},
+				},
+			},
+			ExpectedNamespace: &apiv1.Namespace{
+				TypeMeta: apismetav1.TypeMeta{
+					Kind:       "Namespace",
+					APIVersion: "v1",
+				},
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name: "al9qy",
+					Labels: map[string]string{
+						"cluster":  "al9qy",
+						"customer": "test-customer",
+					},
+				},
+			},
+		},
+
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "foobar",
+					},
+				},
+			},
+			Cur: nil,
+			Des: &apiv1.Namespace{
+				TypeMeta: apismetav1.TypeMeta{
+					Kind:       "Namespace",
+					APIVersion: "v1",
+				},
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name: "al9qy",
+					Labels: map[string]string{
+						"cluster":  "al9qy",
+						"customer": "test-customer",
+					},
+				},
+			},
+			ExpectedNamespace: nil,
+		},
+	}
+
+	var err error
+	var newResource *Resource
+	{
+		resourceConfig := DefaultConfig()
+		resourceConfig.K8sClient = fake.NewSimpleClientset()
+		resourceConfig.Logger = microloggertest.New()
+		newResource, err = New(resourceConfig)
+		if err != nil {
+			t.Fatal("expected", nil, "got", err)
+		}
+	}
+
+	for i, tc := range testCases {
+		result, err := newResource.newDeleteChange(context.TODO(), tc.Obj, tc.Cur, tc.Des)
+		if err != nil {
+			t.Fatal("case", i+1, "expected", nil, "got", err)
+		}
+		if tc.ExpectedNamespace == nil {
+			if tc.ExpectedNamespace != result {
+				t.Fatal("case", i+1, "expected", tc.ExpectedNamespace, "got", result)
+			}
+		} else {
+			name := result.(*apiv1.Namespace).Name
+			if tc.ExpectedNamespace.Name != name {
+				t.Fatal("case", i+1, "expected", tc.ExpectedNamespace.Name, "got", name)
+			}
+		}
+	}
+}

--- a/service/kvmconfig/v3/resource/namespace/desired.go
+++ b/service/kvmconfig/v3/resource/namespace/desired.go
@@ -1,0 +1,40 @@
+package namespace
+
+import (
+	"context"
+
+	"github.com/giantswarm/microerror"
+	apiv1 "k8s.io/api/core/v1"
+	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/giantswarm/kvm-operator/service/kvmconfig/v2/key"
+)
+
+func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interface{}, error) {
+	customObject, err := key.ToCustomObject(obj)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	r.logger.LogCtx(ctx, "debug", "computing the desired namespace")
+
+	// Compute the desired state of the namespace to have a reference of data how
+	// it should be.
+	namespace := &apiv1.Namespace{
+		TypeMeta: apismetav1.TypeMeta{
+			Kind:       "Namespace",
+			APIVersion: "v1",
+		},
+		ObjectMeta: apismetav1.ObjectMeta{
+			Name: key.ClusterNamespace(customObject),
+			Labels: map[string]string{
+				"cluster":  key.ClusterID(customObject),
+				"customer": key.ClusterCustomer(customObject),
+			},
+		},
+	}
+
+	r.logger.LogCtx(ctx, "debug", "computed the desired namespace")
+
+	return namespace, nil
+}

--- a/service/kvmconfig/v3/resource/namespace/desired.go
+++ b/service/kvmconfig/v3/resource/namespace/desired.go
@@ -7,7 +7,7 @@ import (
 	apiv1 "k8s.io/api/core/v1"
 	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/giantswarm/kvm-operator/service/kvmconfig/v2/key"
+	"github.com/giantswarm/kvm-operator/service/kvmconfig/v3/key"
 )
 
 func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interface{}, error) {

--- a/service/kvmconfig/v3/resource/namespace/desired_test.go
+++ b/service/kvmconfig/v3/resource/namespace/desired_test.go
@@ -1,0 +1,62 @@
+package namespace
+
+import (
+	"context"
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/micrologger/microloggertest"
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func Test_Resource_Namespace_GetDesiredState(t *testing.T) {
+	testCases := []struct {
+		Obj          interface{}
+		ExpectedName string
+	}{
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			ExpectedName: "al9qy",
+		},
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "foobar",
+					},
+				},
+			},
+			ExpectedName: "foobar",
+		},
+	}
+
+	var err error
+	var newResource *Resource
+	{
+		resourceConfig := DefaultConfig()
+		resourceConfig.K8sClient = fake.NewSimpleClientset()
+		resourceConfig.Logger = microloggertest.New()
+		newResource, err = New(resourceConfig)
+		if err != nil {
+			t.Fatal("expected", nil, "got", err)
+		}
+	}
+
+	for i, tc := range testCases {
+		result, err := newResource.GetDesiredState(context.TODO(), tc.Obj)
+		if err != nil {
+			t.Fatal("case", i+1, "expected", nil, "got", err)
+		}
+		name := result.(*apiv1.Namespace).Name
+		if tc.ExpectedName != name {
+			t.Fatalf("case %d expected %#v got %#v", i+1, tc.ExpectedName, name)
+		}
+	}
+}

--- a/service/kvmconfig/v3/resource/namespace/error.go
+++ b/service/kvmconfig/v3/resource/namespace/error.go
@@ -1,0 +1,17 @@
+package namespace
+
+import "github.com/giantswarm/microerror"
+
+var invalidConfigError = microerror.New("invalid config")
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var wrongTypeError = microerror.New("wrong type")
+
+// IsWrongTypeError asserts wrongTypeError.
+func IsWrongTypeError(err error) bool {
+	return microerror.Cause(err) == wrongTypeError
+}

--- a/service/kvmconfig/v3/resource/namespace/resource.go
+++ b/service/kvmconfig/v3/resource/namespace/resource.go
@@ -1,0 +1,80 @@
+package namespace
+
+import (
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/giantswarm/operatorkit/framework"
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	// Name is the identifier of the resource.
+	Name = "namespacev2"
+)
+
+// Config represents the configuration used to create a new cloud config resource.
+type Config struct {
+	// Dependencies.
+	K8sClient kubernetes.Interface
+	Logger    micrologger.Logger
+}
+
+// DefaultConfig provides a default configuration to create a new cloud config
+// resource by best effort.
+func DefaultConfig() Config {
+	return Config{
+		// Dependencies.
+		K8sClient: nil,
+		Logger:    nil,
+	}
+}
+
+// Resource implements the cloud config resource.
+type Resource struct {
+	// Dependencies.
+	k8sClient kubernetes.Interface
+	logger    micrologger.Logger
+}
+
+// New creates a new configured cloud config resource.
+func New(config Config) (*Resource, error) {
+	// Dependencies.
+	if config.K8sClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "config.K8sClient must not be empty")
+	}
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "config.Logger must not be empty")
+	}
+
+	newService := &Resource{
+		// Dependencies.
+		k8sClient: config.K8sClient,
+		logger: config.Logger.With(
+			"resource", Name,
+		),
+	}
+
+	return newService, nil
+}
+
+func (r *Resource) Name() string {
+	return Name
+}
+
+func (r *Resource) Underlying() framework.Resource {
+	return r
+}
+
+func toNamespace(v interface{}) (*apiv1.Namespace, error) {
+	if v == nil {
+		return nil, nil
+	}
+
+	namespace, ok := v.(*apiv1.Namespace)
+	if !ok {
+		return nil, microerror.Maskf(wrongTypeError, "expected '%T', got '%T'", &apiv1.Namespace{}, v)
+	}
+
+	return namespace, nil
+}

--- a/service/kvmconfig/v3/resource/namespace/update.go
+++ b/service/kvmconfig/v3/resource/namespace/update.go
@@ -1,0 +1,34 @@
+package namespace
+
+import (
+	"context"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/operatorkit/framework"
+)
+
+func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateChange interface{}) error {
+	return nil
+}
+
+func (r *Resource) NewUpdatePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*framework.Patch, error) {
+	create, err := r.newCreateChange(ctx, obj, currentState, desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	update, err := r.newUpdateChange(ctx, obj, currentState, desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	patch := framework.NewPatch()
+	patch.SetCreateChange(create)
+	patch.SetUpdateChange(update)
+
+	return patch, nil
+}
+
+func (r *Resource) newUpdateChange(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, error) {
+	return nil, nil
+}

--- a/service/kvmconfig/v3/resource/pvc/create.go
+++ b/service/kvmconfig/v3/resource/pvc/create.go
@@ -1,0 +1,68 @@
+package pvc
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/giantswarm/microerror"
+	apiv1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+
+	"github.com/giantswarm/kvm-operator/service/kvmconfig/v2/key"
+)
+
+func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange interface{}) error {
+	customObject, err := key.ToCustomObject(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	pvcsToCreate, err := toPVCs(createChange)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	if len(pvcsToCreate) != 0 {
+		r.logger.LogCtx(ctx, "debug", "creating the PVCs in the Kubernetes API")
+
+		namespace := key.ClusterNamespace(customObject)
+		for _, PVC := range pvcsToCreate {
+			_, err := r.k8sClient.Core().PersistentVolumeClaims(namespace).Create(PVC)
+			if apierrors.IsAlreadyExists(err) {
+				// fall through
+			} else if err != nil {
+				return microerror.Mask(err)
+			}
+		}
+
+		r.logger.LogCtx(ctx, "debug", "created the PVCs in the Kubernetes API")
+	} else {
+		r.logger.LogCtx(ctx, "debug", "the PVCs do not need to be created in the Kubernetes API")
+	}
+
+	return nil
+}
+
+func (r *Resource) newCreateChange(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, error) {
+	currentPVCs, err := toPVCs(currentState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+	desiredPVCs, err := toPVCs(desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	r.logger.LogCtx(ctx, "debug", "finding out which PVCs have to be created")
+
+	var pvcsToCreate []*apiv1.PersistentVolumeClaim
+
+	for _, desiredPVC := range desiredPVCs {
+		if !containsPVC(currentPVCs, desiredPVC) {
+			pvcsToCreate = append(pvcsToCreate, desiredPVC)
+		}
+	}
+
+	r.logger.LogCtx(ctx, "debug", fmt.Sprintf("found %d PVCs that have to be created", len(pvcsToCreate)))
+
+	return pvcsToCreate, nil
+}

--- a/service/kvmconfig/v3/resource/pvc/create.go
+++ b/service/kvmconfig/v3/resource/pvc/create.go
@@ -8,7 +8,7 @@ import (
 	apiv1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 
-	"github.com/giantswarm/kvm-operator/service/kvmconfig/v2/key"
+	"github.com/giantswarm/kvm-operator/service/kvmconfig/v3/key"
 )
 
 func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange interface{}) error {

--- a/service/kvmconfig/v3/resource/pvc/create_test.go
+++ b/service/kvmconfig/v3/resource/pvc/create_test.go
@@ -1,0 +1,243 @@
+package pvc
+
+import (
+	"context"
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/micrologger/microloggertest"
+	apiv1 "k8s.io/api/core/v1"
+	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func Test_Resource_PVC_newCreateChange(t *testing.T) {
+	testCases := []struct {
+		Obj              interface{}
+		CurrentState     interface{}
+		DesiredState     interface{}
+		ExpectedPVCNames []string
+	}{
+		// Test 1, in case current state and desired state are empty the create
+		// state should be empty.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState:     []*apiv1.PersistentVolumeClaim{},
+			DesiredState:     []*apiv1.PersistentVolumeClaim{},
+			ExpectedPVCNames: []string{},
+		},
+
+		// Test 2, in case current state equals desired state the create state
+		// should be empty.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState: []*apiv1.PersistentVolumeClaim{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "pvc-1",
+					},
+				},
+			},
+			DesiredState: []*apiv1.PersistentVolumeClaim{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "pvc-1",
+					},
+				},
+			},
+			ExpectedPVCNames: []string{},
+		},
+
+		// Test 3, in case current state misses one item of desired state the create
+		// state should contain the missing item of the desired state.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState: []*apiv1.PersistentVolumeClaim{},
+			DesiredState: []*apiv1.PersistentVolumeClaim{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "pvc-1",
+					},
+				},
+			},
+			ExpectedPVCNames: []string{
+				"pvc-1",
+			},
+		},
+
+		// Test 4, in case current state misses items of desired state the create
+		// state should contain the missing items of the desired state.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState: []*apiv1.PersistentVolumeClaim{},
+			DesiredState: []*apiv1.PersistentVolumeClaim{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "pvc-1",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "pvc-2",
+					},
+				},
+			},
+			ExpectedPVCNames: []string{
+				"pvc-1",
+				"pvc-2",
+			},
+		},
+
+		// Test 5, in case current state contains one item not being in desired
+		// state the create state should not contain the missing item of the desired
+		// state.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState: []*apiv1.PersistentVolumeClaim{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "pvc-1",
+					},
+				},
+			},
+			DesiredState:     []*apiv1.PersistentVolumeClaim{},
+			ExpectedPVCNames: []string{},
+		},
+
+		// Test 6, in case current state contains items not being in desired state
+		// the create state should not contain the missing items of the desired
+		// state.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState: []*apiv1.PersistentVolumeClaim{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "pvc-1",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "pvc-2",
+					},
+				},
+			},
+			DesiredState:     []*apiv1.PersistentVolumeClaim{},
+			ExpectedPVCNames: []string{},
+		},
+
+		// Test 7, in case current state contains some items of desired state the
+		// create state should contain the items being in desired state which are
+		// not in create state.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState: []*apiv1.PersistentVolumeClaim{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "pvc-1",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "pvc-2",
+					},
+				},
+			},
+			DesiredState: []*apiv1.PersistentVolumeClaim{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "pvc-1",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "pvc-2",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "pvc-3",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "pvc-4",
+					},
+				},
+			},
+			ExpectedPVCNames: []string{
+				"pvc-3",
+				"pvc-4",
+			},
+		},
+	}
+
+	var err error
+	var newResource *Resource
+	{
+		resourceConfig := DefaultConfig()
+		resourceConfig.K8sClient = fake.NewSimpleClientset()
+		resourceConfig.Logger = microloggertest.New()
+		newResource, err = New(resourceConfig)
+		if err != nil {
+			t.Fatal("expected", nil, "got", err)
+		}
+	}
+
+	for i, tc := range testCases {
+		result, err := newResource.newCreateChange(context.TODO(), tc.Obj, tc.CurrentState, tc.DesiredState)
+		if err != nil {
+			t.Fatalf("case %d expected %#v got %#v", i+1, nil, err)
+		}
+
+		configMaps, ok := result.([]*apiv1.PersistentVolumeClaim)
+		if !ok {
+			t.Fatalf("case %d expected %T got %T", i+1, []*apiv1.PersistentVolumeClaim{}, result)
+		}
+
+		if len(configMaps) != len(tc.ExpectedPVCNames) {
+			t.Fatalf("case %d expected %d config maps got %d", i+1, len(tc.ExpectedPVCNames), len(configMaps))
+		}
+	}
+}

--- a/service/kvmconfig/v3/resource/pvc/current.go
+++ b/service/kvmconfig/v3/resource/pvc/current.go
@@ -1,0 +1,44 @@
+package pvc
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/giantswarm/microerror"
+	apiv1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/giantswarm/kvm-operator/service/kvmconfig/v2/key"
+)
+
+func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interface{}, error) {
+	customObject, err := key.ToCustomObject(obj)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	r.logger.LogCtx(ctx, "debug", "looking for PVCs in the Kubernetes API")
+
+	var PVCs []*apiv1.PersistentVolumeClaim
+
+	namespace := key.ClusterNamespace(customObject)
+	pvcNames := key.PVCNames(customObject)
+
+	for _, name := range pvcNames {
+		manifest, err := r.k8sClient.Core().PersistentVolumeClaims(namespace).Get(name, apismetav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			r.logger.LogCtx(ctx, "debug", "did not find a PVC in the Kubernetes API")
+			// fall through
+		} else if err != nil {
+			return nil, microerror.Mask(err)
+		} else {
+			r.logger.LogCtx(ctx, "debug", "found a PVC in the Kubernetes API")
+			PVCs = append(PVCs, manifest)
+		}
+	}
+
+	r.logger.LogCtx(ctx, "debug", fmt.Sprintf("found %d PVCs in the Kubernetes API", len(PVCs)))
+
+	return PVCs, nil
+}

--- a/service/kvmconfig/v3/resource/pvc/current.go
+++ b/service/kvmconfig/v3/resource/pvc/current.go
@@ -9,7 +9,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/giantswarm/kvm-operator/service/kvmconfig/v2/key"
+	"github.com/giantswarm/kvm-operator/service/kvmconfig/v3/key"
 )
 
 func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interface{}, error) {

--- a/service/kvmconfig/v3/resource/pvc/delete.go
+++ b/service/kvmconfig/v3/resource/pvc/delete.go
@@ -10,7 +10,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/giantswarm/kvm-operator/service/kvmconfig/v2/key"
+	"github.com/giantswarm/kvm-operator/service/kvmconfig/v3/key"
 )
 
 func (r *Resource) ApplyDeleteChange(ctx context.Context, obj, deleteChange interface{}) error {

--- a/service/kvmconfig/v3/resource/pvc/delete.go
+++ b/service/kvmconfig/v3/resource/pvc/delete.go
@@ -1,0 +1,82 @@
+package pvc
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/operatorkit/framework"
+	apiv1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/giantswarm/kvm-operator/service/kvmconfig/v2/key"
+)
+
+func (r *Resource) ApplyDeleteChange(ctx context.Context, obj, deleteChange interface{}) error {
+	customObject, err := key.ToCustomObject(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	pvcsToDelete, err := toPVCs(deleteChange)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	if len(pvcsToDelete) != 0 {
+		r.logger.LogCtx(ctx, "debug", "deleting the PVCs in the Kubernetes API")
+
+		namespace := key.ClusterNamespace(customObject)
+		for _, PVC := range pvcsToDelete {
+			err := r.k8sClient.Core().PersistentVolumeClaims(namespace).Delete(PVC.Name, &apismetav1.DeleteOptions{})
+			if apierrors.IsNotFound(err) {
+				// fall through
+			} else if err != nil {
+				return microerror.Mask(err)
+			}
+		}
+
+		r.logger.LogCtx(ctx, "debug", "deleted the PVCs in the Kubernetes API")
+	} else {
+		r.logger.LogCtx(ctx, "debug", "the PVCs do not need to be deleted from the Kubernetes API")
+	}
+
+	return nil
+}
+
+func (r *Resource) NewDeletePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*framework.Patch, error) {
+	delete, err := r.newDeleteChange(ctx, obj, currentState, desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	patch := framework.NewPatch()
+	patch.SetDeleteChange(delete)
+
+	return patch, nil
+}
+
+func (r *Resource) newDeleteChange(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, error) {
+	currentPVCs, err := toPVCs(currentState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+	desiredPVCs, err := toPVCs(desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	r.logger.LogCtx(ctx, "debug", "finding out which PVCs have to be deleted")
+
+	var pvcsToDelete []*apiv1.PersistentVolumeClaim
+
+	for _, currentPVC := range currentPVCs {
+		if containsPVC(desiredPVCs, currentPVC) {
+			pvcsToDelete = append(pvcsToDelete, currentPVC)
+		}
+	}
+
+	r.logger.LogCtx(ctx, "debug", fmt.Sprintf("found %d PVCs that have to be deleted", len(pvcsToDelete)))
+
+	return pvcsToDelete, nil
+}

--- a/service/kvmconfig/v3/resource/pvc/delete_test.go
+++ b/service/kvmconfig/v3/resource/pvc/delete_test.go
@@ -1,0 +1,289 @@
+package pvc
+
+import (
+	"context"
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/micrologger/microloggertest"
+	apiv1 "k8s.io/api/core/v1"
+	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func Test_Resource_PVC_newDeleteChange(t *testing.T) {
+	testCases := []struct {
+		Obj              interface{}
+		CurrentState     interface{}
+		DesiredState     interface{}
+		ExpectedPVCNames []string
+	}{
+		// Test 1, in case current state and desired state are empty the delete
+		// state should be empty.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState:     []*apiv1.PersistentVolumeClaim{},
+			DesiredState:     []*apiv1.PersistentVolumeClaim{},
+			ExpectedPVCNames: []string{},
+		},
+
+		// Test 2, in case current state has one item and equals desired state the
+		// delete state should equal the current state.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState: []*apiv1.PersistentVolumeClaim{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "pvc-1",
+					},
+				},
+			},
+			DesiredState: []*apiv1.PersistentVolumeClaim{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "pvc-1",
+					},
+				},
+			},
+			ExpectedPVCNames: []string{
+				"pvc-1",
+			},
+		},
+
+		// Test 3, in case current state misses one item of desired state the delete
+		// state should not contain the missing item of the desired state.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState: []*apiv1.PersistentVolumeClaim{},
+			DesiredState: []*apiv1.PersistentVolumeClaim{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "pvc-1",
+					},
+				},
+			},
+			ExpectedPVCNames: []string{},
+		},
+
+		// Test 4, in case current state misses items of desired state the delete
+		// state should not contain the missing items of the desired state.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState: []*apiv1.PersistentVolumeClaim{},
+			DesiredState: []*apiv1.PersistentVolumeClaim{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "pvc-1",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "pvc-2",
+					},
+				},
+			},
+			ExpectedPVCNames: []string{},
+		},
+
+		// Test 5, in case current state contains one item and desired state is
+		// empty the delete state should be empty.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState: []*apiv1.PersistentVolumeClaim{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "pvc-1",
+					},
+				},
+			},
+			DesiredState:     []*apiv1.PersistentVolumeClaim{},
+			ExpectedPVCNames: []string{},
+		},
+
+		// Test 6, in case current state contains items and desired state is empty
+		// the delete state should be empty.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState: []*apiv1.PersistentVolumeClaim{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "pvc-1",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "pvc-2",
+					},
+				},
+			},
+			DesiredState:     []*apiv1.PersistentVolumeClaim{},
+			ExpectedPVCNames: []string{},
+		},
+
+		// Test 7, in case all items of current state are in desired state and
+		// desired state contains more items not being in current state the create
+		// state should contain all items being in current state.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState: []*apiv1.PersistentVolumeClaim{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "pvc-1",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "pvc-2",
+					},
+				},
+			},
+			DesiredState: []*apiv1.PersistentVolumeClaim{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "pvc-1",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "pvc-2",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "pvc-3",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "pvc-4",
+					},
+				},
+			},
+			ExpectedPVCNames: []string{
+				"pvc-1",
+				"pvc-2",
+			},
+		},
+
+		// Test 8, in case all items of desired state are in current state and
+		// current state contains more items not being in desired state the create
+		// state should contain all items being in desired state.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState: []*apiv1.PersistentVolumeClaim{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "pvc-1",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "pvc-2",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "pvc-3",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "pvc-4",
+					},
+				},
+			},
+			DesiredState: []*apiv1.PersistentVolumeClaim{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "pvc-1",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "pvc-2",
+					},
+				},
+			},
+			ExpectedPVCNames: []string{
+				"pvc-1",
+				"pvc-2",
+			},
+		},
+	}
+
+	var err error
+	var newResource *Resource
+	{
+		resourceConfig := DefaultConfig()
+		resourceConfig.K8sClient = fake.NewSimpleClientset()
+		resourceConfig.Logger = microloggertest.New()
+		newResource, err = New(resourceConfig)
+		if err != nil {
+			t.Fatal("expected", nil, "got", err)
+		}
+	}
+
+	for i, tc := range testCases {
+		result, err := newResource.newDeleteChange(context.TODO(), tc.Obj, tc.CurrentState, tc.DesiredState)
+		if err != nil {
+			t.Fatalf("case %d expected %#v got %#v", i+1, nil, err)
+		}
+
+		configMaps, ok := result.([]*apiv1.PersistentVolumeClaim)
+		if !ok {
+			t.Fatalf("case %d expected %T got %T", i+1, []*apiv1.PersistentVolumeClaim{}, result)
+		}
+
+		if len(configMaps) != len(tc.ExpectedPVCNames) {
+			t.Fatalf("case %d expected %d config maps got %d", i+1, len(tc.ExpectedPVCNames), len(configMaps))
+		}
+	}
+}

--- a/service/kvmconfig/v3/resource/pvc/desired.go
+++ b/service/kvmconfig/v3/resource/pvc/desired.go
@@ -1,0 +1,35 @@
+package pvc
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/giantswarm/microerror"
+	apiv1 "k8s.io/api/core/v1"
+
+	"github.com/giantswarm/kvm-operator/service/kvmconfig/v2/key"
+)
+
+func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interface{}, error) {
+	customObject, err := key.ToCustomObject(obj)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	var PVCs []*apiv1.PersistentVolumeClaim
+
+	if key.StorageType(customObject) == "persistentVolume" {
+		r.logger.LogCtx(ctx, "debug", "computing the new PVCs")
+
+		PVCs, err = newEtcdPVCs(customObject)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+
+		r.logger.LogCtx(ctx, "debug", fmt.Sprintf("computed the %d new PVCs", len(PVCs)))
+	} else {
+		r.logger.LogCtx(ctx, "debug", "not computing the new PVCs because storage type is not 'persistentVolume'")
+	}
+
+	return PVCs, nil
+}

--- a/service/kvmconfig/v3/resource/pvc/desired.go
+++ b/service/kvmconfig/v3/resource/pvc/desired.go
@@ -7,7 +7,7 @@ import (
 	"github.com/giantswarm/microerror"
 	apiv1 "k8s.io/api/core/v1"
 
-	"github.com/giantswarm/kvm-operator/service/kvmconfig/v2/key"
+	"github.com/giantswarm/kvm-operator/service/kvmconfig/v3/key"
 )
 
 func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interface{}, error) {

--- a/service/kvmconfig/v3/resource/pvc/desired_test.go
+++ b/service/kvmconfig/v3/resource/pvc/desired_test.go
@@ -1,0 +1,221 @@
+package pvc
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/micrologger/microloggertest"
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func Test_Resource_PVC_GetDesiredState(t *testing.T) {
+	testCases := []struct {
+		Obj               interface{}
+		ExpectedEtcdCount int
+	}{
+		// Test 1 ensures there is one PVC for each master when there is one master
+		// and one worker node and storage type is 'persistentVolume' in the custom
+		// object.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+						Masters: []v1alpha1.ClusterNode{
+							{},
+						},
+						Workers: []v1alpha1.ClusterNode{
+							{},
+						},
+					},
+					KVM: v1alpha1.KVMConfigSpecKVM{
+						K8sKVM: v1alpha1.KVMConfigSpecKVMK8sKVM{
+							StorageType: "persistentVolume",
+						},
+					},
+				},
+			},
+			ExpectedEtcdCount: 1,
+		},
+
+		// Test 2 ensures there is one PVC for each master when there is one master
+		// and three worker nodes and storage type is 'persistentVolume' in the
+		// custom object.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+						Masters: []v1alpha1.ClusterNode{
+							{},
+						},
+						Workers: []v1alpha1.ClusterNode{
+							{},
+							{},
+							{},
+						},
+					},
+					KVM: v1alpha1.KVMConfigSpecKVM{
+						K8sKVM: v1alpha1.KVMConfigSpecKVMK8sKVM{
+							StorageType: "persistentVolume",
+						},
+					},
+				},
+			},
+			ExpectedEtcdCount: 1,
+		},
+
+		// Test 3 ensures there is one PVC for each master when there are three
+		// master and three worker nodes and storage type is 'persistentVolume' in
+		// the custom object.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+						Masters: []v1alpha1.ClusterNode{
+							{},
+							{},
+							{},
+						},
+						Workers: []v1alpha1.ClusterNode{
+							{},
+							{},
+							{},
+						},
+					},
+					KVM: v1alpha1.KVMConfigSpecKVM{
+						K8sKVM: v1alpha1.KVMConfigSpecKVMK8sKVM{
+							StorageType: "persistentVolume",
+						},
+					},
+				},
+			},
+			ExpectedEtcdCount: 3,
+		},
+
+		// Test 4 ensures there is no PVC for each master when there is one master
+		// and one worker node and storage type is 'hostPath' in the custom
+		// object.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+						Masters: []v1alpha1.ClusterNode{
+							{},
+						},
+						Workers: []v1alpha1.ClusterNode{
+							{},
+						},
+					},
+					KVM: v1alpha1.KVMConfigSpecKVM{
+						K8sKVM: v1alpha1.KVMConfigSpecKVMK8sKVM{
+							StorageType: "hostPath",
+						},
+					},
+				},
+			},
+			ExpectedEtcdCount: 0,
+		},
+
+		// Test 5 ensures there is no PVC for each master when there is one master
+		// and three worker nodes and storage type is 'hostPath' in the
+		// custom object.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+						Masters: []v1alpha1.ClusterNode{
+							{},
+						},
+						Workers: []v1alpha1.ClusterNode{
+							{},
+							{},
+							{},
+						},
+					},
+					KVM: v1alpha1.KVMConfigSpecKVM{
+						K8sKVM: v1alpha1.KVMConfigSpecKVMK8sKVM{
+							StorageType: "hostPath",
+						},
+					},
+				},
+			},
+			ExpectedEtcdCount: 0,
+		},
+
+		// Test 6 ensures there is no PVC for each master when there are three
+		// master and three worker nodes and storage type is 'hostPath' in
+		// the custom object.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+						Masters: []v1alpha1.ClusterNode{
+							{},
+							{},
+							{},
+						},
+						Workers: []v1alpha1.ClusterNode{
+							{},
+							{},
+							{},
+						},
+					},
+					KVM: v1alpha1.KVMConfigSpecKVM{
+						K8sKVM: v1alpha1.KVMConfigSpecKVMK8sKVM{
+							StorageType: "hostPath",
+						},
+					},
+				},
+			},
+			ExpectedEtcdCount: 0,
+		},
+	}
+
+	var err error
+	var newResource *Resource
+	{
+		resourceConfig := DefaultConfig()
+		resourceConfig.K8sClient = fake.NewSimpleClientset()
+		resourceConfig.Logger = microloggertest.New()
+		newResource, err = New(resourceConfig)
+		if err != nil {
+			t.Fatal("expected", nil, "got", err)
+		}
+	}
+
+	for i, tc := range testCases {
+		result, err := newResource.GetDesiredState(context.TODO(), tc.Obj)
+		if err != nil {
+			t.Fatalf("case %d expected %#v got %#v", i+1, nil, err)
+		}
+
+		PVCs, ok := result.([]*apiv1.PersistentVolumeClaim)
+		if !ok {
+			t.Fatalf("case %d expected %T got %T", i+1, []*apiv1.PersistentVolumeClaim{}, result)
+		}
+
+		if testGetEtcdCount(PVCs) != tc.ExpectedEtcdCount {
+			t.Fatalf("case %d expected %d worker nodes got %d", i+1, tc.ExpectedEtcdCount, testGetEtcdCount(PVCs))
+		}
+	}
+}
+
+func testGetEtcdCount(PVCs []*apiv1.PersistentVolumeClaim) int {
+	var count int
+
+	for _, i := range PVCs {
+		if strings.HasPrefix(i.Name, "pvc-master-etcd") {
+			count++
+		}
+	}
+
+	return count
+}

--- a/service/kvmconfig/v3/resource/pvc/error.go
+++ b/service/kvmconfig/v3/resource/pvc/error.go
@@ -1,0 +1,17 @@
+package pvc
+
+import "github.com/giantswarm/microerror"
+
+var invalidConfigError = microerror.New("invalid config")
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var wrongTypeError = microerror.New("wrong type")
+
+// IsWrongTypeError asserts wrongTypeError.
+func IsWrongTypeError(err error) bool {
+	return microerror.Cause(err) == wrongTypeError
+}

--- a/service/kvmconfig/v3/resource/pvc/etcd_pvc.go
+++ b/service/kvmconfig/v3/resource/pvc/etcd_pvc.go
@@ -1,0 +1,60 @@
+package pvc
+
+import (
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/microerror"
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/giantswarm/kvm-operator/service/kvmconfig/v2/key"
+)
+
+const (
+	// EtcdPVSize is the size the persistent volume for etcd is configured with.
+	EtcdPVSize = "15Gi"
+)
+
+func newEtcdPVCs(customObject v1alpha1.KVMConfig) ([]*apiv1.PersistentVolumeClaim, error) {
+	var persistentVolumeClaims []*apiv1.PersistentVolumeClaim
+
+	for i, masterNode := range customObject.Spec.Cluster.Masters {
+		quantity, err := resource.ParseQuantity(EtcdPVSize)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+
+		persistentVolumeClaim := &apiv1.PersistentVolumeClaim{
+			TypeMeta: apismetav1.TypeMeta{
+				Kind:       "PersistentVolumeClaim",
+				APIVersion: "v1",
+			},
+			ObjectMeta: apismetav1.ObjectMeta{
+				Name: key.EtcdPVCName(key.ClusterID(customObject), key.VMNumber(i)),
+				Labels: map[string]string{
+					"app":      key.MasterID,
+					"cluster":  key.ClusterID(customObject),
+					"customer": key.ClusterCustomer(customObject),
+					"node":     masterNode.ID,
+				},
+				Annotations: map[string]string{
+					"volume.beta.kubernetes.io/storage-class": StorageClass,
+				},
+			},
+			Spec: apiv1.PersistentVolumeClaimSpec{
+				AccessModes: []apiv1.PersistentVolumeAccessMode{
+					apiv1.ReadWriteOnce,
+				},
+				Resources: apiv1.ResourceRequirements{
+					Requests: map[apiv1.ResourceName]resource.Quantity{
+						apiv1.ResourceStorage: quantity,
+					},
+				},
+			},
+		}
+
+		persistentVolumeClaims = append(persistentVolumeClaims, persistentVolumeClaim)
+	}
+
+	return persistentVolumeClaims, nil
+}

--- a/service/kvmconfig/v3/resource/pvc/etcd_pvc.go
+++ b/service/kvmconfig/v3/resource/pvc/etcd_pvc.go
@@ -7,7 +7,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/giantswarm/kvm-operator/service/kvmconfig/v2/key"
+	"github.com/giantswarm/kvm-operator/service/kvmconfig/v3/key"
 )
 
 const (

--- a/service/kvmconfig/v3/resource/pvc/resource.go
+++ b/service/kvmconfig/v3/resource/pvc/resource.go
@@ -1,0 +1,93 @@
+package pvc
+
+import (
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/giantswarm/operatorkit/framework"
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	// Name is the identifier of the resource.
+	Name = "pvcv2"
+	// StorageClass is the storage class annotation persistent volume claims are
+	// configured with.
+	StorageClass = "g8s-storage"
+)
+
+// Config represents the configuration used to create a new PVC resource.
+type Config struct {
+	// Dependencies.
+	K8sClient kubernetes.Interface
+	Logger    micrologger.Logger
+}
+
+// DefaultConfig provides a default configuration to create a new PVC
+// resource by best effort.
+func DefaultConfig() Config {
+	return Config{
+		// Dependencies.
+		K8sClient: nil,
+		Logger:    nil,
+	}
+}
+
+// Resource implements the PVC resource.
+type Resource struct {
+	// Dependencies.
+	k8sClient kubernetes.Interface
+	logger    micrologger.Logger
+}
+
+// New creates a new configured PVC resource.
+func New(config Config) (*Resource, error) {
+	// Dependencies.
+	if config.K8sClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "config.K8sClient must not be empty")
+	}
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "config.Logger must not be empty")
+	}
+
+	newResource := &Resource{
+		// Dependencies.
+		k8sClient: config.K8sClient,
+		logger: config.Logger.With(
+			"resource", Name,
+		),
+	}
+
+	return newResource, nil
+}
+
+func (r *Resource) Name() string {
+	return Name
+}
+
+func (r *Resource) Underlying() framework.Resource {
+	return r
+}
+
+func containsPVC(list []*apiv1.PersistentVolumeClaim, item *apiv1.PersistentVolumeClaim) bool {
+	for _, l := range list {
+		if l.Name == item.Name {
+			return true
+		}
+	}
+
+	return false
+}
+
+func toPVCs(v interface{}) ([]*apiv1.PersistentVolumeClaim, error) {
+	if v == nil {
+		return nil, nil
+	}
+
+	PVCs, ok := v.([]*apiv1.PersistentVolumeClaim)
+	if !ok {
+		return nil, microerror.Maskf(wrongTypeError, "expected '%T', got '%T'", []*apiv1.PersistentVolumeClaim{}, v)
+	}
+
+	return PVCs, nil
+}

--- a/service/kvmconfig/v3/resource/pvc/update.go
+++ b/service/kvmconfig/v3/resource/pvc/update.go
@@ -1,0 +1,34 @@
+package pvc
+
+import (
+	"context"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/operatorkit/framework"
+)
+
+func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateChange interface{}) error {
+	return nil
+}
+
+func (r *Resource) NewUpdatePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*framework.Patch, error) {
+	create, err := r.newCreateChange(ctx, obj, currentState, desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	update, err := r.newUpdateChange(ctx, obj, currentState, desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	patch := framework.NewPatch()
+	patch.SetCreateChange(create)
+	patch.SetUpdateChange(update)
+
+	return patch, nil
+}
+
+func (r *Resource) newUpdateChange(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, error) {
+	return nil, nil
+}

--- a/service/kvmconfig/v3/resource/service/create.go
+++ b/service/kvmconfig/v3/resource/service/create.go
@@ -1,0 +1,68 @@
+package service
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/giantswarm/microerror"
+	apiv1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+
+	"github.com/giantswarm/kvm-operator/service/kvmconfig/v2/key"
+)
+
+func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange interface{}) error {
+	customObject, err := key.ToCustomObject(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	servicesToCreate, err := toServices(createChange)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	if len(servicesToCreate) != 0 {
+		r.logger.LogCtx(ctx, "debug", "creating the services in the Kubernetes API")
+
+		namespace := key.ClusterNamespace(customObject)
+		for _, service := range servicesToCreate {
+			_, err := r.k8sClient.CoreV1().Services(namespace).Create(service)
+			if apierrors.IsAlreadyExists(err) {
+				// fall through
+			} else if err != nil {
+				return microerror.Mask(err)
+			}
+		}
+
+		r.logger.LogCtx(ctx, "debug", "created the services in the Kubernetes API")
+	} else {
+		r.logger.LogCtx(ctx, "debug", "the services do not need to be created in the Kubernetes API")
+	}
+
+	return nil
+}
+
+func (r *Resource) newCreateChange(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, error) {
+	currentServices, err := toServices(currentState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+	desiredServices, err := toServices(desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	r.logger.LogCtx(ctx, "debug", "finding out which services have to be created")
+
+	var servicesToCreate []*apiv1.Service
+
+	for _, desiredService := range desiredServices {
+		if !containsService(currentServices, desiredService) {
+			servicesToCreate = append(servicesToCreate, desiredService)
+		}
+	}
+
+	r.logger.LogCtx(ctx, "debug", fmt.Sprintf("found %d services that have to be created", len(servicesToCreate)))
+
+	return servicesToCreate, nil
+}

--- a/service/kvmconfig/v3/resource/service/create.go
+++ b/service/kvmconfig/v3/resource/service/create.go
@@ -8,7 +8,7 @@ import (
 	apiv1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 
-	"github.com/giantswarm/kvm-operator/service/kvmconfig/v2/key"
+	"github.com/giantswarm/kvm-operator/service/kvmconfig/v3/key"
 )
 
 func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange interface{}) error {

--- a/service/kvmconfig/v3/resource/service/create_test.go
+++ b/service/kvmconfig/v3/resource/service/create_test.go
@@ -1,0 +1,243 @@
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/micrologger/microloggertest"
+	apiv1 "k8s.io/api/core/v1"
+	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func Test_Resource_Service_newCreateChange(t *testing.T) {
+	testCases := []struct {
+		Obj                  interface{}
+		CurrentState         interface{}
+		DesiredState         interface{}
+		ExpectedServiceNames []string
+	}{
+		// Test 1, in case current state and desired state are empty the create
+		// state should be empty.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState:         []*apiv1.Service{},
+			DesiredState:         []*apiv1.Service{},
+			ExpectedServiceNames: []string{},
+		},
+
+		// Test 2, in case current state equals desired state the create state
+		// should be empty.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState: []*apiv1.Service{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "service-1",
+					},
+				},
+			},
+			DesiredState: []*apiv1.Service{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "service-1",
+					},
+				},
+			},
+			ExpectedServiceNames: []string{},
+		},
+
+		// Test 3, in case current state misses one item of desired state the create
+		// state should contain the missing item of the desired state.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState: []*apiv1.Service{},
+			DesiredState: []*apiv1.Service{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "service-1",
+					},
+				},
+			},
+			ExpectedServiceNames: []string{
+				"service-1",
+			},
+		},
+
+		// Test 4, in case current state misses items of desired state the create
+		// state should contain the missing items of the desired state.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState: []*apiv1.Service{},
+			DesiredState: []*apiv1.Service{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "service-1",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "service-2",
+					},
+				},
+			},
+			ExpectedServiceNames: []string{
+				"service-1",
+				"service-2",
+			},
+		},
+
+		// Test 5, in case current state contains one item not being in desired
+		// state the create state should not contain the missing item of the desired
+		// state.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState: []*apiv1.Service{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "service-1",
+					},
+				},
+			},
+			DesiredState:         []*apiv1.Service{},
+			ExpectedServiceNames: []string{},
+		},
+
+		// Test 6, in case current state contains items not being in desired state
+		// the create state should not contain the missing items of the desired
+		// state.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState: []*apiv1.Service{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "service-1",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "service-2",
+					},
+				},
+			},
+			DesiredState:         []*apiv1.Service{},
+			ExpectedServiceNames: []string{},
+		},
+
+		// Test 7, in case current state contains some items of desired state the
+		// create state should contain the items being in desired state which are
+		// not in create state.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState: []*apiv1.Service{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "service-1",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "service-2",
+					},
+				},
+			},
+			DesiredState: []*apiv1.Service{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "service-1",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "service-2",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "service-3",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "service-4",
+					},
+				},
+			},
+			ExpectedServiceNames: []string{
+				"service-3",
+				"service-4",
+			},
+		},
+	}
+
+	var err error
+	var newResource *Resource
+	{
+		resourceConfig := DefaultConfig()
+		resourceConfig.K8sClient = fake.NewSimpleClientset()
+		resourceConfig.Logger = microloggertest.New()
+		newResource, err = New(resourceConfig)
+		if err != nil {
+			t.Fatal("expected", nil, "got", err)
+		}
+	}
+
+	for i, tc := range testCases {
+		result, err := newResource.newCreateChange(context.TODO(), tc.Obj, tc.CurrentState, tc.DesiredState)
+		if err != nil {
+			t.Fatalf("case %d expected %#v got %#v", i+1, nil, err)
+		}
+
+		configMaps, ok := result.([]*apiv1.Service)
+		if !ok {
+			t.Fatalf("case %d expected %T got %T", i+1, []*apiv1.Service{}, result)
+		}
+
+		if len(configMaps) != len(tc.ExpectedServiceNames) {
+			t.Fatalf("case %d expected %d config maps got %d", i+1, len(tc.ExpectedServiceNames), len(configMaps))
+		}
+	}
+}

--- a/service/kvmconfig/v3/resource/service/current.go
+++ b/service/kvmconfig/v3/resource/service/current.go
@@ -9,7 +9,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/giantswarm/kvm-operator/service/kvmconfig/v2/key"
+	"github.com/giantswarm/kvm-operator/service/kvmconfig/v3/key"
 )
 
 func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interface{}, error) {

--- a/service/kvmconfig/v3/resource/service/current.go
+++ b/service/kvmconfig/v3/resource/service/current.go
@@ -1,0 +1,47 @@
+package service
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/giantswarm/microerror"
+	apiv1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/giantswarm/kvm-operator/service/kvmconfig/v2/key"
+)
+
+func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interface{}, error) {
+	customObject, err := key.ToCustomObject(obj)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	r.logger.LogCtx(ctx, "debug", "looking for services in the Kubernetes API")
+
+	var services []*apiv1.Service
+
+	namespace := key.ClusterNamespace(customObject)
+	serviceNames := []string{
+		key.MasterID,
+		key.WorkerID,
+	}
+
+	for _, name := range serviceNames {
+		manifest, err := r.k8sClient.CoreV1().Services(namespace).Get(name, apismetav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			r.logger.LogCtx(ctx, "debug", "did not find a service in the Kubernetes API")
+			// fall through
+		} else if err != nil {
+			return nil, microerror.Mask(err)
+		} else {
+			r.logger.LogCtx(ctx, "debug", "found a service in the Kubernetes API")
+			services = append(services, manifest)
+		}
+	}
+
+	r.logger.LogCtx(ctx, "debug", fmt.Sprintf("found %d services in the Kubernetes API", len(services)))
+
+	return services, nil
+}

--- a/service/kvmconfig/v3/resource/service/delete.go
+++ b/service/kvmconfig/v3/resource/service/delete.go
@@ -1,0 +1,82 @@
+package service
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/operatorkit/framework"
+	apiv1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/giantswarm/kvm-operator/service/kvmconfig/v2/key"
+)
+
+func (r *Resource) ApplyDeleteChange(ctx context.Context, obj, deleteChange interface{}) error {
+	customObject, err := key.ToCustomObject(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	servicesToDelete, err := toServices(deleteChange)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	if len(servicesToDelete) != 0 {
+		r.logger.LogCtx(ctx, "debug", "deleting the services in the Kubernetes API")
+
+		namespace := key.ClusterNamespace(customObject)
+		for _, service := range servicesToDelete {
+			err := r.k8sClient.CoreV1().Services(namespace).Delete(service.Name, &apismetav1.DeleteOptions{})
+			if apierrors.IsNotFound(err) {
+				// fall through
+			} else if err != nil {
+				return microerror.Mask(err)
+			}
+		}
+
+		r.logger.LogCtx(ctx, "debug", "deleted the services in the Kubernetes API")
+	} else {
+		r.logger.LogCtx(ctx, "debug", "the services do not need to be deleted from the Kubernetes API")
+	}
+
+	return nil
+}
+
+func (r *Resource) NewDeletePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*framework.Patch, error) {
+	delete, err := r.newDeleteChange(ctx, obj, currentState, desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	patch := framework.NewPatch()
+	patch.SetDeleteChange(delete)
+
+	return patch, nil
+}
+
+func (r *Resource) newDeleteChange(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, error) {
+	currentServices, err := toServices(currentState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+	desiredServices, err := toServices(desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	r.logger.LogCtx(ctx, "debug", "finding out which services have to be deleted")
+
+	var servicesToDelete []*apiv1.Service
+
+	for _, currentService := range currentServices {
+		if containsService(desiredServices, currentService) {
+			servicesToDelete = append(servicesToDelete, currentService)
+		}
+	}
+
+	r.logger.LogCtx(ctx, "debug", fmt.Sprintf("found %d services that have to be deleted", len(servicesToDelete)))
+
+	return servicesToDelete, nil
+}

--- a/service/kvmconfig/v3/resource/service/delete.go
+++ b/service/kvmconfig/v3/resource/service/delete.go
@@ -10,7 +10,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/giantswarm/kvm-operator/service/kvmconfig/v2/key"
+	"github.com/giantswarm/kvm-operator/service/kvmconfig/v3/key"
 )
 
 func (r *Resource) ApplyDeleteChange(ctx context.Context, obj, deleteChange interface{}) error {

--- a/service/kvmconfig/v3/resource/service/delete_test.go
+++ b/service/kvmconfig/v3/resource/service/delete_test.go
@@ -1,0 +1,289 @@
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/micrologger/microloggertest"
+	apiv1 "k8s.io/api/core/v1"
+	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func Test_Resource_Service_newDeleteChange(t *testing.T) {
+	testCases := []struct {
+		Obj                  interface{}
+		CurrentState         interface{}
+		DesiredState         interface{}
+		ExpectedServiceNames []string
+	}{
+		// Test 1, in case current state and desired state are empty the delete
+		// state should be empty.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState:         []*apiv1.Service{},
+			DesiredState:         []*apiv1.Service{},
+			ExpectedServiceNames: []string{},
+		},
+
+		// Test 2, in case current state has one item and equals desired state the
+		// delete state should equal the current state.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState: []*apiv1.Service{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "service-1",
+					},
+				},
+			},
+			DesiredState: []*apiv1.Service{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "service-1",
+					},
+				},
+			},
+			ExpectedServiceNames: []string{
+				"service-1",
+			},
+		},
+
+		// Test 3, in case current state misses one item of desired state the delete
+		// state should not contain the missing item of the desired state.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState: []*apiv1.Service{},
+			DesiredState: []*apiv1.Service{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "service-1",
+					},
+				},
+			},
+			ExpectedServiceNames: []string{},
+		},
+
+		// Test 4, in case current state misses items of desired state the delete
+		// state should not contain the missing items of the desired state.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState: []*apiv1.Service{},
+			DesiredState: []*apiv1.Service{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "service-1",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "service-2",
+					},
+				},
+			},
+			ExpectedServiceNames: []string{},
+		},
+
+		// Test 5, in case current state contains one item and desired state is
+		// empty the delete state should be empty.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState: []*apiv1.Service{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "service-1",
+					},
+				},
+			},
+			DesiredState:         []*apiv1.Service{},
+			ExpectedServiceNames: []string{},
+		},
+
+		// Test 6, in case current state contains items and desired state is empty
+		// the delete state should be empty.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState: []*apiv1.Service{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "service-1",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "service-2",
+					},
+				},
+			},
+			DesiredState:         []*apiv1.Service{},
+			ExpectedServiceNames: []string{},
+		},
+
+		// Test 7, in case all items of current state are in desired state and
+		// desired state contains more items not being in current state the create
+		// state should contain all items being in current state.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState: []*apiv1.Service{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "service-1",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "service-2",
+					},
+				},
+			},
+			DesiredState: []*apiv1.Service{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "service-1",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "service-2",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "service-3",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "service-4",
+					},
+				},
+			},
+			ExpectedServiceNames: []string{
+				"service-1",
+				"service-2",
+			},
+		},
+
+		// Test 8, in case all items of desired state are in current state and
+		// current state contains more items not being in desired state the create
+		// state should contain all items being in desired state.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState: []*apiv1.Service{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "service-1",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "service-2",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "service-3",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "service-4",
+					},
+				},
+			},
+			DesiredState: []*apiv1.Service{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "service-1",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "service-2",
+					},
+				},
+			},
+			ExpectedServiceNames: []string{
+				"service-1",
+				"service-2",
+			},
+		},
+	}
+
+	var err error
+	var newResource *Resource
+	{
+		resourceConfig := DefaultConfig()
+		resourceConfig.K8sClient = fake.NewSimpleClientset()
+		resourceConfig.Logger = microloggertest.New()
+		newResource, err = New(resourceConfig)
+		if err != nil {
+			t.Fatal("expected", nil, "got", err)
+		}
+	}
+
+	for i, tc := range testCases {
+		result, err := newResource.newDeleteChange(context.TODO(), tc.Obj, tc.CurrentState, tc.DesiredState)
+		if err != nil {
+			t.Fatalf("case %d expected %#v got %#v", i+1, nil, err)
+		}
+
+		configMaps, ok := result.([]*apiv1.Service)
+		if !ok {
+			t.Fatalf("case %d expected %T got %T", i+1, []*apiv1.Service{}, result)
+		}
+
+		if len(configMaps) != len(tc.ExpectedServiceNames) {
+			t.Fatalf("case %d expected %d config maps got %d", i+1, len(tc.ExpectedServiceNames), len(configMaps))
+		}
+	}
+}

--- a/service/kvmconfig/v3/resource/service/desired.go
+++ b/service/kvmconfig/v3/resource/service/desired.go
@@ -1,0 +1,29 @@
+package service
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/giantswarm/microerror"
+	apiv1 "k8s.io/api/core/v1"
+
+	"github.com/giantswarm/kvm-operator/service/kvmconfig/v2/key"
+)
+
+func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interface{}, error) {
+	customObject, err := key.ToCustomObject(obj)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	r.logger.LogCtx(ctx, "debug", "computing the new services")
+
+	var services []*apiv1.Service
+
+	services = append(services, newMasterService(customObject))
+	services = append(services, newWorkerService(customObject))
+
+	r.logger.LogCtx(ctx, "debug", fmt.Sprintf("computed the %d new services", len(services)))
+
+	return services, nil
+}

--- a/service/kvmconfig/v3/resource/service/desired.go
+++ b/service/kvmconfig/v3/resource/service/desired.go
@@ -7,7 +7,7 @@ import (
 	"github.com/giantswarm/microerror"
 	apiv1 "k8s.io/api/core/v1"
 
-	"github.com/giantswarm/kvm-operator/service/kvmconfig/v2/key"
+	"github.com/giantswarm/kvm-operator/service/kvmconfig/v3/key"
 )
 
 func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interface{}, error) {

--- a/service/kvmconfig/v3/resource/service/desired_test.go
+++ b/service/kvmconfig/v3/resource/service/desired_test.go
@@ -1,0 +1,145 @@
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/micrologger/microloggertest"
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func Test_Resource_Service_GetDesiredState(t *testing.T) {
+	testCases := []struct {
+		Obj                 interface{}
+		ExpectedMasterCount int
+		ExpectedWorkerCount int
+	}{
+		// Test 1 ensures there is one service for master and worker each when there
+		// is one master and one worker node in the custom object.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+						Masters: []v1alpha1.ClusterNode{
+							{},
+						},
+						Workers: []v1alpha1.ClusterNode{
+							{},
+						},
+					},
+				},
+			},
+			ExpectedMasterCount: 1,
+			ExpectedWorkerCount: 1,
+		},
+
+		// Test 2 ensures there is one service for master and worker each when there
+		// is one master and three worker nodes in the custom object.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+						Masters: []v1alpha1.ClusterNode{
+							{},
+						},
+						Workers: []v1alpha1.ClusterNode{
+							{},
+							{},
+							{},
+						},
+					},
+				},
+			},
+			ExpectedMasterCount: 1,
+			ExpectedWorkerCount: 1,
+		},
+
+		// Test 3 ensures there is one service for master and worker each when there
+		// are three master and three worker nodes in the custom object.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+						Masters: []v1alpha1.ClusterNode{
+							{},
+							{},
+							{},
+						},
+						Workers: []v1alpha1.ClusterNode{
+							{},
+							{},
+							{},
+						},
+					},
+				},
+			},
+			ExpectedMasterCount: 1,
+			ExpectedWorkerCount: 1,
+		},
+	}
+
+	var err error
+	var newResource *Resource
+	{
+		resourceConfig := DefaultConfig()
+		resourceConfig.K8sClient = fake.NewSimpleClientset()
+		resourceConfig.Logger = microloggertest.New()
+		newResource, err = New(resourceConfig)
+		if err != nil {
+			t.Fatal("expected", nil, "got", err)
+		}
+	}
+
+	for i, tc := range testCases {
+		result, err := newResource.GetDesiredState(context.TODO(), tc.Obj)
+		if err != nil {
+			t.Fatalf("case %d expected %#v got %#v", i+1, nil, err)
+		}
+
+		services, ok := result.([]*apiv1.Service)
+		if !ok {
+			t.Fatalf("case %d expected %T got %T", i+1, []*apiv1.Service{}, result)
+		}
+
+		if testGetMasterCount(services) != tc.ExpectedMasterCount {
+			t.Fatalf("case %d expected %d master nodes got %d", i+1, tc.ExpectedMasterCount, testGetMasterCount(services))
+		}
+
+		if testGetWorkerCount(services) != tc.ExpectedWorkerCount {
+			t.Fatalf("case %d expected %d worker nodes got %d", i+1, tc.ExpectedWorkerCount, testGetWorkerCount(services))
+		}
+
+		if len(services) != tc.ExpectedMasterCount+tc.ExpectedWorkerCount {
+			t.Fatalf("case %d expected %d nodes got %d", i+1, tc.ExpectedMasterCount+tc.ExpectedWorkerCount, len(services))
+		}
+	}
+}
+
+func testGetMasterCount(services []*apiv1.Service) int {
+	var count int
+
+	for _, s := range services {
+		if s.Name == "master" {
+			count++
+		}
+	}
+
+	return count
+}
+
+func testGetWorkerCount(services []*apiv1.Service) int {
+	var count int
+
+	for _, s := range services {
+		if s.Name == "worker" {
+			count++
+		}
+	}
+
+	return count
+}

--- a/service/kvmconfig/v3/resource/service/error.go
+++ b/service/kvmconfig/v3/resource/service/error.go
@@ -1,0 +1,17 @@
+package service
+
+import "github.com/giantswarm/microerror"
+
+var invalidConfigError = microerror.New("invalid config")
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var wrongTypeError = microerror.New("wrong type")
+
+// IsWrongTypeError asserts wrongTypeError.
+func IsWrongTypeError(err error) bool {
+	return microerror.Cause(err) == wrongTypeError
+}

--- a/service/kvmconfig/v3/resource/service/master_service.go
+++ b/service/kvmconfig/v3/resource/service/master_service.go
@@ -1,0 +1,48 @@
+package service
+
+import (
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	apiv1 "k8s.io/api/core/v1"
+	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/giantswarm/kvm-operator/service/kvmconfig/v2/key"
+)
+
+func newMasterService(customObject v1alpha1.KVMConfig) *apiv1.Service {
+	service := &apiv1.Service{
+		TypeMeta: apismetav1.TypeMeta{
+			Kind:       "service",
+			APIVersion: "v1",
+		},
+		ObjectMeta: apismetav1.ObjectMeta{
+			Name: key.MasterID,
+			Labels: map[string]string{
+				"cluster":  key.ClusterID(customObject),
+				"customer": key.ClusterCustomer(customObject),
+				"app":      key.MasterID,
+			},
+			Annotations: map[string]string{
+				"giantswarm.io/prometheus-cluster": key.ClusterID(customObject),
+			},
+		},
+		Spec: apiv1.ServiceSpec{
+			Type: apiv1.ServiceTypeLoadBalancer,
+			Ports: []apiv1.ServicePort{
+				{
+					Name:     "etcd",
+					Port:     int32(2379),
+					Protocol: "TCP",
+				},
+				{
+					Name:     "api",
+					Port:     int32(customObject.Spec.Cluster.Kubernetes.API.SecurePort),
+					Protocol: "TCP",
+				},
+			},
+			// Note that we do not use a selector definition on purpose to be able to
+			// manually set the IP address of the actual VM.
+		},
+	}
+
+	return service
+}

--- a/service/kvmconfig/v3/resource/service/master_service.go
+++ b/service/kvmconfig/v3/resource/service/master_service.go
@@ -5,7 +5,7 @@ import (
 	apiv1 "k8s.io/api/core/v1"
 	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/giantswarm/kvm-operator/service/kvmconfig/v2/key"
+	"github.com/giantswarm/kvm-operator/service/kvmconfig/v3/key"
 )
 
 func newMasterService(customObject v1alpha1.KVMConfig) *apiv1.Service {

--- a/service/kvmconfig/v3/resource/service/resource.go
+++ b/service/kvmconfig/v3/resource/service/resource.go
@@ -1,0 +1,90 @@
+package service
+
+import (
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/giantswarm/operatorkit/framework"
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	// Name is the identifier of the resource.
+	Name = "servicev2"
+)
+
+// Config represents the configuration used to create a new service resource.
+type Config struct {
+	// Dependencies.
+	K8sClient kubernetes.Interface
+	Logger    micrologger.Logger
+}
+
+// DefaultConfig provides a default configuration to create a new service
+// resource by best effort.
+func DefaultConfig() Config {
+	return Config{
+		// Dependencies.
+		K8sClient: nil,
+		Logger:    nil,
+	}
+}
+
+// Resource implements the service resource.
+type Resource struct {
+	// Dependencies.
+	k8sClient kubernetes.Interface
+	logger    micrologger.Logger
+}
+
+// New creates a new configured service resource.
+func New(config Config) (*Resource, error) {
+	// Dependencies.
+	if config.K8sClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "config.K8sClient must not be empty")
+	}
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "config.Logger must not be empty")
+	}
+
+	newService := &Resource{
+		// Dependencies.
+		k8sClient: config.K8sClient,
+		logger: config.Logger.With(
+			"resource", Name,
+		),
+	}
+
+	return newService, nil
+}
+
+func (r *Resource) Name() string {
+	return Name
+}
+
+func (r *Resource) Underlying() framework.Resource {
+	return r
+}
+
+func containsService(list []*apiv1.Service, item *apiv1.Service) bool {
+	for _, l := range list {
+		if l.Name == item.Name {
+			return true
+		}
+	}
+
+	return false
+}
+
+func toServices(v interface{}) ([]*apiv1.Service, error) {
+	if v == nil {
+		return nil, nil
+	}
+
+	services, ok := v.([]*apiv1.Service)
+	if !ok {
+		return nil, microerror.Maskf(wrongTypeError, "expected '%T', got '%T'", []*apiv1.Service{}, v)
+	}
+
+	return services, nil
+}

--- a/service/kvmconfig/v3/resource/service/update.go
+++ b/service/kvmconfig/v3/resource/service/update.go
@@ -1,0 +1,34 @@
+package service
+
+import (
+	"context"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/operatorkit/framework"
+)
+
+func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateChange interface{}) error {
+	return nil
+}
+
+func (r *Resource) NewUpdatePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*framework.Patch, error) {
+	create, err := r.newCreateChange(ctx, obj, currentState, desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	update, err := r.newUpdateChange(ctx, obj, currentState, desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	patch := framework.NewPatch()
+	patch.SetCreateChange(create)
+	patch.SetUpdateChange(update)
+
+	return patch, nil
+}
+
+func (r *Resource) newUpdateChange(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, error) {
+	return nil, nil
+}

--- a/service/kvmconfig/v3/resource/service/worker_service.go
+++ b/service/kvmconfig/v3/resource/service/worker_service.go
@@ -1,0 +1,48 @@
+package service
+
+import (
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	apiv1 "k8s.io/api/core/v1"
+	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+
+	"github.com/giantswarm/kvm-operator/service/kvmconfig/v2/key"
+)
+
+func newWorkerService(customObject v1alpha1.KVMConfig) *apiv1.Service {
+	service := &apiv1.Service{
+		TypeMeta: apismetav1.TypeMeta{
+			Kind:       "service",
+			APIVersion: "v1",
+		},
+		ObjectMeta: apismetav1.ObjectMeta{
+			Name: key.WorkerID,
+			Labels: map[string]string{
+				"cluster":  key.ClusterID(customObject),
+				"customer": key.ClusterCustomer(customObject),
+				"app":      key.WorkerID,
+			},
+		},
+		Spec: apiv1.ServiceSpec{
+			Type: apiv1.ServiceTypeLoadBalancer,
+			Ports: []apiv1.ServicePort{
+				{
+					Name:       "http",
+					Port:       int32(30010),
+					Protocol:   apiv1.ProtocolTCP,
+					TargetPort: intstr.FromInt(30010),
+				},
+				{
+					Name:       "https",
+					Port:       int32(30011),
+					Protocol:   apiv1.ProtocolTCP,
+					TargetPort: intstr.FromInt(30011),
+				},
+			},
+			// Note that we do not use a selector definition on purpose to be able to
+			// manually set the IP address of the actual VM.
+		},
+	}
+
+	return service
+}

--- a/service/kvmconfig/v3/resource/service/worker_service.go
+++ b/service/kvmconfig/v3/resource/service/worker_service.go
@@ -6,7 +6,7 @@ import (
 	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
-	"github.com/giantswarm/kvm-operator/service/kvmconfig/v2/key"
+	"github.com/giantswarm/kvm-operator/service/kvmconfig/v3/key"
 )
 
 func newWorkerService(customObject v1alpha1.KVMConfig) *apiv1.Service {

--- a/service/kvmconfig/v3/resources.go
+++ b/service/kvmconfig/v3/resources.go
@@ -11,14 +11,14 @@ import (
 	"github.com/giantswarm/randomkeys"
 	"k8s.io/client-go/kubernetes"
 
-	// TODO copy missing v2 resources and veresion messagecontext.
-	"github.com/giantswarm/kvm-operator/service/kvmconfig/v2/resource/ingress"
-	"github.com/giantswarm/kvm-operator/service/kvmconfig/v2/resource/namespace"
-	"github.com/giantswarm/kvm-operator/service/kvmconfig/v2/resource/pvc"
-	"github.com/giantswarm/kvm-operator/service/kvmconfig/v2/resource/service"
+	// TODO veresion messagecontext.
 	"github.com/giantswarm/kvm-operator/service/kvmconfig/v3/cloudconfig"
 	"github.com/giantswarm/kvm-operator/service/kvmconfig/v3/resource/configmap"
 	"github.com/giantswarm/kvm-operator/service/kvmconfig/v3/resource/deployment"
+	"github.com/giantswarm/kvm-operator/service/kvmconfig/v3/resource/ingress"
+	"github.com/giantswarm/kvm-operator/service/kvmconfig/v3/resource/namespace"
+	"github.com/giantswarm/kvm-operator/service/kvmconfig/v3/resource/pvc"
+	"github.com/giantswarm/kvm-operator/service/kvmconfig/v3/resource/service"
 	"github.com/giantswarm/kvm-operator/service/kvmconfig/v3/resource/serviceaccount"
 )
 


### PR DESCRIPTION
Please review commit by commit.

1. Is a copy commit. Nothing changed.
2. `/v2/` got replaced with `/v3/`.
3. Fixed imports in resources.go

I'm going to `Rebase and merge` which means all of those commits will land in the master branch.