### PR TITLE
service: freeze 1.2.0; deprecate 1.1.0

### DIFF
--- a/service/version_bundles.go
+++ b/service/version_bundles.go
@@ -150,7 +150,7 @@ func NewVersionBundles() []versionbundle.Bundle {
 				},
 			},
 			Dependencies: []versionbundle.Dependency{},
-			Deprecated:   false,
+			Deprecated:   true,
 			Name:         "kvm-operator",
 			Time:         time.Date(2017, time.December, 19, 10, 00, 0, 0, time.UTC),
 			Version:      "1.1.0",
@@ -166,7 +166,7 @@ func NewVersionBundles() []versionbundle.Bundle {
 				},
 				{
 					Component:   "kubernetes",
-					Description: "Fix audit log.",
+					Description: "Fixed audit log.",
 					Kind:        "fixed",
 				},
 			},
@@ -204,8 +204,8 @@ func NewVersionBundles() []versionbundle.Bundle {
 			Deprecated:   false,
 			Name:         "kvm-operator",
 			Time:         time.Date(2018, time.February, 8, 6, 25, 0, 0, time.UTC),
-			Version:      "1.1.1",
-			WIP:          true,
+			Version:      "1.2.0",
+			WIP:          false,
 		},
 	}
 }


### PR DESCRIPTION
I'll make announcement in #news-dev and merge on Monday if OK.

This is a minor bump, because of OS update.
This also fixes auditlog issue. Towards https://github.com/giantswarm/giantswarm/issues/2346