### PR TITLE
Add $.Release.Time to deployment descriptor

### DIFF
--- a/helm/kvm-operator-chart/templates/deployment.yaml
+++ b/helm/kvm-operator-chart/templates/deployment.yaml
@@ -13,7 +13,6 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         releasetime: {{ $.Release.Time }}
       labels:
         app: kvm-operator

--- a/helm/kvm-operator-chart/templates/deployment.yaml
+++ b/helm/kvm-operator-chart/templates/deployment.yaml
@@ -14,6 +14,7 @@ spec:
     metadata:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        releasetime: {{ $.Release.Time }}
       labels:
         app: kvm-operator
     spec:


### PR DESCRIPTION
In order to make Helm always deploy PODs on deploy event, add release
time to deployment annotation. This changes on every deploy event which
changes deployment descriptor and therefore triggers Helm.