### PR TITLE
opsctl: copy v10 to v11

### DIFF
--- a/service/controller/v11/cloudconfig/cloudconfigtest/cloudconfigtest.go
+++ b/service/controller/v11/cloudconfig/cloudconfigtest/cloudconfigtest.go
@@ -3,7 +3,7 @@ package cloudconfigtest
 import (
 	"github.com/giantswarm/micrologger/microloggertest"
 
-	"github.com/giantswarm/kvm-operator/service/controller/v11/cloudconfig"
+	"github.com/giantswarm/kvm-operator/service/controller/v10/cloudconfig"
 )
 
 func New() *cloudconfig.CloudConfig {

--- a/service/controller/v11/cloudconfig/master_template.go
+++ b/service/controller/v11/cloudconfig/master_template.go
@@ -3,7 +3,7 @@ package cloudconfig
 import (
 	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
 	"github.com/giantswarm/certs"
-	k8scloudconfig "github.com/giantswarm/k8scloudconfig/v_3_2_5"
+	k8scloudconfig "github.com/giantswarm/k8scloudconfig/v_3_2_4"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/randomkeys"
 )
@@ -88,11 +88,11 @@ func (e *masterExtension) Units() ([]k8scloudconfig.UnitAsset, error) {
 			AssetContent: `[Unit]
 Description=Automount for etcd volume
 [Automount]
-Where=/var/lib/etcd
+Where=/etc/kubernetes/data/etcd
 [Install]
 WantedBy=multi-user.target
 `,
-			Name:    "var-lib-etcd.automount",
+			Name:    "etc-kubernetes-data-etcd.automount",
 			Enable:  true,
 			Command: "start",
 		},
@@ -102,13 +102,13 @@ WantedBy=multi-user.target
 Description=Mount for etcd volume
 [Mount]
 What=etcdshare
-Where=/var/lib/etcd
+Where=/etc/kubernetes/data/etcd
 Options=trans=virtio,version=9p2000.L,cache=mmap
 Type=9p
 [Install]
 WantedBy=multi-user.target
 `,
-			Name:   "var-lib-etcd.mount",
+			Name:   "etc-kubernetes-data-etcd.mount",
 			Enable: false,
 		},
 		{

--- a/service/controller/v11/cloudconfig/worker_template.go
+++ b/service/controller/v11/cloudconfig/worker_template.go
@@ -3,7 +3,7 @@ package cloudconfig
 import (
 	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
 	"github.com/giantswarm/certs"
-	k8scloudconfig "github.com/giantswarm/k8scloudconfig/v_3_2_5"
+	k8scloudconfig "github.com/giantswarm/k8scloudconfig/v_3_2_4"
 	"github.com/giantswarm/microerror"
 )
 

--- a/service/controller/v11/error.go
+++ b/service/controller/v11/error.go
@@ -1,4 +1,4 @@
-package v11
+package v10
 
 import "github.com/giantswarm/microerror"
 

--- a/service/controller/v11/key/error.go
+++ b/service/controller/v11/key/error.go
@@ -2,12 +2,6 @@ package key
 
 import "github.com/giantswarm/microerror"
 
-var missingAnnotationError = microerror.New("missing annotation")
-
-func IsMissingAnnotationError(err error) bool {
-	return microerror.Cause(err) == missingAnnotationError
-}
-
 var wrongTypeError = microerror.New("wrong type")
 
 // IsWrongTypeError asserts wrongTypeError.

--- a/service/controller/v11/key/key.go
+++ b/service/controller/v11/key/key.go
@@ -6,11 +6,10 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
 	"github.com/giantswarm/microerror"
-	corev1 "k8s.io/api/core/v1"
+	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 )
 
@@ -37,10 +36,10 @@ const (
 
 	FlannelEnvPathPrefix = "/run/flannel"
 	CoreosImageDir       = "/var/lib/coreos-kvm-images"
-	CoreosVersion        = "1688.5.3"
+	CoreosVersion        = "1632.3.0"
 
 	K8SEndpointUpdaterDocker  = "quay.io/giantswarm/k8s-endpoint-updater:df982fc73b71e60fc70a7444c068b52441ddb30e"
-	K8SKVMDockerImage         = "quay.io/giantswarm/k8s-kvm:16a61cf7fab82df299a1e921bb42e4f6402a8307"
+	K8SKVMDockerImage         = "quay.io/giantswarm/k8s-kvm:4438d70d2181af66ea2b90c7f3bc74d1aa3c55a1"
 	K8SKVMHealthDocker        = "quay.io/giantswarm/k8s-kvm-health:ddf211dfed52086ade32ab8c45e44eb0273319ef"
 	NodeControllerDockerImage = "quay.io/giantswarm/kvm-operator-node-controller:7146561e54142d4f986daee0206336ebee3ceb18"
 
@@ -50,41 +49,16 @@ const (
 	baseWorkerOverheadMultiplier = 2
 	baseWorkerOverheadModulator  = 12
 	workerIOOverhead             = "512M"
-)
 
-const (
-	AnnotationAPIEndpoint = "kvm-operator.giantswarm.io/api-endpoint"
-	AnnotationIp          = "endpoint.kvm.giantswarm.io/ip"
-	AnnotationService     = "endpoint.kvm.giantswarm.io/service"
-	AnnotationPodDrained  = "endpoint.kvm.giantswarm.io/drained"
-)
+	// kvm endpoint annotations
+	AnnotationIp      = "endpoint.kvm.giantswarm.io/ip"
+	AnnotationService = "endpoint.kvm.giantswarm.io/service"
 
-const (
 	VersionBundleVersionAnnotation = "giantswarm.io/version-bundle-version"
-)
-
-const (
-	PodWatcherLabel = "kvm-operator.giantswarm.io/pod-watcher"
-)
-
-const (
-	PodDeletionGracePeriod = 5 * time.Minute
 )
 
 func ClusterAPIEndpoint(customObject v1alpha1.KVMConfig) string {
 	return customObject.Spec.Cluster.Kubernetes.API.Domain
-}
-
-func ClusterAPIEndpointFromPod(pod *corev1.Pod) (string, error) {
-	apiEndpoint, ok := pod.GetAnnotations()[AnnotationAPIEndpoint]
-	if !ok {
-		return "", microerror.Maskf(missingAnnotationError, AnnotationAPIEndpoint)
-	}
-	if apiEndpoint == "" {
-		return "", microerror.Maskf(missingAnnotationError, AnnotationAPIEndpoint)
-	}
-
-	return apiEndpoint, nil
 }
 
 func ClusterCustomer(customObject v1alpha1.KVMConfig) string {
@@ -95,7 +69,7 @@ func ClusterID(customObject v1alpha1.KVMConfig) string {
 	return customObject.Spec.Cluster.ID
 }
 
-func ClusterIDFromPod(pod *corev1.Pod) string {
+func ClusterIDFromPod(pod *apiv1.Pod) string {
 	l, ok := pod.Labels["cluster"]
 	if ok {
 		return l
@@ -143,40 +117,6 @@ func NetworkEnvFilePath(customObject v1alpha1.KVMConfig) string {
 
 func HealthListenAddress(customObject v1alpha1.KVMConfig) string {
 	return "http://" + ProbeHost + ":" + strconv.Itoa(int(LivenessPort(customObject)))
-}
-
-func IsDeleted(customObject v1alpha1.KVMConfig) bool {
-	return customObject.GetDeletionTimestamp() != nil
-}
-
-func IsPodDeleted(pod *corev1.Pod) bool {
-	return pod.GetDeletionTimestamp() != nil
-}
-
-// IsPodDraind checks whether the pod status indicates it got drained. The pod
-// status is partially reflected by its annotations. Here we check for the
-// annotation that tells us if the pod was already drained or not. In case the
-// pod does not have any annotations an unrecoverable error is returned. Such
-// situations should actually never happen. If it happens, something really bad
-// is going on. This is nothing we can just sort right away in our code.
-//
-// TODO(xh3b4sd) handle pod status via the runtime object status primitives
-// and not via annotations.
-func IsPodDraind(pod *corev1.Pod) (bool, error) {
-	a := pod.GetAnnotations()
-	if a == nil {
-		return false, microerror.Mask(missingAnnotationError)
-	}
-	v, ok := a[AnnotationPodDrained]
-	if !ok {
-		return false, microerror.Mask(missingAnnotationError)
-	}
-	b, err := strconv.ParseBool(v)
-	if err != nil {
-		return false, microerror.Mask(err)
-	}
-
-	return b, nil
 }
 
 func LivenessPort(customObject v1alpha1.KVMConfig) int32 {
@@ -296,19 +236,6 @@ func ToCustomObject(v interface{}) (v1alpha1.KVMConfig, error) {
 	customObject := *customObjectPointer
 
 	return customObject, nil
-}
-
-func ToPod(v interface{}) (*corev1.Pod, error) {
-	if v == nil {
-		return nil, nil
-	}
-
-	pod, ok := v.(*corev1.Pod)
-	if !ok {
-		return nil, microerror.Maskf(wrongTypeError, "expected '%T', got '%T'", &corev1.Pod{}, v)
-	}
-
-	return pod, nil
 }
 
 func VersionBundleVersion(customObject v1alpha1.KVMConfig) string {

--- a/service/controller/v11/resource/clusterrolebinding/current.go
+++ b/service/controller/v11/resource/clusterrolebinding/current.go
@@ -9,7 +9,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/giantswarm/kvm-operator/service/controller/v11/key"
+	"github.com/giantswarm/kvm-operator/service/controller/v10/key"
 )
 
 func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interface{}, error) {

--- a/service/controller/v11/resource/clusterrolebinding/desired.go
+++ b/service/controller/v11/resource/clusterrolebinding/desired.go
@@ -9,7 +9,7 @@ import (
 	apiv1 "k8s.io/api/rbac/v1beta1"
 	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/giantswarm/kvm-operator/service/controller/v11/key"
+	"github.com/giantswarm/kvm-operator/service/controller/v10/key"
 )
 
 func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interface{}, error) {

--- a/service/controller/v11/resource/clusterrolebinding/resource.go
+++ b/service/controller/v11/resource/clusterrolebinding/resource.go
@@ -11,7 +11,7 @@ import (
 
 const (
 	// Name is the identifier of the resource.
-	Name = "clusterrolebindingv11"
+	Name = "clusterrolebindingv10"
 )
 
 // Config represents the configuration used to create a new config map resource.

--- a/service/controller/v11/resource/configmap/create.go
+++ b/service/controller/v11/resource/configmap/create.go
@@ -8,7 +8,7 @@ import (
 	apiv1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 
-	"github.com/giantswarm/kvm-operator/service/controller/v11/key"
+	"github.com/giantswarm/kvm-operator/service/controller/v10/key"
 )
 
 func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange interface{}) error {

--- a/service/controller/v11/resource/configmap/create_test.go
+++ b/service/controller/v11/resource/configmap/create_test.go
@@ -12,7 +12,7 @@ import (
 	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 
-	"github.com/giantswarm/kvm-operator/service/controller/v11/cloudconfig/cloudconfigtest"
+	"github.com/giantswarm/kvm-operator/service/controller/v10/cloudconfig/cloudconfigtest"
 )
 
 func Test_Resource_CloudConfig_newCreateChange(t *testing.T) {

--- a/service/controller/v11/resource/configmap/current.go
+++ b/service/controller/v11/resource/configmap/current.go
@@ -5,25 +5,16 @@ import (
 	"fmt"
 
 	"github.com/giantswarm/microerror"
-	"github.com/giantswarm/operatorkit/controller/context/resourcecanceledcontext"
 	apiv1 "k8s.io/api/core/v1"
 	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/giantswarm/kvm-operator/service/controller/v11/key"
+	"github.com/giantswarm/kvm-operator/service/controller/v10/key"
 )
 
 func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interface{}, error) {
 	customObject, err := key.ToCustomObject(obj)
 	if err != nil {
 		return nil, microerror.Mask(err)
-	}
-
-	if key.IsDeleted(customObject) {
-		r.logger.LogCtx(ctx, "level", "debug", "message", "redirecting responsibility of deletion of config maps to namespace termination")
-		resourcecanceledcontext.SetCanceled(ctx)
-		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource for custom object")
-
-		return nil, nil
 	}
 
 	r.logger.LogCtx(ctx, "level", "debug", "message", "looking for a list of config maps in the Kubernetes API")

--- a/service/controller/v11/resource/configmap/delete.go
+++ b/service/controller/v11/resource/configmap/delete.go
@@ -10,7 +10,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/giantswarm/kvm-operator/service/controller/v11/key"
+	"github.com/giantswarm/kvm-operator/service/controller/v10/key"
 )
 
 func (r *Resource) ApplyDeleteChange(ctx context.Context, obj, deleteChange interface{}) error {

--- a/service/controller/v11/resource/configmap/delete_test.go
+++ b/service/controller/v11/resource/configmap/delete_test.go
@@ -12,7 +12,7 @@ import (
 	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 
-	"github.com/giantswarm/kvm-operator/service/controller/v11/cloudconfig/cloudconfigtest"
+	"github.com/giantswarm/kvm-operator/service/controller/v10/cloudconfig/cloudconfigtest"
 )
 
 func Test_Resource_CloudConfig_newDeleteChange(t *testing.T) {

--- a/service/controller/v11/resource/configmap/desired.go
+++ b/service/controller/v11/resource/configmap/desired.go
@@ -9,7 +9,7 @@ import (
 	apiv1 "k8s.io/api/core/v1"
 	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/giantswarm/kvm-operator/service/controller/v11/key"
+	"github.com/giantswarm/kvm-operator/service/controller/v10/key"
 )
 
 func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interface{}, error) {

--- a/service/controller/v11/resource/configmap/desired_test.go
+++ b/service/controller/v11/resource/configmap/desired_test.go
@@ -12,7 +12,7 @@ import (
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes/fake"
 
-	"github.com/giantswarm/kvm-operator/service/controller/v11/cloudconfig/cloudconfigtest"
+	"github.com/giantswarm/kvm-operator/service/controller/v10/cloudconfig/cloudconfigtest"
 )
 
 func Test_Resource_CloudConfig_GetDesiredState(t *testing.T) {

--- a/service/controller/v11/resource/configmap/resource.go
+++ b/service/controller/v11/resource/configmap/resource.go
@@ -10,13 +10,13 @@ import (
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
 
-	"github.com/giantswarm/kvm-operator/service/controller/v11/cloudconfig"
+	"github.com/giantswarm/kvm-operator/service/controller/v10/cloudconfig"
 )
 
 const (
 	KeyUserData = "user_data"
 	// Name is the identifier of the resource.
-	Name = "configmapv11"
+	Name = "configmapv10"
 )
 
 // Config represents the configuration used to create a new config map resource.

--- a/service/controller/v11/resource/configmap/update.go
+++ b/service/controller/v11/resource/configmap/update.go
@@ -8,7 +8,7 @@ import (
 	"github.com/giantswarm/operatorkit/controller"
 	apiv1 "k8s.io/api/core/v1"
 
-	"github.com/giantswarm/kvm-operator/service/controller/v11/key"
+	"github.com/giantswarm/kvm-operator/service/controller/v10/key"
 )
 
 func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateChange interface{}) error {

--- a/service/controller/v11/resource/configmap/update_test.go
+++ b/service/controller/v11/resource/configmap/update_test.go
@@ -13,7 +13,7 @@ import (
 	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 
-	"github.com/giantswarm/kvm-operator/service/controller/v11/cloudconfig/cloudconfigtest"
+	"github.com/giantswarm/kvm-operator/service/controller/v10/cloudconfig/cloudconfigtest"
 )
 
 func Test_Resource_CloudConfig_newUpdateChange(t *testing.T) {

--- a/service/controller/v11/resource/deployment/create.go
+++ b/service/controller/v11/resource/deployment/create.go
@@ -8,7 +8,7 @@ import (
 	"k8s.io/api/extensions/v1beta1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 
-	"github.com/giantswarm/kvm-operator/service/controller/v11/key"
+	"github.com/giantswarm/kvm-operator/service/controller/v10/key"
 )
 
 func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange interface{}) error {

--- a/service/controller/v11/resource/deployment/current.go
+++ b/service/controller/v11/resource/deployment/current.go
@@ -11,7 +11,7 @@ import (
 	"k8s.io/api/extensions/v1beta1"
 	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/giantswarm/kvm-operator/service/controller/v11/key"
+	"github.com/giantswarm/kvm-operator/service/controller/v10/key"
 	"github.com/giantswarm/kvm-operator/service/metric"
 )
 

--- a/service/controller/v11/resource/deployment/delete.go
+++ b/service/controller/v11/resource/deployment/delete.go
@@ -8,9 +8,9 @@ import (
 	"github.com/giantswarm/operatorkit/controller"
 	"k8s.io/api/extensions/v1beta1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/giantswarm/kvm-operator/service/controller/v11/key"
+	"github.com/giantswarm/kvm-operator/service/controller/v10/key"
 )
 
 func (r *Resource) ApplyDeleteChange(ctx context.Context, obj, deleteChange interface{}) error {
@@ -26,9 +26,9 @@ func (r *Resource) ApplyDeleteChange(ctx context.Context, obj, deleteChange inte
 	if len(deploymentsToDelete) != 0 {
 		r.logger.LogCtx(ctx, "level", "debug", "message", "deleting the deployments in the Kubernetes API")
 
+		namespace := key.ClusterNamespace(customObject)
 		for _, deployment := range deploymentsToDelete {
-			n := key.ClusterNamespace(customObject)
-			err := r.k8sClient.Extensions().Deployments(n).Delete(deployment.Name, newDeleteOptions())
+			err := r.k8sClient.Extensions().Deployments(namespace).Delete(deployment.Name, newDeleteOptions())
 			if apierrors.IsNotFound(err) {
 				// fall through
 			} else if err != nil {
@@ -110,10 +110,10 @@ func (r *Resource) newDeleteChangeForUpdatePatch(ctx context.Context, obj, curre
 	return deploymentsToDelete, nil
 }
 
-func newDeleteOptions() *metav1.DeleteOptions {
-	propagation := metav1.DeletePropagationForeground
+func newDeleteOptions() *apismetav1.DeleteOptions {
+	propagation := apismetav1.DeletePropagationForeground
 
-	options := &metav1.DeleteOptions{
+	options := &apismetav1.DeleteOptions{
 		PropagationPolicy: &propagation,
 	}
 

--- a/service/controller/v11/resource/deployment/desired.go
+++ b/service/controller/v11/resource/deployment/desired.go
@@ -7,7 +7,7 @@ import (
 	"github.com/giantswarm/microerror"
 	"k8s.io/api/extensions/v1beta1"
 
-	"github.com/giantswarm/kvm-operator/service/controller/v11/key"
+	"github.com/giantswarm/kvm-operator/service/controller/v10/key"
 )
 
 func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interface{}, error) {

--- a/service/controller/v11/resource/deployment/master_deployment.go
+++ b/service/controller/v11/resource/deployment/master_deployment.go
@@ -11,7 +11,7 @@ import (
 	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
-	"github.com/giantswarm/kvm-operator/service/controller/v11/key"
+	"github.com/giantswarm/kvm-operator/service/controller/v10/key"
 )
 
 func newMasterDeployments(customObject v1alpha1.KVMConfig) ([]*extensionsv1.Deployment, error) {
@@ -19,7 +19,6 @@ func newMasterDeployments(customObject v1alpha1.KVMConfig) ([]*extensionsv1.Depl
 
 	privileged := true
 	replicas := int32(1)
-	podDeletionGracePeriod := int64(key.PodDeletionGracePeriod.Seconds())
 
 	for i, masterNode := range customObject.Spec.Cluster.Masters {
 		capabilities := customObject.Spec.KVM.Masters[i]
@@ -89,19 +88,16 @@ func newMasterDeployments(customObject v1alpha1.KVMConfig) ([]*extensionsv1.Depl
 				Replicas: &replicas,
 				Template: apiv1.PodTemplateSpec{
 					ObjectMeta: apismetav1.ObjectMeta{
-						Annotations: map[string]string{
-							key.AnnotationAPIEndpoint: key.ClusterAPIEndpoint(customObject),
-							key.AnnotationIp:          "",
-							key.AnnotationService:     key.MasterID,
-							key.AnnotationPodDrained:  "False",
-						},
 						GenerateName: key.MasterID,
 						Labels: map[string]string{
-							"app":               key.MasterID,
-							"cluster":           key.ClusterID(customObject),
-							"customer":          key.ClusterCustomer(customObject),
-							"node":              masterNode.ID,
-							key.PodWatcherLabel: "kvm-operator",
+							"app":      key.MasterID,
+							"cluster":  key.ClusterID(customObject),
+							"customer": key.ClusterCustomer(customObject),
+							"node":     masterNode.ID,
+						},
+						Annotations: map[string]string{
+							key.AnnotationIp:      "",
+							key.AnnotationService: key.MasterID,
 						},
 					},
 					Spec: apiv1.PodSpec{
@@ -110,8 +106,7 @@ func newMasterDeployments(customObject v1alpha1.KVMConfig) ([]*extensionsv1.Depl
 						NodeSelector: map[string]string{
 							"role": key.MasterID,
 						},
-						ServiceAccountName:            key.ServiceAccountName(customObject),
-						TerminationGracePeriodSeconds: &podDeletionGracePeriod,
+						ServiceAccountName: key.ServiceAccountName(customObject),
 						Volumes: []apiv1.Volume{
 							{
 								Name: "cloud-config",

--- a/service/controller/v11/resource/deployment/master_pod_affinity.go
+++ b/service/controller/v11/resource/deployment/master_pod_affinity.go
@@ -5,7 +5,7 @@ import (
 	apiv1 "k8s.io/api/core/v1"
 	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/giantswarm/kvm-operator/service/controller/v11/key"
+	"github.com/giantswarm/kvm-operator/service/controller/v10/key"
 )
 
 func newMasterPodAfinity(customObject v1alpha1.KVMConfig) *apiv1.Affinity {

--- a/service/controller/v11/resource/deployment/node_controller_deployment.go
+++ b/service/controller/v11/resource/deployment/node_controller_deployment.go
@@ -9,7 +9,7 @@ import (
 	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
-	"github.com/giantswarm/kvm-operator/service/controller/v11/key"
+	"github.com/giantswarm/kvm-operator/service/controller/v10/key"
 )
 
 func newNodeControllerDeployment(customObject v1alpha1.KVMConfig) (*extensionsv1.Deployment, error) {

--- a/service/controller/v11/resource/deployment/resource.go
+++ b/service/controller/v11/resource/deployment/resource.go
@@ -6,12 +6,12 @@ import (
 	"k8s.io/api/extensions/v1beta1"
 	"k8s.io/client-go/kubernetes"
 
-	"github.com/giantswarm/kvm-operator/service/controller/v11/key"
+	"github.com/giantswarm/kvm-operator/service/controller/v10/key"
 )
 
 const (
 	// Name is the identifier of the resource.
-	Name = "deploymentv11"
+	Name = "deploymentv10"
 )
 
 // Config represents the configuration used to create a new deployment resource.

--- a/service/controller/v11/resource/deployment/update.go
+++ b/service/controller/v11/resource/deployment/update.go
@@ -9,7 +9,7 @@ import (
 	"github.com/giantswarm/operatorkit/controller/context/updateallowedcontext"
 	"k8s.io/api/extensions/v1beta1"
 
-	"github.com/giantswarm/kvm-operator/service/controller/v11/key"
+	"github.com/giantswarm/kvm-operator/service/controller/v10/key"
 )
 
 func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateChange interface{}) error {
@@ -91,7 +91,7 @@ func (r *Resource) newUpdateChange(ctx context.Context, obj, currentState, desir
 		// We select one deployment to be updated per reconciliation loop. Therefore
 		// we have to check its state on the version bundle level to see if a
 		// deployment is already up to date. We also check if there are any other
-		// changes on the pod specs. In case there are none, we check the next one.
+		// changes on the pod specs. In case there are not, we check the next one.
 		// The first one not being up to date will be chosen to be updated next and
 		// the loop will be broken immediatelly.
 		for _, currentDeployment := range currentDeployments {

--- a/service/controller/v11/resource/deployment/update_test.go
+++ b/service/controller/v11/resource/deployment/update_test.go
@@ -14,7 +14,7 @@ import (
 	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 
-	"github.com/giantswarm/kvm-operator/service/controller/v11/key"
+	"github.com/giantswarm/kvm-operator/service/controller/v10/key"
 )
 
 func Test_Resource_Deployment_newUpdateChange(t *testing.T) {

--- a/service/controller/v11/resource/deployment/worker_deployment.go
+++ b/service/controller/v11/resource/deployment/worker_deployment.go
@@ -11,7 +11,7 @@ import (
 	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
-	"github.com/giantswarm/kvm-operator/service/controller/v11/key"
+	"github.com/giantswarm/kvm-operator/service/controller/v10/key"
 )
 
 func newWorkerDeployments(customObject v1alpha1.KVMConfig) ([]*extensionsv1.Deployment, error) {
@@ -19,7 +19,6 @@ func newWorkerDeployments(customObject v1alpha1.KVMConfig) ([]*extensionsv1.Depl
 
 	privileged := true
 	replicas := int32(1)
-	podDeletionGracePeriod := int64(key.PodDeletionGracePeriod.Seconds())
 
 	for i, workerNode := range customObject.Spec.Cluster.Workers {
 		capabilities := customObject.Spec.KVM.Workers[i]
@@ -58,19 +57,16 @@ func newWorkerDeployments(customObject v1alpha1.KVMConfig) ([]*extensionsv1.Depl
 				Replicas: &replicas,
 				Template: apiv1.PodTemplateSpec{
 					ObjectMeta: apismetav1.ObjectMeta{
-						Annotations: map[string]string{
-							key.AnnotationAPIEndpoint: key.ClusterAPIEndpoint(customObject),
-							key.AnnotationIp:          "",
-							key.AnnotationService:     key.WorkerID,
-							key.AnnotationPodDrained:  "False",
-						},
 						Name: key.WorkerID,
 						Labels: map[string]string{
-							"cluster":           key.ClusterID(customObject),
-							"customer":          key.ClusterCustomer(customObject),
-							"app":               key.WorkerID,
-							"node":              workerNode.ID,
-							key.PodWatcherLabel: "kvm-operator",
+							"cluster":  key.ClusterID(customObject),
+							"customer": key.ClusterCustomer(customObject),
+							"app":      key.WorkerID,
+							"node":     workerNode.ID,
+						},
+						Annotations: map[string]string{
+							key.AnnotationIp:      "",
+							key.AnnotationService: key.WorkerID,
 						},
 					},
 					Spec: apiv1.PodSpec{
@@ -79,8 +75,7 @@ func newWorkerDeployments(customObject v1alpha1.KVMConfig) ([]*extensionsv1.Depl
 						NodeSelector: map[string]string{
 							"role": key.WorkerID,
 						},
-						ServiceAccountName:            key.ServiceAccountName(customObject),
-						TerminationGracePeriodSeconds: &podDeletionGracePeriod,
+						ServiceAccountName: key.ServiceAccountName(customObject),
 						Volumes: []apiv1.Volume{
 							{
 								Name: "cloud-config",

--- a/service/controller/v11/resource/deployment/worker_pod_affinity.go
+++ b/service/controller/v11/resource/deployment/worker_pod_affinity.go
@@ -5,7 +5,7 @@ import (
 	apiv1 "k8s.io/api/core/v1"
 	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/giantswarm/kvm-operator/service/controller/v11/key"
+	"github.com/giantswarm/kvm-operator/service/controller/v10/key"
 )
 
 func newWorkerPodAfinity(customObject v1alpha1.KVMConfig) *apiv1.Affinity {

--- a/service/controller/v11/resource/ingress/api_ingress.go
+++ b/service/controller/v11/resource/ingress/api_ingress.go
@@ -6,7 +6,7 @@ import (
 	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
-	"github.com/giantswarm/kvm-operator/service/controller/v11/key"
+	"github.com/giantswarm/kvm-operator/service/controller/v10/key"
 )
 
 func newAPIIngress(customObject v1alpha1.KVMConfig) *extensionsv1.Ingress {

--- a/service/controller/v11/resource/ingress/create.go
+++ b/service/controller/v11/resource/ingress/create.go
@@ -8,7 +8,7 @@ import (
 	"k8s.io/api/extensions/v1beta1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 
-	"github.com/giantswarm/kvm-operator/service/controller/v11/key"
+	"github.com/giantswarm/kvm-operator/service/controller/v10/key"
 )
 
 func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange interface{}) error {

--- a/service/controller/v11/resource/ingress/current.go
+++ b/service/controller/v11/resource/ingress/current.go
@@ -5,13 +5,11 @@ import (
 	"fmt"
 
 	"github.com/giantswarm/microerror"
-	"github.com/giantswarm/operatorkit/controller/context/finalizerskeptcontext"
-	"github.com/giantswarm/operatorkit/controller/context/resourcecanceledcontext"
 	"k8s.io/api/extensions/v1beta1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/giantswarm/kvm-operator/service/controller/v11/key"
+	"github.com/giantswarm/kvm-operator/service/controller/v10/key"
 )
 
 func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interface{}, error) {
@@ -31,7 +29,7 @@ func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interf
 	}
 
 	for _, name := range ingressNames {
-		manifest, err := r.k8sClient.Extensions().Ingresses(namespace).Get(name, metav1.GetOptions{})
+		manifest, err := r.k8sClient.Extensions().Ingresses(namespace).Get(name, apismetav1.GetOptions{})
 		if apierrors.IsNotFound(err) {
 			r.logger.LogCtx(ctx, "level", "debug", "message", "did not find a ingress in the Kubernetes API")
 			// fall through
@@ -44,29 +42,6 @@ func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interf
 	}
 
 	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("found %d ingresses in the Kubernetes API", len(ingresses)))
-
-	// In case a cluster deletion happens, we want to delete the guest cluster
-	// ingresses. We still need to use the ingresses for ingress routing in order
-	// to drain nodes on KVM though. So as long as pods are there we delay the
-	// deletion of the ingresses here in order to still be able to route traffic
-	// to the guest cluster API. As soon as the draining was done and the pods got
-	// removed we get an empty list here after the delete event got replayed. Then
-	// we just remove the ingresses as usual.
-	if key.IsDeleted(customObject) {
-		n := key.ClusterNamespace(customObject)
-		list, err := r.k8sClient.CoreV1().Pods(n).List(metav1.ListOptions{})
-		if err != nil {
-			return nil, microerror.Mask(err)
-		}
-		if len(list.Items) != 0 {
-			r.logger.LogCtx(ctx, "level", "debug", "message", "cannot finish deletion of ingresses due to existing pods")
-			resourcecanceledcontext.SetCanceled(ctx)
-			finalizerskeptcontext.SetKept(ctx)
-			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource for custom object")
-
-			return nil, nil
-		}
-	}
 
 	return ingresses, nil
 }

--- a/service/controller/v11/resource/ingress/delete.go
+++ b/service/controller/v11/resource/ingress/delete.go
@@ -10,7 +10,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/giantswarm/kvm-operator/service/controller/v11/key"
+	"github.com/giantswarm/kvm-operator/service/controller/v10/key"
 )
 
 func (r *Resource) ApplyDeleteChange(ctx context.Context, obj, deleteChange interface{}) error {

--- a/service/controller/v11/resource/ingress/desired.go
+++ b/service/controller/v11/resource/ingress/desired.go
@@ -7,7 +7,7 @@ import (
 	"github.com/giantswarm/microerror"
 	"k8s.io/api/extensions/v1beta1"
 
-	"github.com/giantswarm/kvm-operator/service/controller/v11/key"
+	"github.com/giantswarm/kvm-operator/service/controller/v10/key"
 )
 
 func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interface{}, error) {

--- a/service/controller/v11/resource/ingress/etcd_ingress.go
+++ b/service/controller/v11/resource/ingress/etcd_ingress.go
@@ -6,7 +6,7 @@ import (
 	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
-	"github.com/giantswarm/kvm-operator/service/controller/v11/key"
+	"github.com/giantswarm/kvm-operator/service/controller/v10/key"
 )
 
 func newEtcdIngress(customObject v1alpha1.KVMConfig) *extensionsv1.Ingress {

--- a/service/controller/v11/resource/ingress/resource.go
+++ b/service/controller/v11/resource/ingress/resource.go
@@ -11,7 +11,7 @@ const (
 	APIID  = "api"
 	EtcdID = "etcd"
 	// Name is the identifier of the resource.
-	Name = "ingressv11"
+	Name = "ingressv10"
 )
 
 // Config represents the configuration used to create a new ingress resource.

--- a/service/controller/v11/resource/namespace/current.go
+++ b/service/controller/v11/resource/namespace/current.go
@@ -4,14 +4,12 @@ import (
 	"context"
 
 	"github.com/giantswarm/microerror"
-	"github.com/giantswarm/operatorkit/controller/context/finalizerskeptcontext"
 	"github.com/giantswarm/operatorkit/controller/context/reconciliationcanceledcontext"
-	"github.com/giantswarm/operatorkit/controller/context/resourcecanceledcontext"
-	corev1 "k8s.io/api/core/v1"
+	apiv1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/giantswarm/kvm-operator/service/controller/v11/key"
+	"github.com/giantswarm/kvm-operator/service/controller/v10/key"
 )
 
 func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interface{}, error) {
@@ -23,9 +21,9 @@ func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interf
 	r.logger.LogCtx(ctx, "level", "debug", "message", "looking for the namespace in the Kubernetes API")
 
 	// Lookup the current state of the namespace.
-	var namespace *corev1.Namespace
+	var namespace *apiv1.Namespace
 	{
-		manifest, err := r.k8sClient.CoreV1().Namespaces().Get(key.ClusterNamespace(customObject), metav1.GetOptions{})
+		manifest, err := r.k8sClient.CoreV1().Namespaces().Get(key.ClusterNamespace(customObject), apismetav1.GetOptions{})
 		if apierrors.IsNotFound(err) {
 			r.logger.LogCtx(ctx, "level", "debug", "message", "did not find the namespace in the Kubernetes API")
 			// fall through
@@ -46,29 +44,6 @@ func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interf
 		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling reconciliation for custom object")
 
 		return nil, nil
-	}
-
-	// In case a cluster deletion happens, we want to delete the guest cluster
-	// namespace. We still need to use the namespace for resource creation in
-	// order to drain nodes on KVM though. So as long as pods are there we delay
-	// the deletion of the namespace here in order to still be able to create
-	// resources in it. As soon as the draining was done and the pods got removed
-	// we get an empty list here after the delete event got replayed. Then we just
-	// remove the namespace as usual.
-	if key.IsDeleted(customObject) {
-		n := key.ClusterNamespace(customObject)
-		list, err := r.k8sClient.CoreV1().Pods(n).List(metav1.ListOptions{})
-		if err != nil {
-			return nil, microerror.Mask(err)
-		}
-		if len(list.Items) != 0 {
-			r.logger.LogCtx(ctx, "level", "debug", "message", "cannot finish deletion of namespace due to existing pods")
-			resourcecanceledcontext.SetCanceled(ctx)
-			finalizerskeptcontext.SetKept(ctx)
-			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource for custom object")
-
-			return nil, nil
-		}
 	}
 
 	return namespace, nil

--- a/service/controller/v11/resource/namespace/desired.go
+++ b/service/controller/v11/resource/namespace/desired.go
@@ -7,7 +7,7 @@ import (
 	apiv1 "k8s.io/api/core/v1"
 	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/giantswarm/kvm-operator/service/controller/v11/key"
+	"github.com/giantswarm/kvm-operator/service/controller/v10/key"
 )
 
 func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interface{}, error) {

--- a/service/controller/v11/resource/namespace/resource.go
+++ b/service/controller/v11/resource/namespace/resource.go
@@ -9,7 +9,7 @@ import (
 
 const (
 	// Name is the identifier of the resource.
-	Name = "namespacev11"
+	Name = "namespacev10"
 )
 
 // Config represents the configuration used to create a new cloud config resource.

--- a/service/controller/v11/resource/pvc/create.go
+++ b/service/controller/v11/resource/pvc/create.go
@@ -8,7 +8,7 @@ import (
 	apiv1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 
-	"github.com/giantswarm/kvm-operator/service/controller/v11/key"
+	"github.com/giantswarm/kvm-operator/service/controller/v10/key"
 )
 
 func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange interface{}) error {

--- a/service/controller/v11/resource/pvc/current.go
+++ b/service/controller/v11/resource/pvc/current.go
@@ -9,7 +9,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/giantswarm/kvm-operator/service/controller/v11/key"
+	"github.com/giantswarm/kvm-operator/service/controller/v10/key"
 )
 
 func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interface{}, error) {

--- a/service/controller/v11/resource/pvc/delete.go
+++ b/service/controller/v11/resource/pvc/delete.go
@@ -10,7 +10,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/giantswarm/kvm-operator/service/controller/v11/key"
+	"github.com/giantswarm/kvm-operator/service/controller/v10/key"
 )
 
 func (r *Resource) ApplyDeleteChange(ctx context.Context, obj, deleteChange interface{}) error {

--- a/service/controller/v11/resource/pvc/desired.go
+++ b/service/controller/v11/resource/pvc/desired.go
@@ -7,7 +7,7 @@ import (
 	"github.com/giantswarm/microerror"
 	apiv1 "k8s.io/api/core/v1"
 
-	"github.com/giantswarm/kvm-operator/service/controller/v11/key"
+	"github.com/giantswarm/kvm-operator/service/controller/v10/key"
 )
 
 func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interface{}, error) {

--- a/service/controller/v11/resource/pvc/etcd_pvc.go
+++ b/service/controller/v11/resource/pvc/etcd_pvc.go
@@ -7,7 +7,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/giantswarm/kvm-operator/service/controller/v11/key"
+	"github.com/giantswarm/kvm-operator/service/controller/v10/key"
 )
 
 const (

--- a/service/controller/v11/resource/pvc/resource.go
+++ b/service/controller/v11/resource/pvc/resource.go
@@ -9,7 +9,7 @@ import (
 
 const (
 	// Name is the identifier of the resource.
-	Name = "pvcv11"
+	Name = "pvcv10"
 	// StorageClass is the storage class annotation persistent volume claims are
 	// configured with.
 	StorageClass = "g8s-storage"

--- a/service/controller/v11/resource/service/create.go
+++ b/service/controller/v11/resource/service/create.go
@@ -8,7 +8,7 @@ import (
 	apiv1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 
-	"github.com/giantswarm/kvm-operator/service/controller/v11/key"
+	"github.com/giantswarm/kvm-operator/service/controller/v10/key"
 )
 
 func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange interface{}) error {

--- a/service/controller/v11/resource/service/current.go
+++ b/service/controller/v11/resource/service/current.go
@@ -5,13 +5,11 @@ import (
 	"fmt"
 
 	"github.com/giantswarm/microerror"
-	"github.com/giantswarm/operatorkit/controller/context/finalizerskeptcontext"
-	"github.com/giantswarm/operatorkit/controller/context/resourcecanceledcontext"
-	corev1 "k8s.io/api/core/v1"
+	apiv1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/giantswarm/kvm-operator/service/controller/v11/key"
+	"github.com/giantswarm/kvm-operator/service/controller/v10/key"
 )
 
 func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interface{}, error) {
@@ -22,7 +20,7 @@ func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interf
 
 	r.logger.LogCtx(ctx, "level", "debug", "message", "looking for services in the Kubernetes API")
 
-	var services []*corev1.Service
+	var services []*apiv1.Service
 
 	namespace := key.ClusterNamespace(customObject)
 	serviceNames := []string{
@@ -31,7 +29,7 @@ func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interf
 	}
 
 	for _, name := range serviceNames {
-		manifest, err := r.k8sClient.CoreV1().Services(namespace).Get(name, metav1.GetOptions{})
+		manifest, err := r.k8sClient.CoreV1().Services(namespace).Get(name, apismetav1.GetOptions{})
 		if apierrors.IsNotFound(err) {
 			r.logger.LogCtx(ctx, "level", "debug", "message", "did not find a service in the Kubernetes API")
 			// fall through
@@ -44,29 +42,6 @@ func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interf
 	}
 
 	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("found %d services in the Kubernetes API", len(services)))
-
-	// In case a cluster deletion happens, we want to delete the guest cluster
-	// services. We still need to use the services for ingress routing in order to
-	// drain nodes on KVM though. So as long as pods are there we delay the
-	// deletion of the services here in order to still be able to route traffic to
-	// the guest cluster API. As soon as the draining was done and the pods got
-	// removed we get an empty list here after the delete event got replayed. Then
-	// we just remove the services as usual.
-	if key.IsDeleted(customObject) {
-		n := key.ClusterNamespace(customObject)
-		list, err := r.k8sClient.CoreV1().Pods(n).List(metav1.ListOptions{})
-		if err != nil {
-			return nil, microerror.Mask(err)
-		}
-		if len(list.Items) != 0 {
-			r.logger.LogCtx(ctx, "level", "debug", "message", "cannot finish deletion of services due to existing pods")
-			resourcecanceledcontext.SetCanceled(ctx)
-			finalizerskeptcontext.SetKept(ctx)
-			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource for custom object")
-
-			return nil, nil
-		}
-	}
 
 	return services, nil
 }

--- a/service/controller/v11/resource/service/delete.go
+++ b/service/controller/v11/resource/service/delete.go
@@ -10,7 +10,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/giantswarm/kvm-operator/service/controller/v11/key"
+	"github.com/giantswarm/kvm-operator/service/controller/v10/key"
 )
 
 func (r *Resource) ApplyDeleteChange(ctx context.Context, obj, deleteChange interface{}) error {

--- a/service/controller/v11/resource/service/desired.go
+++ b/service/controller/v11/resource/service/desired.go
@@ -7,7 +7,7 @@ import (
 	"github.com/giantswarm/microerror"
 	apiv1 "k8s.io/api/core/v1"
 
-	"github.com/giantswarm/kvm-operator/service/controller/v11/key"
+	"github.com/giantswarm/kvm-operator/service/controller/v10/key"
 )
 
 func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interface{}, error) {

--- a/service/controller/v11/resource/service/master_service.go
+++ b/service/controller/v11/resource/service/master_service.go
@@ -5,7 +5,7 @@ import (
 	apiv1 "k8s.io/api/core/v1"
 	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/giantswarm/kvm-operator/service/controller/v11/key"
+	"github.com/giantswarm/kvm-operator/service/controller/v10/key"
 )
 
 func newMasterService(customObject v1alpha1.KVMConfig) *apiv1.Service {

--- a/service/controller/v11/resource/service/resource.go
+++ b/service/controller/v11/resource/service/resource.go
@@ -9,7 +9,7 @@ import (
 
 const (
 	// Name is the identifier of the resource.
-	Name = "servicev11"
+	Name = "servicev10"
 )
 
 // Config represents the configuration used to create a new service resource.

--- a/service/controller/v11/resource/service/worker_service.go
+++ b/service/controller/v11/resource/service/worker_service.go
@@ -6,7 +6,7 @@ import (
 	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
-	"github.com/giantswarm/kvm-operator/service/controller/v11/key"
+	"github.com/giantswarm/kvm-operator/service/controller/v10/key"
 )
 
 func newWorkerService(customObject v1alpha1.KVMConfig) *apiv1.Service {

--- a/service/controller/v11/resource/serviceaccount/create.go
+++ b/service/controller/v11/resource/serviceaccount/create.go
@@ -8,7 +8,7 @@ import (
 	apiv1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 
-	"github.com/giantswarm/kvm-operator/service/controller/v11/key"
+	"github.com/giantswarm/kvm-operator/service/controller/v10/key"
 )
 
 func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange interface{}) error {

--- a/service/controller/v11/resource/serviceaccount/current.go
+++ b/service/controller/v11/resource/serviceaccount/current.go
@@ -9,7 +9,7 @@ import (
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 
-	"github.com/giantswarm/kvm-operator/service/controller/v11/key"
+	"github.com/giantswarm/kvm-operator/service/controller/v10/key"
 )
 
 func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interface{}, error) {

--- a/service/controller/v11/resource/serviceaccount/delete.go
+++ b/service/controller/v11/resource/serviceaccount/delete.go
@@ -9,7 +9,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/giantswarm/kvm-operator/service/controller/v11/key"
+	"github.com/giantswarm/kvm-operator/service/controller/v10/key"
 )
 
 func (r *Resource) ApplyDeleteChange(ctx context.Context, obj, deleteChange interface{}) error {

--- a/service/controller/v11/resource/serviceaccount/desired.go
+++ b/service/controller/v11/resource/serviceaccount/desired.go
@@ -7,7 +7,7 @@ import (
 	apiv1 "k8s.io/api/core/v1"
 	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/giantswarm/kvm-operator/service/controller/v11/key"
+	"github.com/giantswarm/kvm-operator/service/controller/v10/key"
 )
 
 func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interface{}, error) {

--- a/service/controller/v11/resource/serviceaccount/resource.go
+++ b/service/controller/v11/resource/serviceaccount/resource.go
@@ -9,7 +9,7 @@ import (
 
 const (
 	// Name is the identifier of the resource.
-	Name = "serviceaccountv11"
+	Name = "serviceaccountv10"
 )
 
 // Config represents the configuration used to create a new cloud config resource.

--- a/service/controller/v11/resource_set.go
+++ b/service/controller/v11/resource_set.go
@@ -1,0 +1,307 @@
+package v10
+
+import (
+	"context"
+
+	"github.com/cenkalti/backoff"
+	"github.com/giantswarm/certs"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/giantswarm/operatorkit/controller"
+	"github.com/giantswarm/operatorkit/controller/context/updateallowedcontext"
+	"github.com/giantswarm/operatorkit/controller/resource/metricsresource"
+	"github.com/giantswarm/operatorkit/controller/resource/retryresource"
+	"github.com/giantswarm/randomkeys"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/giantswarm/kvm-operator/service/controller/v10/cloudconfig"
+	"github.com/giantswarm/kvm-operator/service/controller/v10/key"
+	"github.com/giantswarm/kvm-operator/service/controller/v10/resource/clusterrolebinding"
+	"github.com/giantswarm/kvm-operator/service/controller/v10/resource/configmap"
+	"github.com/giantswarm/kvm-operator/service/controller/v10/resource/deployment"
+	"github.com/giantswarm/kvm-operator/service/controller/v10/resource/ingress"
+	"github.com/giantswarm/kvm-operator/service/controller/v10/resource/namespace"
+	"github.com/giantswarm/kvm-operator/service/controller/v10/resource/pvc"
+	"github.com/giantswarm/kvm-operator/service/controller/v10/resource/service"
+	"github.com/giantswarm/kvm-operator/service/controller/v10/resource/serviceaccount"
+)
+
+const (
+	ResourceRetries uint64 = 3
+)
+
+type ResourceSetConfig struct {
+	CertsSearcher      certs.Interface
+	K8sClient          kubernetes.Interface
+	Logger             micrologger.Logger
+	RandomkeysSearcher randomkeys.Interface
+
+	GuestUpdateEnabled bool
+	ProjectName        string
+}
+
+func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
+	var err error
+
+	if config.CertsSearcher == nil {
+		return nil, microerror.Maskf(invalidConfigError, "config.CertsSearcher must not be empty")
+	}
+	if config.K8sClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "config.K8sClient must not be empty")
+	}
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "config.Logger must not be empty")
+	}
+	if config.RandomkeysSearcher == nil {
+		return nil, microerror.Maskf(invalidConfigError, "config.RandomkeysSearcher must not be empty")
+	}
+
+	if config.ProjectName == "" {
+		return nil, microerror.Maskf(invalidConfigError, "config.ProjectName must not be empty")
+	}
+
+	var cloudConfig *cloudconfig.CloudConfig
+	{
+		c := cloudconfig.DefaultConfig()
+
+		c.Logger = config.Logger
+
+		cloudConfig, err = cloudconfig.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	var clusterRoleBindingResource controller.Resource
+	{
+		c := clusterrolebinding.Config{
+			K8sClient: config.K8sClient,
+			Logger:    config.Logger,
+		}
+
+		ops, err := clusterrolebinding.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+
+		clusterRoleBindingResource, err = toCRUDResource(config.Logger, ops)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	var namespaceResource controller.Resource
+	{
+		c := namespace.DefaultConfig()
+
+		c.K8sClient = config.K8sClient
+		c.Logger = config.Logger
+
+		ops, err := namespace.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+
+		namespaceResource, err = toCRUDResource(config.Logger, ops)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	var serviceAccountResource controller.Resource
+	{
+		c := serviceaccount.DefaultConfig()
+
+		c.K8sClient = config.K8sClient
+		c.Logger = config.Logger
+
+		ops, err := serviceaccount.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+
+		serviceAccountResource, err = toCRUDResource(config.Logger, ops)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	var configMapResource controller.Resource
+	{
+		c := configmap.DefaultConfig()
+
+		c.CertSearcher = config.CertsSearcher
+		c.CloudConfig = cloudConfig
+		c.K8sClient = config.K8sClient
+		c.KeyWatcher = config.RandomkeysSearcher
+		c.Logger = config.Logger
+
+		ops, err := configmap.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+
+		configMapResource, err = toCRUDResource(config.Logger, ops)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	var deploymentResource controller.Resource
+	{
+		c := deployment.DefaultConfig()
+
+		c.K8sClient = config.K8sClient
+		c.Logger = config.Logger
+
+		ops, err := deployment.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+
+		deploymentResource, err = toCRUDResource(config.Logger, ops)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	var ingressResource controller.Resource
+	{
+		c := ingress.DefaultConfig()
+
+		c.K8sClient = config.K8sClient
+		c.Logger = config.Logger
+
+		ops, err := ingress.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+
+		ingressResource, err = toCRUDResource(config.Logger, ops)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	var pvcResource controller.Resource
+	{
+		c := pvc.DefaultConfig()
+
+		c.K8sClient = config.K8sClient
+		c.Logger = config.Logger
+
+		ops, err := pvc.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+
+		pvcResource, err = toCRUDResource(config.Logger, ops)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	var serviceResource controller.Resource
+	{
+		c := service.DefaultConfig()
+
+		c.K8sClient = config.K8sClient
+		c.Logger = config.Logger
+
+		ops, err := service.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+
+		serviceResource, err = toCRUDResource(config.Logger, ops)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	resources := []controller.Resource{
+		clusterRoleBindingResource,
+		namespaceResource,
+		serviceAccountResource,
+		configMapResource,
+		deploymentResource,
+		ingressResource,
+		pvcResource,
+		serviceResource,
+	}
+
+	{
+		c := retryresource.WrapConfig{
+			BackOffFactory: func() backoff.BackOff { return backoff.WithMaxTries(backoff.NewExponentialBackOff(), ResourceRetries) },
+			Logger:         config.Logger,
+		}
+
+		resources, err = retryresource.Wrap(resources, c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	{
+		c := metricsresource.WrapConfig{
+			Name: config.ProjectName,
+		}
+
+		resources, err = metricsresource.Wrap(resources, c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	handlesFunc := func(obj interface{}) bool {
+		kvmConfig, err := key.ToCustomObject(obj)
+		if err != nil {
+			return false
+		}
+
+		if key.VersionBundleVersion(kvmConfig) == VersionBundle().Version {
+			return true
+		}
+
+		return false
+	}
+
+	initCtxFunc := func(ctx context.Context, obj interface{}) (context.Context, error) {
+		if config.GuestUpdateEnabled {
+			updateallowedcontext.SetUpdateAllowed(ctx)
+		}
+
+		return ctx, nil
+	}
+
+	var resourceSet *controller.ResourceSet
+	{
+		c := controller.ResourceSetConfig{
+			Handles:   handlesFunc,
+			InitCtx:   initCtxFunc,
+			Logger:    config.Logger,
+			Resources: resources,
+		}
+
+		resourceSet, err = controller.NewResourceSet(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	return resourceSet, nil
+}
+
+func toCRUDResource(logger micrologger.Logger, ops controller.CRUDResourceOps) (*controller.CRUDResource, error) {
+	c := controller.CRUDResourceConfig{
+		Logger: logger,
+		Ops:    ops,
+	}
+
+	r, err := controller.NewCRUDResource(c)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	return r, nil
+}

--- a/service/controller/v11/version_bundle.go
+++ b/service/controller/v11/version_bundle.go
@@ -1,4 +1,4 @@
-package v11
+package v10
 
 import (
 	"time"
@@ -10,110 +10,40 @@ func VersionBundle() versionbundle.Bundle {
 	return versionbundle.Bundle{
 		Changelogs: []versionbundle.Changelog{
 			{
-				Component:   "kubernetes",
-				Description: "Updated to 1.10.1.",
+				Component:   "cloudconfig",
+				Description: "Improved encryption key injection.",
 				Kind:        versionbundle.KindChanged,
 			},
 			{
-				Component:   "cloudconfig",
-				Description: "Updated kube-state-metrics to version 1.3.1.",
-				Kind:        versionbundle.KindChanged,
-			},
-			{
-				Component:   "cloudconfig",
-				Description: "Changed kubelet bind mount mode from shared to rshared.",
-				Kind:        versionbundle.KindChanged,
-			},
-			{
-				Component:   "cloudconfig",
-				Description: "Disabled etcd3-defragmentation service in favor systemd timer.",
-				Kind:        versionbundle.KindChanged,
-			},
-			{
-				Component:   "cloudconfig",
-				Description: "Added /lib/modules mount for kubelet.",
-				Kind:        versionbundle.KindChanged,
-			},
-			{
-				Component:   "cloudconfig",
-				Description: "Updated CoreDNS to 1.1.1.",
-				Kind:        versionbundle.KindChanged,
-			},
-			{
-				Component:   "cloudconfig",
-				Description: "Fixed node-exporter running in container by adjusting host mounts.",
-				Kind:        versionbundle.KindChanged,
-			},
-			{
-				Component:   "cloudconfig",
-				Description: "Updated Calico to 3.0.5.",
-				Kind:        versionbundle.KindChanged,
-			},
-			{
-				Component:   "cloudconfig",
-				Description: "Updated Etcd to 3.3.3.",
-				Kind:        versionbundle.KindChanged,
-			},
-			{
-				Component:   "cloudconfig",
-				Description: "Added trusted certificate CNs to aggregation API allowed names.",
-				Kind:        versionbundle.KindChanged,
-			},
-			{
-				Component:   "cloudconfig",
-				Description: "Disabled SSL passthrough in nginx-ingress-controller.",
-				Kind:        versionbundle.KindChanged,
-			},
-			{
-				Component:   "cloudconfig",
-				Description: "Removed docker flag --disable-legacy-registry.",
-				Kind:        versionbundle.KindRemoved,
-			},
-			{
-				Component:   "cloudconfig",
-				Description: "Removed calico-ipip-pinger.",
-				Kind:        versionbundle.KindRemoved,
-			},
-			{
-				Component:   "kvm-operator",
-				Description: "Added node draining support.",
-				Kind:        versionbundle.KindAdded,
-			},
-			{
-				Component:   "cloudconfig",
-				Description: "Fixed etcd mount path.",
-				Kind:        versionbundle.KindChanged,
-			},
-			{
-				Component:   "cloudconfig",
-				Description: "Removed explicit hostname labeling for kubelet.",
+				Component:   "kvmconfig",
+				Description: "Updated ingress annotations for api and etcd.",
 				Kind:        versionbundle.KindChanged,
 			},
 		},
 		Components: []versionbundle.Component{
 			{
 				Name:    "calico",
-				Version: "3.0.5",
+				Version: "3.0.2",
 			},
 			{
 				Name:    "containerlinux",
-				Version: "1688.5.3",
+				Version: "1632.3.0",
 			},
 			{
 				Name:    "docker",
-				Version: "17.12.1",
+				Version: "17.09.0",
 			},
 			{
 				Name:    "etcd",
-				Version: "3.3.3",
+				Version: "3.3.1",
 			},
 			{
 				Name:    "coredns",
-				Version: "1.1.1",
+				Version: "1.0.6",
 			},
 			{
 				Name:    "kubernetes",
-				Version: "1.10.1",
+				Version: "1.9.5",
 			},
 			{
 				Name:    "nginx-ingress-controller",
@@ -121,10 +51,10 @@ func VersionBundle() versionbundle.Bundle {
 			},
 		},
 		Dependencies: []versionbundle.Dependency{},
-		Deprecated:   false,
+		Deprecated:   true,
 		Name:         "kvm-operator",
-		Time:         time.Date(2018, time.April, 25, 13, 00, 0, 0, time.UTC),
-		Version:      "2.2.0",
+		Time:         time.Date(2018, time.March, 22, 15, 30, 0, 0, time.UTC),
+		Version:      "2.1.3",
 		WIP:          false,
 	}
 }


### PR DESCRIPTION
This PR got created by `opsctl` in order to automate the creation of a new WIP version bundle. This specific PR is to copy the latest resource package only. FYI @giantswarm/sig-operator @giantswarm/sig-customer @giantswarm/sre.