### PR TITLE
resilient-calico-kube-kill

### DIFF
--- a/service/controller/v14/cloudconfig/master_template.go
+++ b/service/controller/v14/cloudconfig/master_template.go
@@ -133,7 +133,7 @@ After=k8s-kubelet.service
 Environment="KUBECONFIG=/etc/kubernetes/config/addons-kubeconfig.yml"
 Environment="KUBECTL=quay.io/giantswarm/docker-kubectl:e777d4eaf369d4dabc393c5da42121c2a725ea6a"
 ExecStart=/bin/sh -c '\
-	while [ "$(/usr/bin/docker run -e KUBECONFIG=${KUBECONFIG} --net=host --rm -v /etc/kubernetes:/etc/kubernetes $KUBECTL get cs | grep Healthy | wc -l)" -ne "3" ]; do sleep 1 && echo "Waiting for healthy k8s"; done;sleep 30s; \
+	while [ "$(/usr/bin/docker run -e KUBECONFIG=${KUBECONFIG} --net=host --rm -v /etc/kubernetes:/etc/kubernetes $KUBECTL get cs | grep Healthy | wc -l)" -ne "3" ]; do sleep 1 && echo "Waiting for healthy k8s"; done; \
 	RETRY=5;result="";\
 	while [ "$result" != "ok" ] && [ $RETRY -gt 0 ]; do\
 		sleep 10s; echo "Trying to restart k8s services ...";\
@@ -141,7 +141,6 @@ ExecStart=/bin/sh -c '\
 		/usr/bin/docker run -e KUBECONFIG=${KUBECONFIG} --net=host --rm -v /etc/kubernetes:/etc/kubernetes $KUBECTL -n kube-system delete pod -l k8s-app=calico-node && \
 		sleep 1m && \
 		/usr/bin/docker run -e KUBECONFIG=${KUBECONFIG} --net=host --rm -v /etc/kubernetes:/etc/kubernetes $KUBECTL -n kube-system delete pod -l k8s-app=kube-proxy && \
-		sleep 1m && \
 		/usr/bin/docker run -e KUBECONFIG=${KUBECONFIG} --net=host --rm -v /etc/kubernetes:/etc/kubernetes $KUBECTL -n kube-system delete pod -l k8s-app=calico-kube-controllers && \
 		/usr/bin/docker run -e KUBECONFIG=${KUBECONFIG} --net=host --rm -v /etc/kubernetes:/etc/kubernetes $KUBECTL -n kube-system delete pod -l k8s-app=coredns &&\
 		result="ok" || echo "failed";\

--- a/service/controller/v14/cloudconfig/master_template.go
+++ b/service/controller/v14/cloudconfig/master_template.go
@@ -133,7 +133,7 @@ After=k8s-kubelet.service
 Environment="KUBECONFIG=/etc/kubernetes/config/addons-kubeconfig.yml"
 Environment="KUBECTL=quay.io/giantswarm/docker-kubectl:e777d4eaf369d4dabc393c5da42121c2a725ea6a"
 ExecStart=/bin/sh -c '\
-	while [ "$(/usr/bin/docker run -e KUBECONFIG=${KUBECONFIG} --net=host --rm -v /etc/kubernetes:/etc/kubernetes $KUBECTL get cs | grep Healthy | wc -l)" -ne "3" ]; do sleep 1 && echo "Waiting for healthy k8s"; done; \
+	while [ "$(/usr/bin/docker run -e KUBECONFIG=${KUBECONFIG} --net=host --rm -v /etc/kubernetes:/etc/kubernetes $KUBECTL get cs | grep Healthy | wc -l)" -ne "3" ]; do sleep 1 && echo "Waiting for healthy k8s";done;sleep 30s; \
 	RETRY=5;result="";\
 	while [ "$result" != "ok" ] && [ $RETRY -gt 0 ]; do\
 		sleep 10s; echo "Trying to restart k8s services ...";\

