### PR TITLE
adds versioning for pod reconciliation

### DIFF
--- a/service/controller/v11/drainer_resource_set.go
+++ b/service/controller/v11/drainer_resource_set.go
@@ -10,6 +10,7 @@ import (
 	"github.com/giantswarm/operatorkit/controller/resource/retryresource"
 	"k8s.io/client-go/kubernetes"
 
+	"github.com/giantswarm/kvm-operator/service/controller/v11/key"
 	"github.com/giantswarm/kvm-operator/service/controller/v11/resource/endpoint"
 	"github.com/giantswarm/kvm-operator/service/controller/v11/resource/pod"
 )
@@ -26,7 +27,20 @@ func NewDrainerResourceSet(config DrainerResourceSetConfig) (*controller.Resourc
 	var err error
 
 	handlesFunc := func(obj interface{}) bool {
-		return true
+		p, err := key.ToPod(obj)
+		if err != nil {
+			return false
+		}
+		v, err := key.VersionBundleVersionFromPod(p)
+		if err != nil {
+			return false
+		}
+
+		if v == VersionBundle().Version {
+			return true
+		}
+
+		return false
 	}
 
 	var podResource controller.Resource

--- a/service/controller/v11/drainer_resource_set.go
+++ b/service/controller/v11/drainer_resource_set.go
@@ -32,13 +32,22 @@ func NewDrainerResourceSet(config DrainerResourceSetConfig) (*controller.Resourc
 			return false
 		}
 		v, err := key.VersionBundleVersionFromPod(p)
-		if err != nil {
-			return false
-		}
-
-		if v == VersionBundle().Version {
+		// NOTE this is the hack we have to backport to ensure existing clusters
+		// work the way they do while paving the ground for v12 where we have to
+		// check more explictly against our desired version bundle version.
+		if v == "" {
 			return true
 		}
+
+		// TODO this error handling has to be enabled when going from v11 to v12.
+		//if err != nil {
+		//	return false
+		//}
+
+		// TODO this check has to be enabled when going from v11 to v12.
+		//if v == VersionBundle().Version {
+		//	return true
+		//}
 
 		return false
 	}

--- a/service/controller/v11/drainer_resource_set.go
+++ b/service/controller/v11/drainer_resource_set.go
@@ -35,7 +35,7 @@ func NewDrainerResourceSet(config DrainerResourceSetConfig) (*controller.Resourc
 		// NOTE this is the hack we have to backport to ensure existing clusters
 		// work the way they do while paving the ground for v12 where we have to
 		// check more explictly against our desired version bundle version.
-		if v == "" {
+		if v == "" || v == VersionBundle().Version {
 			return true
 		}
 

--- a/service/controller/v11/key/key.go
+++ b/service/controller/v11/key/key.go
@@ -53,10 +53,11 @@ const (
 )
 
 const (
-	AnnotationAPIEndpoint = "kvm-operator.giantswarm.io/api-endpoint"
-	AnnotationIp          = "endpoint.kvm.giantswarm.io/ip"
-	AnnotationService     = "endpoint.kvm.giantswarm.io/service"
-	AnnotationPodDrained  = "endpoint.kvm.giantswarm.io/drained"
+	AnnotationAPIEndpoint   = "kvm-operator.giantswarm.io/api-endpoint"
+	AnnotationIp            = "endpoint.kvm.giantswarm.io/ip"
+	AnnotationService       = "endpoint.kvm.giantswarm.io/service"
+	AnnotationPodDrained    = "endpoint.kvm.giantswarm.io/drained"
+	AnnotationVersionBundle = "kvm-operator.giantswarm.io/version-bundle"
 )
 
 const (
@@ -313,6 +314,19 @@ func ToPod(v interface{}) (*corev1.Pod, error) {
 
 func VersionBundleVersion(customObject v1alpha1.KVMConfig) string {
 	return customObject.Spec.VersionBundle.Version
+}
+
+func VersionBundleVersionFromPod(pod *corev1.Pod) (string, error) {
+	a := pod.GetAnnotations()
+	if a == nil {
+		return "", microerror.Mask(missingAnnotationError)
+	}
+	v, ok := a[AnnotationVersionBundle]
+	if !ok {
+		return "", microerror.Mask(missingAnnotationError)
+	}
+
+	return v, nil
 }
 
 func VMNumber(ID int) string {

--- a/service/controller/v11/resource/deployment/master_deployment.go
+++ b/service/controller/v11/resource/deployment/master_deployment.go
@@ -90,10 +90,11 @@ func newMasterDeployments(customObject v1alpha1.KVMConfig) ([]*extensionsv1.Depl
 				Template: apiv1.PodTemplateSpec{
 					ObjectMeta: apismetav1.ObjectMeta{
 						Annotations: map[string]string{
-							key.AnnotationAPIEndpoint: key.ClusterAPIEndpoint(customObject),
-							key.AnnotationIp:          "",
-							key.AnnotationService:     key.MasterID,
-							key.AnnotationPodDrained:  "False",
+							key.AnnotationAPIEndpoint:   key.ClusterAPIEndpoint(customObject),
+							key.AnnotationIp:            "",
+							key.AnnotationService:       key.MasterID,
+							key.AnnotationPodDrained:    "False",
+							key.AnnotationVersionBundle: key.VersionBundleVersion(customObject),
 						},
 						GenerateName: key.MasterID,
 						Labels: map[string]string{

--- a/service/controller/v11/resource/deployment/worker_deployment.go
+++ b/service/controller/v11/resource/deployment/worker_deployment.go
@@ -59,10 +59,11 @@ func newWorkerDeployments(customObject v1alpha1.KVMConfig) ([]*extensionsv1.Depl
 				Template: apiv1.PodTemplateSpec{
 					ObjectMeta: apismetav1.ObjectMeta{
 						Annotations: map[string]string{
-							key.AnnotationAPIEndpoint: key.ClusterAPIEndpoint(customObject),
-							key.AnnotationIp:          "",
-							key.AnnotationService:     key.WorkerID,
-							key.AnnotationPodDrained:  "False",
+							key.AnnotationAPIEndpoint:   key.ClusterAPIEndpoint(customObject),
+							key.AnnotationIp:            "",
+							key.AnnotationService:       key.WorkerID,
+							key.AnnotationPodDrained:    "False",
+							key.AnnotationVersionBundle: key.VersionBundleVersion(customObject),
 						},
 						Name: key.WorkerID,
 						Labels: map[string]string{


### PR DESCRIPTION
A while ago we added a first basic pod draining support. We forgot to version the pod reconciliation. This here backports some rough logic to keep `v11` resources working and at the same time paving the ground for v12 which we are going to introduce next. 