### PR TITLE
pin node controller docker image in v3 deployment resource

### DIFF
--- a/service/kvmconfig/v3/key/key.go
+++ b/service/kvmconfig/v3/key/key.go
@@ -36,8 +36,9 @@ const (
 
 	FlannelEnvPathPrefix = "/run/flannel"
 
-	K8SKVMHealthDocker       = "quay.io/giantswarm/k8s-kvm-health:ddf211dfed52086ade32ab8c45e44eb0273319ef"
-	K8SEndpointUpdaterDocker = "quay.io/giantswarm/k8s-endpoint-updater:df982fc73b71e60fc70a7444c068b52441ddb30e"
+	K8SEndpointUpdaterDocker  = "quay.io/giantswarm/k8s-endpoint-updater:df982fc73b71e60fc70a7444c068b52441ddb30e"
+	K8SKVMHealthDocker        = "quay.io/giantswarm/k8s-kvm-health:ddf211dfed52086ade32ab8c45e44eb0273319ef"
+	NodeControllerDockerImage = "quay.io/giantswarm/kvm-operator-node-controller:e63163a2fc0a34a519cdd5c787b3e2e4cbadd5a2"
 
 	// defaultWorkerMemory represents the extra memory to add due to qemu overhead.
 	defaultWorkerMemory = "1G"
@@ -91,13 +92,6 @@ func DeploymentName(prefix string, nodeID string) string {
 
 func EtcdPVCName(clusterID string, vmNumber string) string {
 	return fmt.Sprintf("%s-%s-%s", "pvc-master-etcd", clusterID, vmNumber)
-}
-
-func HasNodeController(customObject v1alpha1.KVMConfig) bool {
-	if customObject.Spec.KVM.NodeController != (v1alpha1.KVMConfigSpecKVMNodeController{}) {
-		return true
-	}
-	return false
 }
 
 func NetworkEnvFilePath(customObject v1alpha1.KVMConfig) string {

--- a/service/kvmconfig/v3/key/key_test.go
+++ b/service/kvmconfig/v3/key/key_test.go
@@ -45,55 +45,6 @@ func Test_ClusterCustomer(t *testing.T) {
 	}
 }
 
-func Test_HasNodeController(t *testing.T) {
-	testCases := []struct {
-		Obj            v1alpha1.KVMConfig
-		ExpectedResult bool
-	}{
-		{
-			Obj: v1alpha1.KVMConfig{
-				Spec: v1alpha1.KVMConfigSpec{
-					KVM: v1alpha1.KVMConfigSpecKVM{
-						K8sKVM: v1alpha1.KVMConfigSpecKVMK8sKVM{
-							Docker: v1alpha1.KVMConfigSpecKVMK8sKVMDocker{
-								Image: "123",
-							},
-						},
-						NodeController: v1alpha1.KVMConfigSpecKVMNodeController{
-							Docker: v1alpha1.KVMConfigSpecKVMNodeControllerDocker{
-								Image: "123",
-							},
-						},
-					},
-				},
-			},
-			ExpectedResult: true,
-		},
-		{
-			Obj: v1alpha1.KVMConfig{
-				Spec: v1alpha1.KVMConfigSpec{
-					KVM: v1alpha1.KVMConfigSpecKVM{
-						K8sKVM: v1alpha1.KVMConfigSpecKVMK8sKVM{
-							Docker: v1alpha1.KVMConfigSpecKVMK8sKVMDocker{
-								Image: "123",
-							},
-						},
-					},
-				},
-			},
-			ExpectedResult: false,
-		},
-	}
-
-	for i, tc := range testCases {
-		ActualResult := HasNodeController(tc.Obj)
-
-		if ActualResult != tc.ExpectedResult {
-			t.Fatalf("Case %d expected %t got %t", i+1, tc.ExpectedResult, ActualResult)
-		}
-	}
-}
-
 func Test_NetworkDNSBlock(t *testing.T) {
 	dnsServers := NetworkDNSBlock([]net.IP{
 		net.ParseIP("8.8.8.8"),

--- a/service/kvmconfig/v3/resource/deployment/desired.go
+++ b/service/kvmconfig/v3/resource/deployment/desired.go
@@ -33,13 +33,11 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interf
 		}
 		deployments = append(deployments, workerDeployments...)
 
-		if key.HasNodeController(customObject) {
-			nodeControllerDeployment, err := newNodeControllerDeployment(customObject)
-			if err != nil {
-				return nil, microerror.Mask(err)
-			}
-			deployments = append(deployments, nodeControllerDeployment)
+		nodeControllerDeployment, err := newNodeControllerDeployment(customObject)
+		if err != nil {
+			return nil, microerror.Mask(err)
 		}
+		deployments = append(deployments, nodeControllerDeployment)
 	}
 
 	r.logger.LogCtx(ctx, "debug", fmt.Sprintf("computed the %d new deployments", len(deployments)))

--- a/service/kvmconfig/v3/resource/deployment/desired_test.go
+++ b/service/kvmconfig/v3/resource/deployment/desired_test.go
@@ -50,7 +50,7 @@ func Test_Resource_Deployment_GetDesiredState(t *testing.T) {
 				},
 			},
 			ExpectedMasterCount:   1,
-			ExpectedNodeCtrlCount: 0,
+			ExpectedNodeCtrlCount: 1,
 			ExpectedWorkerCount:   1,
 			ExpectedMastersResources: []apiv1.ResourceRequirements{
 				{
@@ -100,11 +100,6 @@ func Test_Resource_Deployment_GetDesiredState(t *testing.T) {
 						},
 						Masters: []v1alpha1.KVMConfigSpecKVMNode{
 							{CPUs: 1, Memory: "1G"},
-						},
-						NodeController: v1alpha1.KVMConfigSpecKVMNodeController{
-							Docker: v1alpha1.KVMConfigSpecKVMNodeControllerDocker{
-								Image: "123",
-							},
 						},
 						Workers: []v1alpha1.KVMConfigSpecKVMNode{
 							{CPUs: 4, Memory: "8G"},
@@ -189,11 +184,6 @@ func Test_Resource_Deployment_GetDesiredState(t *testing.T) {
 							{CPUs: 1, Memory: "1G"},
 							{CPUs: 1, Memory: "1G"},
 							{CPUs: 1, Memory: "1G"},
-						},
-						NodeController: v1alpha1.KVMConfigSpecKVMNodeController{
-							Docker: v1alpha1.KVMConfigSpecKVMNodeControllerDocker{
-								Image: "123",
-							},
 						},
 						Workers: []v1alpha1.KVMConfigSpecKVMNode{
 							{CPUs: 4, Memory: "8G"},

--- a/service/kvmconfig/v3/resource/deployment/node_controller_deployment.go
+++ b/service/kvmconfig/v3/resource/deployment/node_controller_deployment.go
@@ -50,7 +50,7 @@ func newNodeControllerDeployment(customObject v1alpha1.KVMConfig) (*extensionsv1
 					Containers: []apiv1.Container{
 						{
 							Name:            key.NodeControllerID,
-							Image:           customObject.Spec.KVM.NodeController.Docker.Image,
+							Image:           key.NodeControllerDockerImage,
 							ImagePullPolicy: apiv1.PullIfNotPresent,
 							Args: []string{
 								fmt.Sprintf("-cluster-api=%s", key.ClusterAPIEndpoint(customObject)),


### PR DESCRIPTION
Here we hard code the Docker image of the node-controller to get rid of it in the KVMConfig custom object eventually. The changes are only applied to v3 resources which are only used by the WIP version bundle `1.1.0`. Existing clusters are not affected. This PR also fixes https://github.com/giantswarm/kvm-operator/issues/223. See also https://github.com/giantswarm/kubernetesd/pull/359 and https://github.com/giantswarm/apiextensions/pull/44. 