### PR TITLE
kvmconfig/v4: update imports

### DIFF
--- a/service/kvmconfig/v4/cloudconfig/cloudconfigtest/cloudconfigtest.go
+++ b/service/kvmconfig/v4/cloudconfig/cloudconfigtest/cloudconfigtest.go
@@ -1,7 +1,7 @@
 package cloudconfigtest
 
 import (
-	"github.com/giantswarm/kvm-operator/service/kvmconfig/v3/cloudconfig"
+	"github.com/giantswarm/kvm-operator/service/kvmconfig/v4/cloudconfig"
 	"github.com/giantswarm/micrologger/microloggertest"
 )
 

--- a/service/kvmconfig/v4/error.go
+++ b/service/kvmconfig/v4/error.go
@@ -1,4 +1,4 @@
-package v3
+package v4
 
 import "github.com/giantswarm/microerror"
 

--- a/service/kvmconfig/v4/resource/configmap/create.go
+++ b/service/kvmconfig/v4/resource/configmap/create.go
@@ -8,7 +8,7 @@ import (
 	apiv1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 
-	"github.com/giantswarm/kvm-operator/service/kvmconfig/v3/key"
+	"github.com/giantswarm/kvm-operator/service/kvmconfig/v4/key"
 )
 
 func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange interface{}) error {

--- a/service/kvmconfig/v4/resource/configmap/create_test.go
+++ b/service/kvmconfig/v4/resource/configmap/create_test.go
@@ -12,7 +12,7 @@ import (
 	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 
-	"github.com/giantswarm/kvm-operator/service/kvmconfig/v3/cloudconfig/cloudconfigtest"
+	"github.com/giantswarm/kvm-operator/service/kvmconfig/v4/cloudconfig/cloudconfigtest"
 )
 
 func Test_Resource_CloudConfig_newCreateChange(t *testing.T) {

--- a/service/kvmconfig/v4/resource/configmap/current.go
+++ b/service/kvmconfig/v4/resource/configmap/current.go
@@ -8,7 +8,7 @@ import (
 	apiv1 "k8s.io/api/core/v1"
 	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/giantswarm/kvm-operator/service/kvmconfig/v3/key"
+	"github.com/giantswarm/kvm-operator/service/kvmconfig/v4/key"
 )
 
 func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interface{}, error) {

--- a/service/kvmconfig/v4/resource/configmap/delete.go
+++ b/service/kvmconfig/v4/resource/configmap/delete.go
@@ -10,7 +10,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/giantswarm/kvm-operator/service/kvmconfig/v3/key"
+	"github.com/giantswarm/kvm-operator/service/kvmconfig/v4/key"
 )
 
 func (r *Resource) ApplyDeleteChange(ctx context.Context, obj, deleteChange interface{}) error {

--- a/service/kvmconfig/v4/resource/configmap/delete_test.go
+++ b/service/kvmconfig/v4/resource/configmap/delete_test.go
@@ -12,7 +12,7 @@ import (
 	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 
-	"github.com/giantswarm/kvm-operator/service/kvmconfig/v3/cloudconfig/cloudconfigtest"
+	"github.com/giantswarm/kvm-operator/service/kvmconfig/v4/cloudconfig/cloudconfigtest"
 )
 
 func Test_Resource_CloudConfig_newDeleteChange(t *testing.T) {

--- a/service/kvmconfig/v4/resource/configmap/desired.go
+++ b/service/kvmconfig/v4/resource/configmap/desired.go
@@ -9,7 +9,7 @@ import (
 	apiv1 "k8s.io/api/core/v1"
 	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/giantswarm/kvm-operator/service/kvmconfig/v3/key"
+	"github.com/giantswarm/kvm-operator/service/kvmconfig/v4/key"
 )
 
 func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interface{}, error) {

--- a/service/kvmconfig/v4/resource/configmap/desired_test.go
+++ b/service/kvmconfig/v4/resource/configmap/desired_test.go
@@ -12,7 +12,7 @@ import (
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes/fake"
 
-	"github.com/giantswarm/kvm-operator/service/kvmconfig/v3/cloudconfig/cloudconfigtest"
+	"github.com/giantswarm/kvm-operator/service/kvmconfig/v4/cloudconfig/cloudconfigtest"
 )
 
 func Test_Resource_CloudConfig_GetDesiredState(t *testing.T) {

--- a/service/kvmconfig/v4/resource/configmap/resource.go
+++ b/service/kvmconfig/v4/resource/configmap/resource.go
@@ -11,7 +11,7 @@ import (
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
 
-	"github.com/giantswarm/kvm-operator/service/kvmconfig/v3/cloudconfig"
+	"github.com/giantswarm/kvm-operator/service/kvmconfig/v4/cloudconfig"
 )
 
 const (

--- a/service/kvmconfig/v4/resource/configmap/update.go
+++ b/service/kvmconfig/v4/resource/configmap/update.go
@@ -8,7 +8,7 @@ import (
 	"github.com/giantswarm/operatorkit/framework"
 	apiv1 "k8s.io/api/core/v1"
 
-	"github.com/giantswarm/kvm-operator/service/kvmconfig/v3/key"
+	"github.com/giantswarm/kvm-operator/service/kvmconfig/v4/key"
 )
 
 func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateChange interface{}) error {

--- a/service/kvmconfig/v4/resource/configmap/update_test.go
+++ b/service/kvmconfig/v4/resource/configmap/update_test.go
@@ -13,7 +13,7 @@ import (
 	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 
-	"github.com/giantswarm/kvm-operator/service/kvmconfig/v3/cloudconfig/cloudconfigtest"
+	"github.com/giantswarm/kvm-operator/service/kvmconfig/v4/cloudconfig/cloudconfigtest"
 )
 
 func Test_Resource_CloudConfig_newUpdateChange(t *testing.T) {

--- a/service/kvmconfig/v4/resource/deployment/create.go
+++ b/service/kvmconfig/v4/resource/deployment/create.go
@@ -8,7 +8,7 @@ import (
 	"k8s.io/api/extensions/v1beta1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 
-	"github.com/giantswarm/kvm-operator/service/kvmconfig/v3/key"
+	"github.com/giantswarm/kvm-operator/service/kvmconfig/v4/key"
 )
 
 func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange interface{}) error {

--- a/service/kvmconfig/v4/resource/deployment/current.go
+++ b/service/kvmconfig/v4/resource/deployment/current.go
@@ -11,7 +11,7 @@ import (
 	"k8s.io/api/extensions/v1beta1"
 	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/giantswarm/kvm-operator/service/kvmconfig/v3/key"
+	"github.com/giantswarm/kvm-operator/service/kvmconfig/v4/key"
 )
 
 func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interface{}, error) {

--- a/service/kvmconfig/v4/resource/deployment/delete.go
+++ b/service/kvmconfig/v4/resource/deployment/delete.go
@@ -10,7 +10,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/giantswarm/kvm-operator/service/kvmconfig/v3/key"
+	"github.com/giantswarm/kvm-operator/service/kvmconfig/v4/key"
 )
 
 func (r *Resource) ApplyDeleteChange(ctx context.Context, obj, deleteChange interface{}) error {

--- a/service/kvmconfig/v4/resource/deployment/desired.go
+++ b/service/kvmconfig/v4/resource/deployment/desired.go
@@ -7,7 +7,7 @@ import (
 	"github.com/giantswarm/microerror"
 	"k8s.io/api/extensions/v1beta1"
 
-	"github.com/giantswarm/kvm-operator/service/kvmconfig/v3/key"
+	"github.com/giantswarm/kvm-operator/service/kvmconfig/v4/key"
 )
 
 func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interface{}, error) {

--- a/service/kvmconfig/v4/resource/deployment/master_deployment.go
+++ b/service/kvmconfig/v4/resource/deployment/master_deployment.go
@@ -11,7 +11,7 @@ import (
 	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
-	"github.com/giantswarm/kvm-operator/service/kvmconfig/v3/key"
+	"github.com/giantswarm/kvm-operator/service/kvmconfig/v4/key"
 )
 
 func newMasterDeployments(customObject v1alpha1.KVMConfig) ([]*extensionsv1.Deployment, error) {

--- a/service/kvmconfig/v4/resource/deployment/master_pod_affinity.go
+++ b/service/kvmconfig/v4/resource/deployment/master_pod_affinity.go
@@ -5,7 +5,7 @@ import (
 	apiv1 "k8s.io/api/core/v1"
 	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/giantswarm/kvm-operator/service/kvmconfig/v3/key"
+	"github.com/giantswarm/kvm-operator/service/kvmconfig/v4/key"
 )
 
 func newMasterPodAfinity(customObject v1alpha1.KVMConfig) *apiv1.Affinity {

--- a/service/kvmconfig/v4/resource/deployment/node_controller_deployment.go
+++ b/service/kvmconfig/v4/resource/deployment/node_controller_deployment.go
@@ -9,7 +9,7 @@ import (
 	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
-	"github.com/giantswarm/kvm-operator/service/kvmconfig/v3/key"
+	"github.com/giantswarm/kvm-operator/service/kvmconfig/v4/key"
 )
 
 func newNodeControllerDeployment(customObject v1alpha1.KVMConfig) (*extensionsv1.Deployment, error) {

--- a/service/kvmconfig/v4/resource/deployment/update.go
+++ b/service/kvmconfig/v4/resource/deployment/update.go
@@ -9,7 +9,7 @@ import (
 	"github.com/giantswarm/operatorkit/framework/context/updateallowedcontext"
 	"k8s.io/api/extensions/v1beta1"
 
-	"github.com/giantswarm/kvm-operator/service/kvmconfig/v3/key"
+	"github.com/giantswarm/kvm-operator/service/kvmconfig/v4/key"
 )
 
 func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateChange interface{}) error {

--- a/service/kvmconfig/v4/resource/deployment/worker_deployment.go
+++ b/service/kvmconfig/v4/resource/deployment/worker_deployment.go
@@ -11,7 +11,7 @@ import (
 	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
-	"github.com/giantswarm/kvm-operator/service/kvmconfig/v3/key"
+	"github.com/giantswarm/kvm-operator/service/kvmconfig/v4/key"
 )
 
 func newWorkerDeployments(customObject v1alpha1.KVMConfig) ([]*extensionsv1.Deployment, error) {

--- a/service/kvmconfig/v4/resource/deployment/worker_pod_affinity.go
+++ b/service/kvmconfig/v4/resource/deployment/worker_pod_affinity.go
@@ -5,7 +5,7 @@ import (
 	apiv1 "k8s.io/api/core/v1"
 	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/giantswarm/kvm-operator/service/kvmconfig/v3/key"
+	"github.com/giantswarm/kvm-operator/service/kvmconfig/v4/key"
 )
 
 func newWorkerPodAfinity(customObject v1alpha1.KVMConfig) *apiv1.Affinity {

--- a/service/kvmconfig/v4/resource/ingress/api_ingress.go
+++ b/service/kvmconfig/v4/resource/ingress/api_ingress.go
@@ -6,7 +6,7 @@ import (
 	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
-	"github.com/giantswarm/kvm-operator/service/kvmconfig/v3/key"
+	"github.com/giantswarm/kvm-operator/service/kvmconfig/v4/key"
 )
 
 func newAPIIngress(customObject v1alpha1.KVMConfig) *extensionsv1.Ingress {

--- a/service/kvmconfig/v4/resource/ingress/create.go
+++ b/service/kvmconfig/v4/resource/ingress/create.go
@@ -8,7 +8,7 @@ import (
 	"k8s.io/api/extensions/v1beta1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 
-	"github.com/giantswarm/kvm-operator/service/kvmconfig/v3/key"
+	"github.com/giantswarm/kvm-operator/service/kvmconfig/v4/key"
 )
 
 func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange interface{}) error {

--- a/service/kvmconfig/v4/resource/ingress/current.go
+++ b/service/kvmconfig/v4/resource/ingress/current.go
@@ -9,7 +9,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/giantswarm/kvm-operator/service/kvmconfig/v3/key"
+	"github.com/giantswarm/kvm-operator/service/kvmconfig/v4/key"
 )
 
 func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interface{}, error) {

--- a/service/kvmconfig/v4/resource/ingress/delete.go
+++ b/service/kvmconfig/v4/resource/ingress/delete.go
@@ -10,7 +10,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/giantswarm/kvm-operator/service/kvmconfig/v3/key"
+	"github.com/giantswarm/kvm-operator/service/kvmconfig/v4/key"
 )
 
 func (r *Resource) ApplyDeleteChange(ctx context.Context, obj, deleteChange interface{}) error {

--- a/service/kvmconfig/v4/resource/ingress/desired.go
+++ b/service/kvmconfig/v4/resource/ingress/desired.go
@@ -7,7 +7,7 @@ import (
 	"github.com/giantswarm/microerror"
 	"k8s.io/api/extensions/v1beta1"
 
-	"github.com/giantswarm/kvm-operator/service/kvmconfig/v3/key"
+	"github.com/giantswarm/kvm-operator/service/kvmconfig/v4/key"
 )
 
 func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interface{}, error) {

--- a/service/kvmconfig/v4/resource/ingress/etcd_ingress.go
+++ b/service/kvmconfig/v4/resource/ingress/etcd_ingress.go
@@ -6,7 +6,7 @@ import (
 	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
-	"github.com/giantswarm/kvm-operator/service/kvmconfig/v3/key"
+	"github.com/giantswarm/kvm-operator/service/kvmconfig/v4/key"
 )
 
 func newEtcdIngress(customObject v1alpha1.KVMConfig) *extensionsv1.Ingress {

--- a/service/kvmconfig/v4/resource/namespace/current.go
+++ b/service/kvmconfig/v4/resource/namespace/current.go
@@ -9,7 +9,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/giantswarm/kvm-operator/service/kvmconfig/v3/key"
+	"github.com/giantswarm/kvm-operator/service/kvmconfig/v4/key"
 )
 
 func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interface{}, error) {

--- a/service/kvmconfig/v4/resource/namespace/desired.go
+++ b/service/kvmconfig/v4/resource/namespace/desired.go
@@ -7,7 +7,7 @@ import (
 	apiv1 "k8s.io/api/core/v1"
 	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/giantswarm/kvm-operator/service/kvmconfig/v3/key"
+	"github.com/giantswarm/kvm-operator/service/kvmconfig/v4/key"
 )
 
 func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interface{}, error) {

--- a/service/kvmconfig/v4/resource/pvc/create.go
+++ b/service/kvmconfig/v4/resource/pvc/create.go
@@ -8,7 +8,7 @@ import (
 	apiv1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 
-	"github.com/giantswarm/kvm-operator/service/kvmconfig/v3/key"
+	"github.com/giantswarm/kvm-operator/service/kvmconfig/v4/key"
 )
 
 func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange interface{}) error {

--- a/service/kvmconfig/v4/resource/pvc/current.go
+++ b/service/kvmconfig/v4/resource/pvc/current.go
@@ -9,7 +9,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/giantswarm/kvm-operator/service/kvmconfig/v3/key"
+	"github.com/giantswarm/kvm-operator/service/kvmconfig/v4/key"
 )
 
 func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interface{}, error) {

--- a/service/kvmconfig/v4/resource/pvc/delete.go
+++ b/service/kvmconfig/v4/resource/pvc/delete.go
@@ -10,7 +10,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/giantswarm/kvm-operator/service/kvmconfig/v3/key"
+	"github.com/giantswarm/kvm-operator/service/kvmconfig/v4/key"
 )
 
 func (r *Resource) ApplyDeleteChange(ctx context.Context, obj, deleteChange interface{}) error {

--- a/service/kvmconfig/v4/resource/pvc/desired.go
+++ b/service/kvmconfig/v4/resource/pvc/desired.go
@@ -7,7 +7,7 @@ import (
 	"github.com/giantswarm/microerror"
 	apiv1 "k8s.io/api/core/v1"
 
-	"github.com/giantswarm/kvm-operator/service/kvmconfig/v3/key"
+	"github.com/giantswarm/kvm-operator/service/kvmconfig/v4/key"
 )
 
 func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interface{}, error) {

--- a/service/kvmconfig/v4/resource/pvc/etcd_pvc.go
+++ b/service/kvmconfig/v4/resource/pvc/etcd_pvc.go
@@ -7,7 +7,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/giantswarm/kvm-operator/service/kvmconfig/v3/key"
+	"github.com/giantswarm/kvm-operator/service/kvmconfig/v4/key"
 )
 
 const (

--- a/service/kvmconfig/v4/resource/service/create.go
+++ b/service/kvmconfig/v4/resource/service/create.go
@@ -8,7 +8,7 @@ import (
 	apiv1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 
-	"github.com/giantswarm/kvm-operator/service/kvmconfig/v3/key"
+	"github.com/giantswarm/kvm-operator/service/kvmconfig/v4/key"
 )
 
 func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange interface{}) error {

--- a/service/kvmconfig/v4/resource/service/current.go
+++ b/service/kvmconfig/v4/resource/service/current.go
@@ -9,7 +9,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/giantswarm/kvm-operator/service/kvmconfig/v3/key"
+	"github.com/giantswarm/kvm-operator/service/kvmconfig/v4/key"
 )
 
 func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interface{}, error) {

--- a/service/kvmconfig/v4/resource/service/delete.go
+++ b/service/kvmconfig/v4/resource/service/delete.go
@@ -10,7 +10,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/giantswarm/kvm-operator/service/kvmconfig/v3/key"
+	"github.com/giantswarm/kvm-operator/service/kvmconfig/v4/key"
 )
 
 func (r *Resource) ApplyDeleteChange(ctx context.Context, obj, deleteChange interface{}) error {

--- a/service/kvmconfig/v4/resource/service/desired.go
+++ b/service/kvmconfig/v4/resource/service/desired.go
@@ -7,7 +7,7 @@ import (
 	"github.com/giantswarm/microerror"
 	apiv1 "k8s.io/api/core/v1"
 
-	"github.com/giantswarm/kvm-operator/service/kvmconfig/v3/key"
+	"github.com/giantswarm/kvm-operator/service/kvmconfig/v4/key"
 )
 
 func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interface{}, error) {

--- a/service/kvmconfig/v4/resource/service/master_service.go
+++ b/service/kvmconfig/v4/resource/service/master_service.go
@@ -5,7 +5,7 @@ import (
 	apiv1 "k8s.io/api/core/v1"
 	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/giantswarm/kvm-operator/service/kvmconfig/v3/key"
+	"github.com/giantswarm/kvm-operator/service/kvmconfig/v4/key"
 )
 
 func newMasterService(customObject v1alpha1.KVMConfig) *apiv1.Service {

--- a/service/kvmconfig/v4/resource/service/worker_service.go
+++ b/service/kvmconfig/v4/resource/service/worker_service.go
@@ -6,7 +6,7 @@ import (
 	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
-	"github.com/giantswarm/kvm-operator/service/kvmconfig/v3/key"
+	"github.com/giantswarm/kvm-operator/service/kvmconfig/v4/key"
 )
 
 func newWorkerService(customObject v1alpha1.KVMConfig) *apiv1.Service {

--- a/service/kvmconfig/v4/resource/serviceaccount/create.go
+++ b/service/kvmconfig/v4/resource/serviceaccount/create.go
@@ -8,7 +8,7 @@ import (
 	apiv1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 
-	"github.com/giantswarm/kvm-operator/service/kvmconfig/v3/key"
+	"github.com/giantswarm/kvm-operator/service/kvmconfig/v4/key"
 )
 
 func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange interface{}) error {

--- a/service/kvmconfig/v4/resource/serviceaccount/current.go
+++ b/service/kvmconfig/v4/resource/serviceaccount/current.go
@@ -9,7 +9,7 @@ import (
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 
-	"github.com/giantswarm/kvm-operator/service/kvmconfig/v3/key"
+	"github.com/giantswarm/kvm-operator/service/kvmconfig/v4/key"
 )
 
 func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interface{}, error) {

--- a/service/kvmconfig/v4/resource/serviceaccount/delete.go
+++ b/service/kvmconfig/v4/resource/serviceaccount/delete.go
@@ -9,7 +9,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/giantswarm/kvm-operator/service/kvmconfig/v3/key"
+	"github.com/giantswarm/kvm-operator/service/kvmconfig/v4/key"
 )
 
 func (r *Resource) ApplyDeleteChange(ctx context.Context, obj, deleteChange interface{}) error {

--- a/service/kvmconfig/v4/resource/serviceaccount/desired.go
+++ b/service/kvmconfig/v4/resource/serviceaccount/desired.go
@@ -7,7 +7,7 @@ import (
 	apiv1 "k8s.io/api/core/v1"
 	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/giantswarm/kvm-operator/service/kvmconfig/v3/key"
+	"github.com/giantswarm/kvm-operator/service/kvmconfig/v4/key"
 )
 
 func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interface{}, error) {

--- a/service/kvmconfig/v4/resource_set.go
+++ b/service/kvmconfig/v4/resource_set.go
@@ -1,4 +1,4 @@
-package v3
+package v4
 
 import (
 	"context"
@@ -14,15 +14,15 @@ import (
 	"github.com/giantswarm/randomkeys"
 	"k8s.io/client-go/kubernetes"
 
-	"github.com/giantswarm/kvm-operator/service/kvmconfig/v3/cloudconfig"
-	"github.com/giantswarm/kvm-operator/service/kvmconfig/v3/key"
-	"github.com/giantswarm/kvm-operator/service/kvmconfig/v3/resource/configmap"
-	"github.com/giantswarm/kvm-operator/service/kvmconfig/v3/resource/deployment"
-	"github.com/giantswarm/kvm-operator/service/kvmconfig/v3/resource/ingress"
-	"github.com/giantswarm/kvm-operator/service/kvmconfig/v3/resource/namespace"
-	"github.com/giantswarm/kvm-operator/service/kvmconfig/v3/resource/pvc"
-	"github.com/giantswarm/kvm-operator/service/kvmconfig/v3/resource/service"
-	"github.com/giantswarm/kvm-operator/service/kvmconfig/v3/resource/serviceaccount"
+	"github.com/giantswarm/kvm-operator/service/kvmconfig/v4/cloudconfig"
+	"github.com/giantswarm/kvm-operator/service/kvmconfig/v4/key"
+	"github.com/giantswarm/kvm-operator/service/kvmconfig/v4/resource/configmap"
+	"github.com/giantswarm/kvm-operator/service/kvmconfig/v4/resource/deployment"
+	"github.com/giantswarm/kvm-operator/service/kvmconfig/v4/resource/ingress"
+	"github.com/giantswarm/kvm-operator/service/kvmconfig/v4/resource/namespace"
+	"github.com/giantswarm/kvm-operator/service/kvmconfig/v4/resource/pvc"
+	"github.com/giantswarm/kvm-operator/service/kvmconfig/v4/resource/service"
+	"github.com/giantswarm/kvm-operator/service/kvmconfig/v4/resource/serviceaccount"
 )
 
 const (


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/2346

New resources will handle 1.1.1 version bundle fixing audit logs (k8scloudconfig v_2_0_1).