### PR TITLE
removes resource version setting when updating service

### DIFF
--- a/service/controller/v14/resource/service/update.go
+++ b/service/controller/v14/resource/service/update.go
@@ -76,7 +76,6 @@ func (r *Resource) newUpdateChange(ctx context.Context, obj, currentState, desir
 		if isServiceModified(desiredService, currentService) {
 			// Make a copy and set the resource version so the service can be updated.
 			serviceToUpdate := desiredService.DeepCopy()
-			serviceToUpdate.ObjectMeta.ResourceVersion = currentService.ObjectMeta.ResourceVersion
 			serviceToUpdate.Spec.ClusterIP = currentService.Spec.ClusterIP
 
 			servicesToUpdate = append(servicesToUpdate, serviceToUpdate)


### PR DESCRIPTION
Follow up on https://github.com/giantswarm/kvm-operator/pull/509#discussion_r204369909. 