### PR TITLE
kvmconfig: fix handling 1.2.0 with v4

### DIFF
--- a/service/kvmconfig/framework.go
+++ b/service/kvmconfig/framework.go
@@ -150,7 +150,7 @@ func NewFramework(config FrameworkConfig) (*framework.Framework, error) {
 
 			GuestUpdateEnabled: config.GuestUpdateEnabled,
 			HandledVersionBundles: []string{
-				"1.1.1",
+				"1.2.0",
 			},
 			ProjectName: config.Name,
 		}


### PR DESCRIPTION
v4 was handling a version that doesn't exist.