### PR TITLE
kvmconfig/v3: remove gauge init

### DIFF
--- a/service/kvmconfig/v3/resource/deployment/metric.go
+++ b/service/kvmconfig/v3/resource/deployment/metric.go
@@ -19,7 +19,3 @@ var versionBundleVersionGauge = prometheus.NewGaugeVec(
 	},
 	[]string{"major", "minor", "patch"},
 )
-
-func init() {
-	prometheus.MustRegister(versionBundleVersionGauge)
-}


### PR DESCRIPTION
This causes panics in v4.

I know it's change on frozen version. But I don't see how we can continue
otherwise. I'll propose a solution which gets rid of the problem.