### PR TITLE
enable-crd-label-selector

### DIFF
--- a/flag/service/crd/crd.go
+++ b/flag/service/crd/crd.go
@@ -1,0 +1,5 @@
+package crd
+
+type CRD struct {
+	LabelSelector string
+}

--- a/flag/service/service.go
+++ b/flag/service/service.go
@@ -1,12 +1,14 @@
 package service
 
 import (
+	"github.com/giantswarm/kvm-operator/flag/service/crd"
 	"github.com/giantswarm/kvm-operator/flag/service/guest"
 	"github.com/giantswarm/kvm-operator/flag/service/installation"
 	"github.com/giantswarm/kvm-operator/flag/service/kubernetes"
 )
 
 type Service struct {
+	CRD          crd.CRD
 	Guest        guest.Guest
 	Installation installation.Installation
 	Kubernetes   kubernetes.Kubernetes

--- a/helm/kvm-operator-chart/templates/configmap.yaml
+++ b/helm/kvm-operator-chart/templates/configmap.yaml
@@ -9,6 +9,8 @@ data:
       listen:
         address: 'http://0.0.0.0:8000'
     service:
+      crd:
+        labelSelector: '{{ .Values.labelSelector }}'
       guest:
         ssh:
           ssoPublicKey: '{{ .Values.Installation.V1.Guest.SSH.SSOPublicKey }}'

--- a/helm/kvm-operator-chart/values.yaml
+++ b/helm/kvm-operator-chart/values.yaml
@@ -1,1 +1,2 @@
+labelSelector: ''
 namespace: giantswarm

--- a/main.go
+++ b/main.go
@@ -114,6 +114,7 @@ func mainError() error {
 	daemonCommand.PersistentFlags().String(f.Service.Installation.Guest.Kubernetes.API.Auth.Provider.OIDC.UsernameClaim, "", "OIDC authorization provider UsernameClaim.")
 	daemonCommand.PersistentFlags().String(f.Service.Installation.Guest.Kubernetes.API.Auth.Provider.OIDC.GroupsClaim, "", "OIDC authorization provider GroupsClaim.")
 
+	daemonCommand.PersistentFlags().String(f.Service.CRD.LabelSelector, "", "Label selector for CRD informer ListOptions.")
 	daemonCommand.PersistentFlags().String(f.Service.Guest.SSH.SSOPublicKey, "", "Public key for trusted SSO CA.")
 	daemonCommand.PersistentFlags().Bool(f.Service.Guest.Update.Enabled, false, "Whether updates of guest cluster nodes are allowed to be processed upon reconciliation.")
 

--- a/main.go
+++ b/main.go
@@ -115,6 +115,7 @@ func mainError() error {
 	daemonCommand.PersistentFlags().String(f.Service.Installation.Guest.Kubernetes.API.Auth.Provider.OIDC.GroupsClaim, "", "OIDC authorization provider GroupsClaim.")
 
 	daemonCommand.PersistentFlags().String(f.Service.CRD.LabelSelector, "", "Label selector for CRD informer ListOptions.")
+
 	daemonCommand.PersistentFlags().String(f.Service.Guest.SSH.SSOPublicKey, "", "Public key for trusted SSO CA.")
 	daemonCommand.PersistentFlags().Bool(f.Service.Guest.Update.Enabled, false, "Whether updates of guest cluster nodes are allowed to be processed upon reconciliation.")
 

--- a/service/controller/cluster.go
+++ b/service/controller/cluster.go
@@ -24,6 +24,7 @@ import (
 	v15cloudconfig "github.com/giantswarm/kvm-operator/service/controller/v15/cloudconfig"
 	"github.com/giantswarm/kvm-operator/service/controller/v2"
 	"github.com/giantswarm/kvm-operator/service/controller/v4"
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 type ClusterConfig struct {
@@ -33,6 +34,7 @@ type ClusterConfig struct {
 	K8sExtClient  apiextensionsclient.Interface
 	Logger        micrologger.Logger
 
+	CRDLabelSelector   string
 	GuestUpdateEnabled bool
 	OIDC               ClusterConfigOIDC
 	ProjectName        string
@@ -91,6 +93,11 @@ func NewCluster(config ClusterConfig) (*Cluster, error) {
 
 			RateWait:     informer.DefaultRateWait,
 			ResyncPeriod: informer.DefaultResyncPeriod,
+		}
+		if config.CRDLabelSelector != "" {
+			c.ListOptions = v1.ListOptions{
+				LabelSelector: config.CRDLabelSelector,
+			}
 		}
 
 		newInformer, err = informer.New(c)

--- a/service/controller/cluster.go
+++ b/service/controller/cluster.go
@@ -11,6 +11,7 @@ import (
 	"github.com/giantswarm/operatorkit/informer"
 	"github.com/giantswarm/randomkeys"
 	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/giantswarm/kvm-operator/service/controller/v11"
@@ -24,7 +25,6 @@ import (
 	v15cloudconfig "github.com/giantswarm/kvm-operator/service/controller/v15/cloudconfig"
 	"github.com/giantswarm/kvm-operator/service/controller/v2"
 	"github.com/giantswarm/kvm-operator/service/controller/v4"
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 type ClusterConfig struct {

--- a/service/service.go
+++ b/service/service.go
@@ -129,6 +129,7 @@ func New(config Config) (*Service, error) {
 			K8sExtClient:  k8sExtClient,
 			Logger:        config.Logger,
 
+			CRDLabelSelector:   config.Viper.GetString(config.Flag.Service.CRD.LabelSelector),
 			GuestUpdateEnabled: config.Viper.GetBool(config.Flag.Service.Guest.Update.Enabled),
 			ProjectName:        config.Name,
 


### PR DESCRIPTION
enable the option to watch for specific CRDs via label selector

By default, it won't be set. This change is towards https://github.com/giantswarm/kvm-operator/pull/528
As we will run multiple `kvm-operators` in gastropod and they should only watch their CRDs.

