### PR TITLE
added version bundles to version command of microkit daemon

### DIFF
--- a/service/service.go
+++ b/service/service.go
@@ -32,19 +32,6 @@ type Config struct {
 	Viper       *viper.Viper
 }
 
-func DefaultConfig() Config {
-	return Config{
-		Logger: nil,
-
-		Description: "",
-		Flag:        nil,
-		GitCommit:   "",
-		Name:        "",
-		Source:      "",
-		Viper:       nil,
-	}
-}
-
 type Service struct {
 	Healthz            *healthz.Service
 	KVMConfigFramework *framework.Framework
@@ -157,7 +144,7 @@ func New(config Config) (*Service, error) {
 		versionConfig.GitCommit = config.GitCommit
 		versionConfig.Name = config.Name
 		versionConfig.Source = config.Source
-		versionConfig.VersionBundles = newVersionBundles()
+		versionConfig.VersionBundles = NewVersionBundles()
 
 		versionService, err = version.New(versionConfig)
 		if err != nil {

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -16,14 +16,16 @@ func Test_Service_New(t *testing.T) {
 	}{
 		// Test that the default config is invalid.
 		{
-			config:               DefaultConfig,
+			config: func() Config {
+				return Config{}
+			},
 			expectedErrorHandler: IsInvalidConfig,
 		},
 
 		// Test a production-like config is valid.
 		{
 			config: func() Config {
-				config := DefaultConfig()
+				config := Config{}
 
 				config.Logger = microloggertest.New()
 

--- a/service/version_bundles.go
+++ b/service/version_bundles.go
@@ -6,7 +6,7 @@ import (
 	"github.com/giantswarm/versionbundle"
 )
 
-func newVersionBundles() []versionbundle.Bundle {
+func NewVersionBundles() []versionbundle.Bundle {
 	return []versionbundle.Bundle{
 		{
 			Changelogs: []versionbundle.Changelog{


### PR DESCRIPTION
### Before

```
$ ./kvm-operator version
description: The kvm-operator handles Kubernetes clusters running on a Kubernetes
  cluster.
gitcommit: n/a
name: kvm-operator
source: https://github.com/giantswarm/kvm-operator
goversion: go1.9.1
os: darwin
arch: amd64
versionbundles: []
```

### Now

```
$ ./kvm-operator version
description: The kvm-operator handles Kubernetes clusters running on a Kubernetes
  cluster.
gitcommit: n/a
name: kvm-operator
source: https://github.com/giantswarm/kvm-operator
goversion: go1.9.1
os: darwin
arch: amd64
versionbundles:
- changelogs:
  - component: calico
    description: Calico version updated.
    kind: changed
  - component: docker
    description: Docker version updated.
    kind: changed
  - component: etcd
    description: Etcd version updated.
    kind: changed
  - component: kubedns
    description: KubeDNS version updated.
    kind: changed
  - component: kubernetes
    description: Kubernetes version updated.
    kind: changed
  - component: nginx-ingress-controller
    description: Nginx-ingress-controller version updated.
    kind: changed
  components:
  - name: calico
    version: 2.6.2
  - name: docker
    version: 1.12.6
  - name: etcd
    version: 3.2.7
  - name: kubedns
    version: 1.14.5
  - name: kubernetes
    version: 1.8.1
  - name: nginx-ingress-controller
    version: 0.9.0
  dependencies: []
  deprecated: true
  name: kvm-operator
  time: 2017-10-26T16:38:00Z
  version: 0.1.0
  wip: false
- changelogs:
  - component: kubernetes
    description: Updated to kubernetes 1.8.4. Fixes a goroutine leak in the k8s api.
    kind: changed
  components:
  - name: calico
    version: 2.6.2
  - name: docker
    version: 1.12.6
  - name: etcd
    version: 3.2.7
  - name: kubedns
    version: 1.14.5
  - name: kubernetes
    version: 1.8.4
  - name: nginx-ingress-controller
    version: 0.9.0
  dependencies: []
  deprecated: false
  name: kvm-operator
  time: 2017-12-12T10:00:00Z
  version: 1.0.0
  wip: false
- changelogs:
  - component: kubernetes
    description: Enable encryption at rest
    kind: changed
  components:
  - name: calico
    version: 2.6.2
  - name: docker
    version: 1.12.6
  - name: etcd
    version: 3.2.7
  - name: kubedns
    version: 1.14.5
  - name: kubernetes
    version: 1.8.4
  - name: nginx-ingress-controller
    version: 0.9.0
  dependencies: []
  deprecated: false
  name: kvm-operator
  time: 2017-12-19T10:00:00Z
  version: 1.1.0
  wip: true
```