### PR TITLE
Update certs dependency

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -75,13 +75,13 @@
   revision = "292a0157b9683e2593f1d65e2e52c5ff2859f124"
 
 [[projects]]
-  branch = "make-calico-etcd-client-cert-optional-for-searcher"
+  branch = "master"
   name = "github.com/giantswarm/certs"
   packages = [
     ".",
     "certstest"
   ]
-  revision = "bcfbbb885eb7371ed64f1729e96c9b4bd1548ea1"
+  revision = "c087c8dd2a0a56cdebb4f41275de1ac448071a9c"
 
 [[projects]]
   branch = "master"
@@ -746,6 +746,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "52b560e47a369946318c81031d9fd00706483bbeefef673094321477241f58ab"
+  inputs-digest = "68ecbd5386e91d3bdf77857595f95748dac26275b718dd0f5601f9020ff957d0"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -75,13 +75,13 @@
   revision = "292a0157b9683e2593f1d65e2e52c5ff2859f124"
 
 [[projects]]
-  branch = "master"
+  branch = "make-calico-etcd-client-cert-optional-for-searcher"
   name = "github.com/giantswarm/certs"
   packages = [
     ".",
     "certstest"
   ]
-  revision = "7be474c80bf0e824b1e575d21fb699686c0a9e4d"
+  revision = "0a3d5eef98a48c1f87c9502043aab23082de025d"
 
 [[projects]]
   branch = "master"
@@ -746,6 +746,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "68ecbd5386e91d3bdf77857595f95748dac26275b718dd0f5601f9020ff957d0"
+  inputs-digest = "52b560e47a369946318c81031d9fd00706483bbeefef673094321477241f58ab"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -81,7 +81,7 @@
     ".",
     "certstest"
   ]
-  revision = "0a3d5eef98a48c1f87c9502043aab23082de025d"
+  revision = "bcfbbb885eb7371ed64f1729e96c9b4bd1548ea1"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -30,7 +30,7 @@
   name = "github.com/giantswarm/apiextensions"
 
 [[constraint]]
-  branch = "make-calico-etcd-client-cert-optional-for-searcher"
+  branch = "master"
   name = "github.com/giantswarm/certs"
 
 [[constraint]]

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -30,7 +30,7 @@
   name = "github.com/giantswarm/apiextensions"
 
 [[constraint]]
-  branch = "master"
+  branch = "make-calico-etcd-client-cert-optional-for-searcher"
   name = "github.com/giantswarm/certs"
 
 [[constraint]]

--- a/vendor/github.com/giantswarm/certs/searcher.go
+++ b/vendor/github.com/giantswarm/certs/searcher.go
@@ -60,12 +60,13 @@ func (s *Searcher) SearchCluster(clusterID string) (Cluster, error) {
 	var cluster Cluster
 
 	certificates := []struct {
-		TLS  *TLS
-		Cert Cert
+		TLS      *TLS
+		Cert     Cert
+		optional bool
 	}{
 		{TLS: &cluster.APIServer, Cert: APICert},
 		{TLS: &cluster.CalicoClient, Cert: CalicoCert},
-		{TLS: &cluster.CalicoEtcdClient, Cert: CalicoEtcdClientCert},
+		{TLS: &cluster.CalicoEtcdClient, Cert: CalicoEtcdClientCert, optional: true},
 		{TLS: &cluster.EtcdServer, Cert: EtcdCert},
 		{TLS: &cluster.ServiceAccount, Cert: ServiceAccountCert},
 		{TLS: &cluster.Worker, Cert: WorkerCert},
@@ -73,7 +74,7 @@ func (s *Searcher) SearchCluster(clusterID string) (Cluster, error) {
 
 	for _, c := range certificates {
 		err := s.search(c.TLS, clusterID, c.Cert)
-		if err != nil {
+		if !c.optional && err != nil {
 			return Cluster{}, microerror.Mask(err)
 		}
 	}

--- a/vendor/github.com/giantswarm/certs/searcher.go
+++ b/vendor/github.com/giantswarm/certs/searcher.go
@@ -74,8 +74,12 @@ func (s *Searcher) SearchCluster(clusterID string) (Cluster, error) {
 
 	for _, c := range certificates {
 		err := s.search(c.TLS, clusterID, c.Cert)
-		if !c.optional && err != nil {
-			return Cluster{}, microerror.Mask(err)
+		if err != nil {
+			if c.optional {
+				s.logger.Log("level", "warning", "message", err.Error())
+			} else {
+				return Cluster{}, microerror.Mask(err)
+			}
 		}
 	}
 


### PR DESCRIPTION
Update certs dependency to fix pressing issue on missing
calico-etcd-client cert on old clusters.