### PR TITLE
Move namespace to values

### DIFF
--- a/helm/kvm-operator-chart/templates/configmap.yaml
+++ b/helm/kvm-operator-chart/templates/configmap.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: kvm-operator-configmap
-  namespace: giantswarm
+  namespace: {{ .Values.namespace }}
 data:
   config.yml: |
     server:

--- a/helm/kvm-operator-chart/templates/deployment.yaml
+++ b/helm/kvm-operator-chart/templates/deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: kvm-operator
-  namespace: giantswarm
+  namespace: {{ .Values.namespace }}
   labels:
     app: kvm-operator
 spec:

--- a/helm/kvm-operator-chart/templates/pull-secret.yml
+++ b/helm/kvm-operator-chart/templates/pull-secret.yml
@@ -3,6 +3,6 @@ kind: Secret
 type: kubernetes.io/dockerconfigjson
 metadata:
   name: kvm-operator-pull-secret
-  namespace: giantswarm
+  namespace: {{ .Values.namespace }}
 data:
   .dockerconfigjson: {{ .Values.Installation.V1.Secret.Registry.PullSecret.DockerConfigJSON | b64enc | quote }}

--- a/helm/kvm-operator-chart/templates/rbac.yaml
+++ b/helm/kvm-operator-chart/templates/rbac.yaml
@@ -94,7 +94,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: kvm-operator
-    namespace: giantswarm
+    namespace: {{ .Values.namespace }}
 roleRef:
   kind: ClusterRole
   name: kvm-operator
@@ -121,7 +121,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: kvm-operator
-    namespace: giantswarm
+    namespace: {{ .Values.namespace }}
 roleRef:
   kind: ClusterRole
   name: kvm-operator-psp

--- a/helm/kvm-operator-chart/templates/service-account.yaml
+++ b/helm/kvm-operator-chart/templates/service-account.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: kvm-operator
-  namespace: giantswarm
+  namespace: {{ .Values.namespace }}

--- a/helm/kvm-operator-chart/templates/service.yaml
+++ b/helm/kvm-operator-chart/templates/service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: kvm-operator
-  namespace: giantswarm
+  namespace: {{ .Values.namespace }}
   labels:
     app: kvm-operator
   annotations:

--- a/helm/kvm-operator-chart/values.yaml
+++ b/helm/kvm-operator-chart/values.yaml
@@ -1,0 +1,1 @@
+namespace: giantswarm


### PR DESCRIPTION
in order to be able change namespace where kvm-operator is installed we need to template the namespace in the manifest, this is for kvm e2e