--- a/service/controller/v14/cloudconfig/master_template.go
+++ b/service/controller/v14/cloudconfig/master_template.go
@@ -126,20 +126,27 @@ WantedBy=multi-user.target
 		{
 			AssetContent: `[Unit]
 Description=Temporary fix for issues with calico-node and kube-proxy after master restart
-Require=k8s-kubelet.service
+Requires=k8s-kubelet.service
 After=k8s-kubelet.service
 
 [Service]
 Environment="KUBECONFIG=/etc/kubernetes/config/addons-kubeconfig.yml"
-Environment="KUBECTL=quay.io/giantswarm/docker-kubectl:1dc536ec6dc4597ba46769b3d5d6ce53a7e62038"
-ExecStart=/bin/sh -c "\
-	while [ \"$(/usr/bin/docker run -e KUBECONFIG=${KUBECONFIG} --net=host --rm -v /etc/kubernetes:/etc/kubernetes $KUBECTL get cs | grep Healthy | wc -l)\" -ne \"3\" ]; do sleep 1 && echo 'Waiting for healthy k8s'; done;sleep 30s; \
-	/usr/bin/docker run -e KUBECONFIG=${KUBECONFIG} --net=host --rm -v /etc/kubernetes:/etc/kubernetes $KUBECTL -n kube-system delete pod -l k8s-app=calico-node; \
-	sleep 1m; \
-	/usr/bin/docker run -e KUBECONFIG=${KUBECONFIG} --net=host --rm -v /etc/kubernetes:/etc/kubernetes $KUBECTL -n kube-system delete pod -l k8s-app=kube-proxy; \
-	sleep 1m; \
-	/usr/bin/docker run -e KUBECONFIG=${KUBECONFIG} --net=host --rm -v /etc/kubernetes:/etc/kubernetes $KUBECTL -n kube-system delete pod -l k8s-app=calico-kube-controllers; \
-	/usr/bin/docker run -e KUBECONFIG=${KUBECONFIG} --net=host --rm -v /etc/kubernetes:/etc/kubernetes $KUBECTL -n kube-system delete pod -l k8s-app=kube-dns"
+Environment="KUBECTL=quay.io/giantswarm/docker-kubectl:e777d4eaf369d4dabc393c5da42121c2a725ea6a"
+ExecStart=/bin/sh -c '\
+	while [ "$(/usr/bin/docker run -e KUBECONFIG=${KUBECONFIG} --net=host --rm -v /etc/kubernetes:/etc/kubernetes $KUBECTL get cs | grep Healthy | wc -l)" -ne "3" ]; do sleep 1 && echo "Waiting for healthy k8s"; done;sleep 30s; \
+	RETRY=5;result="";\
+	while [ "$result" != "ok" ] && [ $RETRY -gt 0 ]; do\
+	sleep 10s; echo "Trying to restart k8s services ...";\
+	let RETRY=$RETRY-1;\
+	/usr/bin/docker run -e KUBECONFIG=${KUBECONFIG} --net=host --rm -v /etc/kubernetes:/etc/kubernetes $KUBECTL -n kube-system delete pod -l k8s-app=calico-node && \
+	sleep 1m && \
+	/usr/bin/docker run -e KUBECONFIG=${KUBECONFIG} --net=host --rm -v /etc/kubernetes:/etc/kubernetes $KUBECTL -n kube-system delete pod -l k8s-app=kube-proxy && \
+	sleep 1m && \
+	/usr/bin/docker run -e KUBECONFIG=${KUBECONFIG} --net=host --rm -v /etc/kubernetes:/etc/kubernetes $KUBECTL -n kube-system delete pod -l k8s-app=calico-kube-controllers && \
+	/usr/bin/docker run -e KUBECONFIG=${KUBECONFIG} --net=host --rm -v /etc/kubernetes:/etc/kubernetes $KUBECTL -n kube-system delete pod -l k8s-app=coredns &&\
+    result="ok" || echo "failed";\
+	done;\
+	[ "$result" != "ok" ] && echo "Failed to restart k8s services." && exit 1 || echo "Successfully restarted k8s services.";'
 
 [Install]
 WantedBy=multi-user.target`,

--- a/service/controller/v14/cloudconfig/master_template.go
+++ b/service/controller/v14/cloudconfig/master_template.go
@@ -136,15 +136,15 @@ ExecStart=/bin/sh -c '\
 	while [ "$(/usr/bin/docker run -e KUBECONFIG=${KUBECONFIG} --net=host --rm -v /etc/kubernetes:/etc/kubernetes $KUBECTL get cs | grep Healthy | wc -l)" -ne "3" ]; do sleep 1 && echo "Waiting for healthy k8s"; done;sleep 30s; \
 	RETRY=5;result="";\
 	while [ "$result" != "ok" ] && [ $RETRY -gt 0 ]; do\
-	sleep 10s; echo "Trying to restart k8s services ...";\
-	let RETRY=$RETRY-1;\
-	/usr/bin/docker run -e KUBECONFIG=${KUBECONFIG} --net=host --rm -v /etc/kubernetes:/etc/kubernetes $KUBECTL -n kube-system delete pod -l k8s-app=calico-node && \
-	sleep 1m && \
-	/usr/bin/docker run -e KUBECONFIG=${KUBECONFIG} --net=host --rm -v /etc/kubernetes:/etc/kubernetes $KUBECTL -n kube-system delete pod -l k8s-app=kube-proxy && \
-	sleep 1m && \
-	/usr/bin/docker run -e KUBECONFIG=${KUBECONFIG} --net=host --rm -v /etc/kubernetes:/etc/kubernetes $KUBECTL -n kube-system delete pod -l k8s-app=calico-kube-controllers && \
-	/usr/bin/docker run -e KUBECONFIG=${KUBECONFIG} --net=host --rm -v /etc/kubernetes:/etc/kubernetes $KUBECTL -n kube-system delete pod -l k8s-app=coredns &&\
-    result="ok" || echo "failed";\
+		sleep 10s; echo "Trying to restart k8s services ...";\
+		let RETRY=$RETRY-1;\
+		/usr/bin/docker run -e KUBECONFIG=${KUBECONFIG} --net=host --rm -v /etc/kubernetes:/etc/kubernetes $KUBECTL -n kube-system delete pod -l k8s-app=calico-node && \
+		sleep 1m && \
+		/usr/bin/docker run -e KUBECONFIG=${KUBECONFIG} --net=host --rm -v /etc/kubernetes:/etc/kubernetes $KUBECTL -n kube-system delete pod -l k8s-app=kube-proxy && \
+		sleep 1m && \
+		/usr/bin/docker run -e KUBECONFIG=${KUBECONFIG} --net=host --rm -v /etc/kubernetes:/etc/kubernetes $KUBECTL -n kube-system delete pod -l k8s-app=calico-kube-controllers && \
+		/usr/bin/docker run -e KUBECONFIG=${KUBECONFIG} --net=host --rm -v /etc/kubernetes:/etc/kubernetes $KUBECTL -n kube-system delete pod -l k8s-app=coredns &&\
+		result="ok" || echo "failed";\
 	done;\
 	[ "$result" != "ok" ] && echo "Failed to restart k8s services." && exit 1 || echo "Successfully restarted k8s services.";'
 


### PR DESCRIPTION
towards https://github.com/giantswarm/giantswarm/issues/3634
Make `calico-kube-kill.service` resilient to failures by introducing retry logic.

Also including changes from this: https://github.com/giantswarm/kvm-operator/pull/505 apparently v13 was created before it was merged.

As boy scouting bumping `docker-kubectl` version to 1.10.4