### PR TITLE
v14patch1: copy v14

### DIFF
--- a/service/controller/v14patch1/cloudconfig/cloud_config.go
+++ b/service/controller/v14patch1/cloudconfig/cloud_config.go
@@ -1,0 +1,82 @@
+package cloudconfig
+
+import (
+	"fmt"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+)
+
+const (
+	FileOwner      = "root:root"
+	FilePermission = 0700
+)
+
+// Config represents the configuration used to create a cloud config service.
+type Config struct {
+	// Dependencies.
+	Logger micrologger.Logger
+
+	OIDC         OIDCConfig
+	SSOPublicKey string
+}
+
+// DefaultConfig provides a default configuration to create a new cloud config
+// service by best effort.
+func DefaultConfig() Config {
+	return Config{
+		// Dependencies.
+		Logger: nil,
+	}
+}
+
+// CloudConfig implements the cloud config service interface.
+type CloudConfig struct {
+	// Dependencies.
+	logger micrologger.Logger
+
+	k8sAPIExtraArgs []string
+	ssoPublicKey    string
+}
+
+// OIDCConfig represents the configuration of the OIDC authorization provider
+type OIDCConfig struct {
+	ClientID      string
+	IssuerURL     string
+	UsernameClaim string
+	GroupsClaim   string
+}
+
+// New creates a new configured cloud config service.
+func New(config Config) (*CloudConfig, error) {
+	// Dependencies.
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "logger must not be empty")
+	}
+
+	var k8sAPIExtraArgs []string
+	{
+		if config.OIDC.ClientID != "" {
+			k8sAPIExtraArgs = append(k8sAPIExtraArgs, fmt.Sprintf("--oidc-client-id=%s", config.OIDC.ClientID))
+		}
+		if config.OIDC.IssuerURL != "" {
+			k8sAPIExtraArgs = append(k8sAPIExtraArgs, fmt.Sprintf("--oidc-issuer-url=%s", config.OIDC.IssuerURL))
+		}
+		if config.OIDC.UsernameClaim != "" {
+			k8sAPIExtraArgs = append(k8sAPIExtraArgs, fmt.Sprintf("--oidc-username-claim=%s", config.OIDC.UsernameClaim))
+		}
+		if config.OIDC.GroupsClaim != "" {
+			k8sAPIExtraArgs = append(k8sAPIExtraArgs, fmt.Sprintf("--oidc-groups-claim=%s", config.OIDC.GroupsClaim))
+		}
+	}
+
+	newCloudConfig := &CloudConfig{
+		// Dependencies.
+		logger: config.Logger,
+
+		k8sAPIExtraArgs: k8sAPIExtraArgs,
+		ssoPublicKey:    config.SSOPublicKey,
+	}
+
+	return newCloudConfig, nil
+}

--- a/service/controller/v14patch1/cloudconfig/cloudconfigtest/cloudconfigtest.go
+++ b/service/controller/v14patch1/cloudconfig/cloudconfigtest/cloudconfigtest.go
@@ -1,0 +1,20 @@
+package cloudconfigtest
+
+import (
+	"github.com/giantswarm/micrologger/microloggertest"
+
+	"github.com/giantswarm/kvm-operator/service/controller/v14/cloudconfig"
+)
+
+func New() *cloudconfig.CloudConfig {
+	c := cloudconfig.DefaultConfig()
+
+	c.Logger = microloggertest.New()
+
+	newCloudConfig, err := cloudconfig.New(c)
+	if err != nil {
+		panic(err)
+	}
+
+	return newCloudConfig
+}

--- a/service/controller/v14patch1/cloudconfig/error.go
+++ b/service/controller/v14patch1/cloudconfig/error.go
@@ -1,0 +1,21 @@
+package cloudconfig
+
+import "github.com/giantswarm/microerror"
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var notFoundError = &microerror.Error{
+	Kind: "notFoundError",
+}
+
+// IsNotFound asserts notFoundError.
+func IsNotFound(err error) bool {
+	return microerror.Cause(err) == notFoundError
+}

--- a/service/controller/v14patch1/cloudconfig/master_template.go
+++ b/service/controller/v14patch1/cloudconfig/master_template.go
@@ -1,0 +1,179 @@
+package cloudconfig
+
+import (
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/certs"
+	k8scloudconfig "github.com/giantswarm/k8scloudconfig/v_3_4_0"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/randomkeys"
+)
+
+// NewMasterTemplate generates a new worker cloud config template and returns it
+// as a base64 encoded string.
+func (c *CloudConfig) NewMasterTemplate(customObject v1alpha1.KVMConfig, certs certs.Cluster, node v1alpha1.ClusterNode, randomKeys randomkeys.Cluster) (string, error) {
+	var err error
+
+	var params k8scloudconfig.Params
+	{
+		params.APIServerEncryptionKey = string(randomKeys.APIServerEncryptionKey)
+		params.Cluster = customObject.Spec.Cluster
+		params.Extension = &masterExtension{
+			certs: certs,
+		}
+		params.Node = node
+		params.Hyperkube.Apiserver.Pod.CommandExtraArgs = c.k8sAPIExtraArgs
+		params.SSOPublicKey = c.ssoPublicKey
+	}
+
+	var newCloudConfig *k8scloudconfig.CloudConfig
+	{
+		cloudConfigConfig := k8scloudconfig.DefaultCloudConfigConfig()
+		cloudConfigConfig.Params = params
+		cloudConfigConfig.Template = k8scloudconfig.MasterTemplate
+
+		newCloudConfig, err = k8scloudconfig.NewCloudConfig(cloudConfigConfig)
+		if err != nil {
+			return "", microerror.Mask(err)
+		}
+
+		err = newCloudConfig.ExecuteTemplate()
+		if err != nil {
+			return "", microerror.Mask(err)
+		}
+	}
+
+	return newCloudConfig.Base64(), nil
+}
+
+type masterExtension struct {
+	certs certs.Cluster
+}
+
+func (e *masterExtension) Files() ([]k8scloudconfig.FileAsset, error) {
+	var filesMeta []k8scloudconfig.FileMetadata
+
+	for _, f := range certs.NewFilesClusterMaster(e.certs) {
+		m := k8scloudconfig.FileMetadata{
+			AssetContent: string(f.Data),
+			Path:         f.AbsolutePath,
+			Owner:        FileOwner,
+			Permissions:  FilePermission,
+		}
+		filesMeta = append(filesMeta, m)
+	}
+
+	var newFiles []k8scloudconfig.FileAsset
+
+	for _, fm := range filesMeta {
+		c, err := k8scloudconfig.RenderAssetContent(fm.AssetContent, nil)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+
+		fileAsset := k8scloudconfig.FileAsset{
+			Metadata: fm,
+			Content:  c,
+		}
+
+		newFiles = append(newFiles, fileAsset)
+	}
+
+	return newFiles, nil
+}
+
+func (e *masterExtension) Units() ([]k8scloudconfig.UnitAsset, error) {
+	unitsMeta := []k8scloudconfig.UnitMetadata{
+		// Mount etcd volume when directory first accessed
+		// This automount is workaround for
+		// https://bugzilla.redhat.com/show_bug.cgi?id=1184122
+		{
+			AssetContent: `[Unit]
+Description=Automount for etcd volume
+[Automount]
+Where=/var/lib/etcd
+[Install]
+WantedBy=multi-user.target
+`,
+			Name:    "var-lib-etcd.automount",
+			Enable:  true,
+			Command: "start",
+		},
+		// Mount for etcd volume activated by automount
+		{
+			AssetContent: `[Unit]
+Description=Mount for etcd volume
+[Mount]
+What=etcdshare
+Where=/var/lib/etcd
+Options=trans=virtio,version=9p2000.L,cache=mmap
+Type=9p
+[Install]
+WantedBy=multi-user.target
+`,
+			Name:   "var-lib-etcd.mount",
+			Enable: false,
+		},
+		{
+			Name:    "iscsid.service",
+			Enable:  true,
+			Command: "start",
+		},
+		{
+			Name:    "multipathd.service",
+			Enable:  true,
+			Command: "start",
+		},
+		{
+			AssetContent: `[Unit]
+Description=Temporary fix for issues with calico-node and kube-proxy after master restart
+Requires=k8s-kubelet.service
+After=k8s-kubelet.service
+
+[Service]
+Environment="KUBECONFIG=/etc/kubernetes/config/addons-kubeconfig.yml"
+Environment="KUBECTL=quay.io/giantswarm/docker-kubectl:e777d4eaf369d4dabc393c5da42121c2a725ea6a"
+ExecStart=/bin/sh -c '\
+	while [ "$(/usr/bin/docker run -e KUBECONFIG=${KUBECONFIG} --net=host --rm -v /etc/kubernetes:/etc/kubernetes $KUBECTL get cs | grep Healthy | wc -l)" -ne "3" ]; do sleep 1 && echo "Waiting for healthy k8s";done;sleep 30s; \
+	RETRY=5;result="";\
+	while [ "$result" != "ok" ] && [ $RETRY -gt 0 ]; do\
+		sleep 10s; echo "Trying to restart k8s services ...";\
+		let RETRY=$RETRY-1;\
+		/usr/bin/docker run -e KUBECONFIG=${KUBECONFIG} --net=host --rm -v /etc/kubernetes:/etc/kubernetes $KUBECTL -n kube-system delete pod -l k8s-app=calico-node && \
+		sleep 1m && \
+		/usr/bin/docker run -e KUBECONFIG=${KUBECONFIG} --net=host --rm -v /etc/kubernetes:/etc/kubernetes $KUBECTL -n kube-system delete pod -l k8s-app=kube-proxy && \
+		/usr/bin/docker run -e KUBECONFIG=${KUBECONFIG} --net=host --rm -v /etc/kubernetes:/etc/kubernetes $KUBECTL -n kube-system delete pod -l k8s-app=calico-kube-controllers && \
+		/usr/bin/docker run -e KUBECONFIG=${KUBECONFIG} --net=host --rm -v /etc/kubernetes:/etc/kubernetes $KUBECTL -n kube-system delete pod -l k8s-app=coredns &&\
+		result="ok" || echo "failed";\
+	done;\
+	[ "$result" != "ok" ] && echo "Failed to restart k8s services." && exit 1 || echo "Successfully restarted k8s services.";'
+
+[Install]
+WantedBy=multi-user.target`,
+			Name:    "calico-kube-kill.service",
+			Command: "start",
+			Enable:  true,
+		},
+	}
+
+	var newUnits []k8scloudconfig.UnitAsset
+
+	for _, fm := range unitsMeta {
+		c, err := k8scloudconfig.RenderAssetContent(fm.AssetContent, nil)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+
+		unitAsset := k8scloudconfig.UnitAsset{
+			Metadata: fm,
+			Content:  c,
+		}
+
+		newUnits = append(newUnits, unitAsset)
+	}
+
+	return newUnits, nil
+}
+
+func (e *masterExtension) VerbatimSections() []k8scloudconfig.VerbatimSection {
+	return nil
+}

--- a/service/controller/v14patch1/cloudconfig/worker_template.go
+++ b/service/controller/v14patch1/cloudconfig/worker_template.go
@@ -1,0 +1,116 @@
+package cloudconfig
+
+import (
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/certs"
+	k8scloudconfig "github.com/giantswarm/k8scloudconfig/v_3_4_0"
+	"github.com/giantswarm/microerror"
+)
+
+// NewWorkerTemplate generates a new worker cloud config template and returns it
+// as a base64 encoded string.
+func (c *CloudConfig) NewWorkerTemplate(customObject v1alpha1.KVMConfig, certs certs.Cluster, node v1alpha1.ClusterNode) (string, error) {
+	var err error
+
+	var params k8scloudconfig.Params
+	{
+		params.Cluster = customObject.Spec.Cluster
+		params.Extension = &workerExtension{
+			certs: certs,
+		}
+		params.Node = node
+		params.SSOPublicKey = c.ssoPublicKey
+	}
+
+	var newCloudConfig *k8scloudconfig.CloudConfig
+	{
+		cloudConfigConfig := k8scloudconfig.DefaultCloudConfigConfig()
+		cloudConfigConfig.Params = params
+		cloudConfigConfig.Template = k8scloudconfig.WorkerTemplate
+
+		newCloudConfig, err = k8scloudconfig.NewCloudConfig(cloudConfigConfig)
+		if err != nil {
+			return "", microerror.Mask(err)
+		}
+
+		err = newCloudConfig.ExecuteTemplate()
+		if err != nil {
+			return "", microerror.Mask(err)
+		}
+	}
+
+	return newCloudConfig.Base64(), nil
+}
+
+type workerExtension struct {
+	certs certs.Cluster
+}
+
+func (e *workerExtension) Files() ([]k8scloudconfig.FileAsset, error) {
+	var filesMeta []k8scloudconfig.FileMetadata
+
+	for _, f := range certs.NewFilesClusterWorker(e.certs) {
+		m := k8scloudconfig.FileMetadata{
+			AssetContent: string(f.Data),
+			Path:         f.AbsolutePath,
+			Owner:        FileOwner,
+			Permissions:  FilePermission,
+		}
+		filesMeta = append(filesMeta, m)
+	}
+
+	var newFiles []k8scloudconfig.FileAsset
+
+	for _, fm := range filesMeta {
+		c, err := k8scloudconfig.RenderAssetContent(fm.AssetContent, nil)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+
+		fileAsset := k8scloudconfig.FileAsset{
+			Metadata: fm,
+			Content:  c,
+		}
+
+		newFiles = append(newFiles, fileAsset)
+	}
+
+	return newFiles, nil
+}
+
+func (e *workerExtension) Units() ([]k8scloudconfig.UnitAsset, error) {
+	unitsMeta := []k8scloudconfig.UnitMetadata{
+		{
+			Name:    "iscsid.service",
+			Enable:  true,
+			Command: "start",
+		},
+		{
+			Name:    "multipathd.service",
+			Enable:  true,
+			Command: "start",
+		},
+	}
+
+	var newUnits []k8scloudconfig.UnitAsset
+
+	for _, fm := range unitsMeta {
+		c, err := k8scloudconfig.RenderAssetContent(fm.AssetContent, nil)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+
+		unitAsset := k8scloudconfig.UnitAsset{
+			Metadata: fm,
+			Content:  c,
+		}
+
+		newUnits = append(newUnits, unitAsset)
+	}
+
+	return newUnits, nil
+}
+
+func (e *workerExtension) VerbatimSections() []k8scloudconfig.VerbatimSection {
+	return nil
+}

--- a/service/controller/v14patch1/cluster_resource_set.go
+++ b/service/controller/v14patch1/cluster_resource_set.go
@@ -1,0 +1,293 @@
+package v14
+
+import (
+	"context"
+
+	"github.com/giantswarm/certs"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/giantswarm/operatorkit/controller"
+	"github.com/giantswarm/operatorkit/controller/context/updateallowedcontext"
+	"github.com/giantswarm/operatorkit/controller/resource/metricsresource"
+	"github.com/giantswarm/operatorkit/controller/resource/retryresource"
+	"github.com/giantswarm/randomkeys"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/giantswarm/kvm-operator/service/controller/v14/cloudconfig"
+	"github.com/giantswarm/kvm-operator/service/controller/v14/key"
+	"github.com/giantswarm/kvm-operator/service/controller/v14/resource/clusterrolebinding"
+	"github.com/giantswarm/kvm-operator/service/controller/v14/resource/configmap"
+	"github.com/giantswarm/kvm-operator/service/controller/v14/resource/deployment"
+	"github.com/giantswarm/kvm-operator/service/controller/v14/resource/ingress"
+	"github.com/giantswarm/kvm-operator/service/controller/v14/resource/namespace"
+	"github.com/giantswarm/kvm-operator/service/controller/v14/resource/pvc"
+	"github.com/giantswarm/kvm-operator/service/controller/v14/resource/service"
+	"github.com/giantswarm/kvm-operator/service/controller/v14/resource/serviceaccount"
+)
+
+type ClusterResourceSetConfig struct {
+	CertsSearcher      certs.Interface
+	K8sClient          kubernetes.Interface
+	Logger             micrologger.Logger
+	RandomkeysSearcher randomkeys.Interface
+
+	OIDC               cloudconfig.OIDCConfig
+	GuestUpdateEnabled bool
+	ProjectName        string
+	SSOPublicKey       string
+}
+
+func NewClusterResourceSet(config ClusterResourceSetConfig) (*controller.ResourceSet, error) {
+	var err error
+
+	if config.SSOPublicKey == "" {
+		return nil, microerror.Maskf(invalidConfigError, "%T.SSOPublicKey must not be empty", config)
+	}
+
+	var cloudConfig *cloudconfig.CloudConfig
+	{
+		c := cloudconfig.Config{
+			Logger: config.Logger,
+
+			OIDC:         config.OIDC,
+			SSOPublicKey: config.SSOPublicKey,
+		}
+
+		cloudConfig, err = cloudconfig.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	var clusterRoleBindingResource controller.Resource
+	{
+		c := clusterrolebinding.Config{
+			K8sClient: config.K8sClient,
+			Logger:    config.Logger,
+		}
+
+		ops, err := clusterrolebinding.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+
+		clusterRoleBindingResource, err = toCRUDResource(config.Logger, ops)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	var namespaceResource controller.Resource
+	{
+		c := namespace.DefaultConfig()
+
+		c.K8sClient = config.K8sClient
+		c.Logger = config.Logger
+
+		ops, err := namespace.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+
+		namespaceResource, err = toCRUDResource(config.Logger, ops)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	var serviceAccountResource controller.Resource
+	{
+		c := serviceaccount.DefaultConfig()
+
+		c.K8sClient = config.K8sClient
+		c.Logger = config.Logger
+
+		ops, err := serviceaccount.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+
+		serviceAccountResource, err = toCRUDResource(config.Logger, ops)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	var configMapResource controller.Resource
+	{
+		c := configmap.Config{
+			CertsSearcher: config.CertsSearcher,
+			CloudConfig:   cloudConfig,
+			K8sClient:     config.K8sClient,
+			KeyWatcher:    config.RandomkeysSearcher,
+			Logger:        config.Logger,
+		}
+
+		ops, err := configmap.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+
+		configMapResource, err = toCRUDResource(config.Logger, ops)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	var deploymentResource controller.Resource
+	{
+		c := deployment.DefaultConfig()
+
+		c.K8sClient = config.K8sClient
+		c.Logger = config.Logger
+
+		ops, err := deployment.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+
+		deploymentResource, err = toCRUDResource(config.Logger, ops)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	var ingressResource controller.Resource
+	{
+		c := ingress.DefaultConfig()
+
+		c.K8sClient = config.K8sClient
+		c.Logger = config.Logger
+
+		ops, err := ingress.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+
+		ingressResource, err = toCRUDResource(config.Logger, ops)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	var pvcResource controller.Resource
+	{
+		c := pvc.DefaultConfig()
+
+		c.K8sClient = config.K8sClient
+		c.Logger = config.Logger
+
+		ops, err := pvc.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+
+		pvcResource, err = toCRUDResource(config.Logger, ops)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	var serviceResource controller.Resource
+	{
+		c := service.DefaultConfig()
+
+		c.K8sClient = config.K8sClient
+		c.Logger = config.Logger
+
+		ops, err := service.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+
+		serviceResource, err = toCRUDResource(config.Logger, ops)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	resources := []controller.Resource{
+		clusterRoleBindingResource,
+		namespaceResource,
+		serviceAccountResource,
+		configMapResource,
+		deploymentResource,
+		ingressResource,
+		pvcResource,
+		serviceResource,
+	}
+
+	{
+		c := retryresource.WrapConfig{
+			Logger: config.Logger,
+		}
+
+		resources, err = retryresource.Wrap(resources, c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	{
+		c := metricsresource.WrapConfig{
+			Name: config.ProjectName,
+		}
+
+		resources, err = metricsresource.Wrap(resources, c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	handlesFunc := func(obj interface{}) bool {
+		kvmConfig, err := key.ToCustomObject(obj)
+		if err != nil {
+			return false
+		}
+
+		if key.VersionBundleVersion(kvmConfig) == VersionBundle().Version {
+			return true
+		}
+
+		return false
+	}
+
+	initCtxFunc := func(ctx context.Context, obj interface{}) (context.Context, error) {
+		if config.GuestUpdateEnabled {
+			updateallowedcontext.SetUpdateAllowed(ctx)
+		}
+
+		return ctx, nil
+	}
+
+	var clusterResourceSet *controller.ResourceSet
+	{
+		c := controller.ResourceSetConfig{
+			Handles:   handlesFunc,
+			InitCtx:   initCtxFunc,
+			Logger:    config.Logger,
+			Resources: resources,
+		}
+
+		clusterResourceSet, err = controller.NewResourceSet(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	return clusterResourceSet, nil
+}
+
+func toCRUDResource(logger micrologger.Logger, ops controller.CRUDResourceOps) (*controller.CRUDResource, error) {
+	c := controller.CRUDResourceConfig{
+		Logger: logger,
+		Ops:    ops,
+	}
+
+	r, err := controller.NewCRUDResource(c)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	return r, nil
+}

--- a/service/controller/v14patch1/deleter_resource_set.go
+++ b/service/controller/v14patch1/deleter_resource_set.go
@@ -1,0 +1,95 @@
+package v14
+
+import (
+	"github.com/giantswarm/certs"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/giantswarm/operatorkit/controller"
+	"github.com/giantswarm/operatorkit/controller/resource/metricsresource"
+	"github.com/giantswarm/operatorkit/controller/resource/retryresource"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/giantswarm/kvm-operator/service/controller/v14/key"
+	"github.com/giantswarm/kvm-operator/service/controller/v14/resource/node"
+)
+
+type DeleterResourceSetConfig struct {
+	CertsSearcher certs.Interface
+	K8sClient     kubernetes.Interface
+	Logger        micrologger.Logger
+
+	ProjectName string
+}
+
+func NewDeleterResourceSet(config DeleterResourceSetConfig) (*controller.ResourceSet, error) {
+	var err error
+
+	handlesFunc := func(obj interface{}) bool {
+		kvmConfig, err := key.ToCustomObject(obj)
+		if err != nil {
+			return false
+		}
+
+		if key.VersionBundleVersion(kvmConfig) == VersionBundle().Version {
+			return true
+		}
+
+		return false
+	}
+
+	var nodeResource controller.Resource
+	{
+		c := node.Config{
+			CertsSearcher: config.CertsSearcher,
+			K8sClient:     config.K8sClient,
+			Logger:        config.Logger,
+		}
+
+		nodeResource, err = node.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	resources := []controller.Resource{
+		nodeResource,
+	}
+
+	{
+		c := retryresource.WrapConfig{
+			Logger: config.Logger,
+		}
+
+		resources, err = retryresource.Wrap(resources, c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	{
+		c := metricsresource.WrapConfig{
+			Name: config.ProjectName,
+		}
+
+		resources, err = metricsresource.Wrap(resources, c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	var deleterResourceSet *controller.ResourceSet
+	{
+		c := controller.ResourceSetConfig{
+			Handles:   handlesFunc,
+			Logger:    config.Logger,
+			Resources: resources,
+		}
+
+		deleterResourceSet, err = controller.NewResourceSet(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	return deleterResourceSet, nil
+}

--- a/service/controller/v14patch1/drainer_resource_set.go
+++ b/service/controller/v14patch1/drainer_resource_set.go
@@ -1,0 +1,120 @@
+package v14
+
+import (
+	"github.com/giantswarm/apiextensions/pkg/clientset/versioned"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/giantswarm/operatorkit/controller"
+	"github.com/giantswarm/operatorkit/controller/resource/metricsresource"
+	"github.com/giantswarm/operatorkit/controller/resource/retryresource"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/giantswarm/kvm-operator/service/controller/v14/key"
+	"github.com/giantswarm/kvm-operator/service/controller/v14/resource/endpoint"
+	"github.com/giantswarm/kvm-operator/service/controller/v14/resource/pod"
+)
+
+type DrainerResourceSetConfig struct {
+	G8sClient versioned.Interface
+	K8sClient kubernetes.Interface
+	Logger    micrologger.Logger
+
+	ProjectName string
+}
+
+func NewDrainerResourceSet(config DrainerResourceSetConfig) (*controller.ResourceSet, error) {
+	var err error
+
+	handlesFunc := func(obj interface{}) bool {
+		p, err := key.ToPod(obj)
+		if err != nil {
+			return false
+		}
+		v, err := key.VersionBundleVersionFromPod(p)
+		if err != nil {
+			return false
+		}
+
+		if v == VersionBundle().Version {
+			return true
+		}
+
+		return false
+	}
+
+	var podResource controller.Resource
+	{
+		c := pod.Config{
+			G8sClient: config.G8sClient,
+			K8sClient: config.K8sClient,
+			Logger:    config.Logger,
+		}
+
+		podResource, err = pod.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	var endpointResource controller.Resource
+	{
+		c := endpoint.Config{
+			G8sClient: config.G8sClient,
+			K8sClient: config.K8sClient,
+			Logger:    config.Logger,
+		}
+
+		ops, err := endpoint.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+
+		endpointResource, err = toCRUDResource(config.Logger, ops)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	resources := []controller.Resource{
+		endpointResource,
+		podResource,
+	}
+
+	{
+		c := retryresource.WrapConfig{
+			Logger: config.Logger,
+		}
+
+		resources, err = retryresource.Wrap(resources, c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	{
+		c := metricsresource.WrapConfig{
+			Name: config.ProjectName,
+		}
+
+		resources, err = metricsresource.Wrap(resources, c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	var drainerResourceSet *controller.ResourceSet
+	{
+		c := controller.ResourceSetConfig{
+			Handles:   handlesFunc,
+			Logger:    config.Logger,
+			Resources: resources,
+		}
+
+		drainerResourceSet, err = controller.NewResourceSet(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	return drainerResourceSet, nil
+}

--- a/service/controller/v14patch1/error.go
+++ b/service/controller/v14patch1/error.go
@@ -1,0 +1,12 @@
+package v14
+
+import "github.com/giantswarm/microerror"
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}

--- a/service/controller/v14patch1/key/error.go
+++ b/service/controller/v14patch1/key/error.go
@@ -1,0 +1,20 @@
+package key
+
+import "github.com/giantswarm/microerror"
+
+var missingAnnotationError = &microerror.Error{
+	Kind: "missingAnnotationError",
+}
+
+func IsMissingAnnotationError(err error) bool {
+	return microerror.Cause(err) == missingAnnotationError
+}
+
+var wrongTypeError = &microerror.Error{
+	Kind: "wrongTypeError",
+}
+
+// IsWrongTypeError asserts wrongTypeError.
+func IsWrongTypeError(err error) bool {
+	return microerror.Cause(err) == wrongTypeError
+}

--- a/service/controller/v14patch1/key/key.go
+++ b/service/controller/v14patch1/key/key.go
@@ -1,0 +1,377 @@
+package key
+
+import (
+	"fmt"
+	"net"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/microerror"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+const (
+	MasterID = "master"
+	WorkerID = "worker"
+	EtcdPort = 443
+	// portBase is a baseline for computing the port for liveness probes.
+	portBase = 23000
+	// HealthEndpoint is http path for liveness probe.
+	HealthEndpoint = "/healthz"
+	// ProbeHost host for liveness probe.
+	ProbeHost = "127.0.0.1"
+	// InitialDelaySeconds is InitialDelaySeconds param in liveness probe config
+	InitialDelaySeconds = 60
+	// TimeoutSeconds is TimeoutSeconds param in liveness probe config
+	TimeoutSeconds = 3
+	// PeriodSeconds is PeriodSeconds param in liveness probe config
+	PeriodSeconds = 20
+	// FailureThreshold is FailureThreshold param in liveness probe config
+	FailureThreshold = 4
+	// SuccessThreshold is SuccessThreshold param in liveness probe config
+	SuccessThreshold = 1
+
+	FlannelEnvPathPrefix = "/run/flannel"
+	CoreosImageDir       = "/var/lib/coreos-kvm-images"
+	CoreosVersion        = "1688.5.3"
+
+	K8SEndpointUpdaterDocker = "quay.io/giantswarm/k8s-endpoint-updater:df982fc73b71e60fc70a7444c068b52441ddb30e"
+	K8SKVMDockerImage        = "quay.io/giantswarm/k8s-kvm:d808ee530c434ee1d084b1e2000f184caf5cd283"
+	K8SKVMHealthDocker       = "quay.io/giantswarm/k8s-kvm-health:ddf211dfed52086ade32ab8c45e44eb0273319ef"
+
+	// constants for calculation qemu memory overhead.
+	baseMasterMemoryOverhead     = "1G"
+	baseWorkerMemoryOverheadMB   = 512
+	baseWorkerOverheadMultiplier = 2
+	baseWorkerOverheadModulator  = 12
+	workerIOOverhead             = "512M"
+)
+
+const (
+	AnnotationAPIEndpoint       = "kvm-operator.giantswarm.io/api-endpoint"
+	AnnotationEtcdDomain        = "giantswarm.io/etcd-domain"
+	AnnotationIp                = "endpoint.kvm.giantswarm.io/ip"
+	AnnotationService           = "endpoint.kvm.giantswarm.io/service"
+	AnnotationPodDrained        = "endpoint.kvm.giantswarm.io/drained"
+	AnnotationPrometheusCluster = "giantswarm.io/prometheus-cluster"
+	AnnotationVersionBundle     = "kvm-operator.giantswarm.io/version-bundle"
+
+	LabelApp           = "app"
+	LabelCluster       = "giantswarm.io/cluster"
+	LabelCustomer      = "customer"
+	LabelOrganization  = "giantswarm.io/organization"
+	LabelVersionBundle = "giantswarm.io/version-bundle"
+
+	LegacyLabelCluster = "cluster"
+)
+
+const (
+	VersionBundleVersionAnnotation = "giantswarm.io/version-bundle-version"
+)
+
+const (
+	PodWatcherLabel = "kvm-operator.giantswarm.io/pod-watcher"
+)
+
+const (
+	PodDeletionGracePeriod = 5 * time.Minute
+)
+
+func ClusterAPIEndpoint(customObject v1alpha1.KVMConfig) string {
+	return customObject.Spec.Cluster.Kubernetes.API.Domain
+}
+
+func ClusterAPIEndpointFromPod(pod *corev1.Pod) (string, error) {
+	apiEndpoint, ok := pod.GetAnnotations()[AnnotationAPIEndpoint]
+	if !ok {
+		return "", microerror.Maskf(missingAnnotationError, AnnotationAPIEndpoint)
+	}
+	if apiEndpoint == "" {
+		return "", microerror.Maskf(missingAnnotationError, AnnotationAPIEndpoint)
+	}
+
+	return apiEndpoint, nil
+}
+
+func ClusterCustomer(customObject v1alpha1.KVMConfig) string {
+	return customObject.Spec.Cluster.Customer.ID
+}
+
+func ClusterEtcdDomain(customObject v1alpha1.KVMConfig) string {
+	return fmt.Sprintf("%s:%d", customObject.Spec.Cluster.Etcd.Domain, EtcdPort)
+}
+
+func ClusterID(customObject v1alpha1.KVMConfig) string {
+	return customObject.Spec.Cluster.ID
+}
+
+func ClusterIDFromPod(pod *corev1.Pod) string {
+	l, ok := pod.Labels["cluster"]
+	if ok {
+		return l
+	}
+
+	return "n/a"
+}
+
+func ClusterNamespace(customObject v1alpha1.KVMConfig) string {
+	return ClusterID(customObject)
+}
+
+func ClusterRoleBindingName(customObject v1alpha1.KVMConfig) string {
+	return ClusterID(customObject)
+}
+
+func ClusterRoleBindingPSPName(customObject v1alpha1.KVMConfig) string {
+	return ClusterID(customObject) + "-psp"
+}
+
+func ConfigMapName(customObject v1alpha1.KVMConfig, node v1alpha1.ClusterNode, prefix string) string {
+	return fmt.Sprintf("%s-%s-%s", prefix, ClusterID(customObject), node.ID)
+}
+
+func CPUQuantity(n v1alpha1.KVMConfigSpecKVMNode) (resource.Quantity, error) {
+	cpu := strconv.Itoa(n.CPUs)
+	q, err := resource.ParseQuantity(cpu)
+	if err != nil {
+		return resource.Quantity{}, microerror.Mask(err)
+	}
+	return q, nil
+}
+
+func DeploymentName(prefix string, nodeID string) string {
+	return fmt.Sprintf("%s-%s", prefix, nodeID)
+}
+
+func EtcdPVCName(clusterID string, vmNumber string) string {
+	return fmt.Sprintf("%s-%s-%s", "pvc-master-etcd", clusterID, vmNumber)
+}
+
+func NetworkEnvFilePath(customObject v1alpha1.KVMConfig) string {
+	return fmt.Sprintf("%s/networks/%s.env", FlannelEnvPathPrefix, NetworkBridgeName(customObject))
+}
+
+func HealthListenAddress(customObject v1alpha1.KVMConfig) string {
+	return "http://" + ProbeHost + ":" + strconv.Itoa(int(LivenessPort(customObject)))
+}
+
+func IsDeleted(customObject v1alpha1.KVMConfig) bool {
+	return customObject.GetDeletionTimestamp() != nil
+}
+
+// IsPodDraind checks whether the pod status indicates it got drained. The pod
+// status is partially reflected by its annotations. Here we check for the
+// annotation that tells us if the pod was already drained or not. In case the
+// pod does not have any annotations an unrecoverable error is returned. Such
+// situations should actually never happen. If it happens, something really bad
+// is going on. This is nothing we can just sort right away in our code.
+//
+// TODO(xh3b4sd) handle pod status via the runtime object status primitives
+// and not via annotations.
+func IsPodDraind(pod *corev1.Pod) (bool, error) {
+	a := pod.GetAnnotations()
+	if a == nil {
+		return false, microerror.Mask(missingAnnotationError)
+	}
+	v, ok := a[AnnotationPodDrained]
+	if !ok {
+		return false, microerror.Mask(missingAnnotationError)
+	}
+	b, err := strconv.ParseBool(v)
+	if err != nil {
+		return false, microerror.Mask(err)
+	}
+
+	return b, nil
+}
+
+func LivenessPort(customObject v1alpha1.KVMConfig) int32 {
+	return int32(portBase + customObject.Spec.KVM.Network.Flannel.VNI)
+}
+
+func MasterHostPathVolumeDir(clusterID string, vmNumber string) string {
+	return filepath.Join("/home/core/volumes", clusterID, "k8s-master-vm"+vmNumber)
+}
+
+// MemoryQuantity returns a resource.Quantity that represents the memory to be used by the nodes.
+// It adds the memory from the node definition parameter to the additional memory calculated on the node role
+func MemoryQuantityMaster(n v1alpha1.KVMConfigSpecKVMNode) (resource.Quantity, error) {
+	q, err := resource.ParseQuantity(n.Memory)
+	if err != nil {
+		return resource.Quantity{}, microerror.Maskf(err, "creating Memory quantity from node definition")
+	}
+	additionalMemory := resource.MustParse(baseMasterMemoryOverhead)
+	if err != nil {
+		return resource.Quantity{}, microerror.Maskf(err, "creating Memory quantity from addtional memory")
+	}
+	q.Add(additionalMemory)
+
+	return q, nil
+}
+
+// MemoryQuantity returns a resource.Quantity that represents the memory to be used by the nodes.
+// It adds the memory from the node definition parameter to the additional memory calculated on the node role
+func MemoryQuantityWorker(n v1alpha1.KVMConfigSpecKVMNode) (resource.Quantity, error) {
+	mQuantity, err := resource.ParseQuantity(n.Memory)
+	if err != nil {
+		return resource.Quantity{}, microerror.Maskf(err, "calculating memory overhead multiplier")
+	}
+
+	// base worker memory calculated in MB
+	q, err := resource.ParseQuantity(fmt.Sprintf("%dM", mQuantity.ScaledValue(resource.Giga)*1024))
+	if err != nil {
+		return resource.Quantity{}, microerror.Maskf(err, "creating Memory quantity from node definition")
+	}
+	// IO overhead for qemu is around 512M memory
+	ioOverhead := resource.MustParse(workerIOOverhead)
+	q.Add(ioOverhead)
+
+	// memory overhead is more complex as it increases with the size of the memory
+	// basic calculation is (2 + (memory / 12))*512M
+	// examples:
+	// Memory under 15G >> overhead 1024M
+	// memory between 15 - 30G >> overhead 1536M
+	// memory between 30 - 45G >> overhead 2048M
+	overheadMultiplier := int(baseWorkerOverheadMultiplier + mQuantity.ScaledValue(resource.Giga)/baseWorkerOverheadModulator)
+	workerMemoryOverhead := strconv.Itoa(baseWorkerMemoryOverheadMB*overheadMultiplier) + "M"
+
+	memOverhead, err := resource.ParseQuantity(workerMemoryOverhead)
+	if err != nil {
+		return resource.Quantity{}, microerror.Maskf(err, "creating Memory quantity from memory overhead")
+	}
+	q.Add(memOverhead)
+
+	return q, nil
+}
+
+func NetworkBridgeName(customObject v1alpha1.KVMConfig) string {
+	return fmt.Sprintf("br-%s", ClusterID(customObject))
+}
+
+func NetworkTapName(customObject v1alpha1.KVMConfig) string {
+	return fmt.Sprintf("tap-%s", ClusterID(customObject))
+}
+
+func NetworkDNSBlock(servers []net.IP) string {
+	var dnsBlockParts []string
+
+	for _, s := range servers {
+		dnsBlockParts = append(dnsBlockParts, fmt.Sprintf("DNS=%s", s.String()))
+	}
+
+	dnsBlock := strings.Join(dnsBlockParts, "\n")
+
+	return dnsBlock
+}
+
+func NetworkNTPBlock(servers []net.IP) string {
+	var ntpBlockParts []string
+
+	for _, s := range servers {
+		ntpBlockParts = append(ntpBlockParts, fmt.Sprintf("NTP=%s", s.String()))
+	}
+
+	ntpBlock := strings.Join(ntpBlockParts, "\n")
+
+	return ntpBlock
+}
+
+func PortMappings(customObject v1alpha1.KVMConfig) []corev1.ServicePort {
+	var ports []corev1.ServicePort
+
+	// Compatibility mode, if no port mappings specified.
+	if len(customObject.Spec.KVM.PortMappings) == 0 {
+		ports := []corev1.ServicePort{
+			{
+				Name:       "http",
+				Port:       int32(30010),
+				TargetPort: intstr.FromInt(30010),
+			},
+			{
+				Name:       "https",
+				Port:       int32(30011),
+				TargetPort: intstr.FromInt(30011),
+			},
+		}
+		return ports
+	}
+
+	for _, p := range customObject.Spec.KVM.PortMappings {
+		port := corev1.ServicePort{
+			Name:       p.Name,
+			NodePort:   int32(p.NodePort),
+			Port:       int32(p.TargetPort),
+			TargetPort: intstr.FromInt(p.TargetPort),
+		}
+		ports = append(ports, port)
+	}
+
+	return ports
+}
+
+func PVCNames(customObject v1alpha1.KVMConfig) []string {
+	var names []string
+
+	for i := range customObject.Spec.Cluster.Masters {
+		names = append(names, EtcdPVCName(ClusterID(customObject), VMNumber(i)))
+	}
+
+	return names
+}
+
+func ServiceAccountName(customObject v1alpha1.KVMConfig) string {
+	return ClusterID(customObject)
+}
+
+func StorageType(customObject v1alpha1.KVMConfig) string {
+	return customObject.Spec.KVM.K8sKVM.StorageType
+}
+
+func ToCustomObject(v interface{}) (v1alpha1.KVMConfig, error) {
+	customObjectPointer, ok := v.(*v1alpha1.KVMConfig)
+	if !ok {
+		return v1alpha1.KVMConfig{}, microerror.Maskf(wrongTypeError, "expected '%T', got '%T'", &v1alpha1.KVMConfig{}, v)
+	}
+	customObject := *customObjectPointer
+
+	return customObject, nil
+}
+
+func ToPod(v interface{}) (*corev1.Pod, error) {
+	if v == nil {
+		return nil, nil
+	}
+
+	pod, ok := v.(*corev1.Pod)
+	if !ok {
+		return nil, microerror.Maskf(wrongTypeError, "expected '%T', got '%T'", &corev1.Pod{}, v)
+	}
+
+	return pod, nil
+}
+
+func VersionBundleVersion(customObject v1alpha1.KVMConfig) string {
+	return customObject.Spec.VersionBundle.Version
+}
+
+func VersionBundleVersionFromPod(pod *corev1.Pod) (string, error) {
+	a := pod.GetAnnotations()
+	if a == nil {
+		return "", microerror.Mask(missingAnnotationError)
+	}
+	v, ok := a[AnnotationVersionBundle]
+	if !ok {
+		return "", microerror.Mask(missingAnnotationError)
+	}
+
+	return v, nil
+}
+
+func VMNumber(ID int) string {
+	return fmt.Sprintf("%d", ID)
+}

--- a/service/controller/v14patch1/key/key_test.go
+++ b/service/controller/v14patch1/key/key_test.go
@@ -1,0 +1,137 @@
+package key
+
+import (
+	"net"
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+func Test_ClusterID(t *testing.T) {
+	expectedID := "test-cluster"
+
+	customObject := v1alpha1.KVMConfig{
+		Spec: v1alpha1.KVMConfigSpec{
+			Cluster: v1alpha1.Cluster{
+				ID: expectedID,
+				Customer: v1alpha1.ClusterCustomer{
+					ID: "test-customer",
+				},
+			},
+		},
+	}
+
+	if ClusterID(customObject) != expectedID {
+		t.Fatalf("Expected cluster ID %s but was %s", expectedID, ClusterID(customObject))
+	}
+}
+
+func Test_ClusterCustomer(t *testing.T) {
+	expectedID := "test-customer"
+
+	customObject := v1alpha1.KVMConfig{
+		Spec: v1alpha1.KVMConfigSpec{
+			Cluster: v1alpha1.Cluster{
+				ID: expectedID,
+				Customer: v1alpha1.ClusterCustomer{
+					ID: "test-customer",
+				},
+			},
+		},
+	}
+
+	if ClusterCustomer(customObject) != expectedID {
+		t.Fatalf("Expected customer ID %s but was %s", expectedID, ClusterCustomer(customObject))
+	}
+}
+
+func Test_NetworkDNSBlock(t *testing.T) {
+	dnsServers := NetworkDNSBlock([]net.IP{
+		net.ParseIP("8.8.8.8"),
+		net.ParseIP("8.8.4.4"),
+	})
+
+	expected := `DNS=8.8.8.8
+DNS=8.8.4.4`
+
+	if dnsServers != expected {
+		t.Fatal("expected", expected, "got", dnsServers)
+	}
+}
+
+func Test_PortMappings(t *testing.T) {
+	customObject := v1alpha1.KVMConfig{
+		Spec: v1alpha1.KVMConfigSpec{
+			KVM: v1alpha1.KVMConfigSpecKVM{
+				PortMappings: []v1alpha1.KVMConfigSpecKVMPortMappings{
+					{
+						Name:       "ingress-http",
+						NodePort:   31010,
+						TargetPort: 30010,
+					},
+					{
+						Name:       "ingress-https",
+						NodePort:   31011,
+						TargetPort: 30011,
+					},
+				},
+			},
+		},
+	}
+
+	expected := []corev1.ServicePort{
+		{
+			Name:       "ingress-http",
+			NodePort:   int32(31010),
+			Port:       int32(30010),
+			TargetPort: intstr.FromInt(30010),
+		},
+		{
+			Name:       "ingress-https",
+			NodePort:   int32(31011),
+			Port:       int32(30011),
+			TargetPort: intstr.FromInt(30011),
+		},
+	}
+
+	actual := PortMappings(customObject)
+
+	for i := range actual {
+		if actual[i] != expected[i] {
+			t.Fatalf("Expected port mapping %+v but was %+v", expected[i], actual[i])
+		}
+	}
+}
+
+func Test_PortMappings_CompatibilityMode(t *testing.T) {
+	customObject := v1alpha1.KVMConfig{
+		Spec: v1alpha1.KVMConfigSpec{
+			KVM: v1alpha1.KVMConfigSpecKVM{
+				PortMappings: []v1alpha1.KVMConfigSpecKVMPortMappings{},
+			},
+		},
+	}
+
+	expected := []corev1.ServicePort{
+		{
+			Name:       "http",
+			Port:       int32(30010),
+			TargetPort: intstr.FromInt(30010),
+		},
+		{
+			Name:       "https",
+			Port:       int32(30011),
+			TargetPort: intstr.FromInt(30011),
+		},
+	}
+
+	actual := PortMappings(customObject)
+
+	for i := range actual {
+		if actual[i] != expected[i] {
+			t.Fatalf("Expected port mapping %+v but was %+v", expected[i], actual[i])
+		}
+	}
+}

--- a/service/controller/v14patch1/resource/clusterrolebinding/create.go
+++ b/service/controller/v14patch1/resource/clusterrolebinding/create.go
@@ -1,0 +1,61 @@
+package clusterrolebinding
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/giantswarm/microerror"
+	apiv1 "k8s.io/api/rbac/v1beta1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+)
+
+func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange interface{}) error {
+	clusterRoleBindingsToCreate, err := toClusterRoleBindings(createChange)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	// Create the cluster role bindings in the Kubernetes API.
+	if len(clusterRoleBindingsToCreate) != 0 {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "creating the cluster role bindings in the Kubernetes API")
+
+		for _, clusterRoleBinding := range clusterRoleBindingsToCreate {
+			_, err := r.k8sClient.RbacV1beta1().ClusterRoleBindings().Create(clusterRoleBinding)
+			if apierrors.IsAlreadyExists(err) {
+			} else if err != nil {
+				return microerror.Mask(err)
+			}
+		}
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", "created the cluster role bindings in the Kubernetes API")
+	} else {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "the cluster role bindings do not need to be created in the Kubernetes API")
+	}
+
+	return nil
+}
+
+func (r *Resource) newCreateChange(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, error) {
+	currentClusterRoleBindings, err := toClusterRoleBindings(currentState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+	desiredClusterRoleBindings, err := toClusterRoleBindings(desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", "finding out which cluster role bindings have to be created")
+
+	var clusterRoleBindingsToCreate []*apiv1.ClusterRoleBinding
+
+	for _, desiredClusterRoleBinding := range desiredClusterRoleBindings {
+		if !containsClusterRoleBinding(currentClusterRoleBindings, desiredClusterRoleBinding) {
+			clusterRoleBindingsToCreate = append(clusterRoleBindingsToCreate, desiredClusterRoleBinding)
+		}
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("found %d cluster role bindings that have to be created", len(clusterRoleBindingsToCreate)))
+
+	return clusterRoleBindingsToCreate, nil
+}

--- a/service/controller/v14patch1/resource/clusterrolebinding/create_test.go
+++ b/service/controller/v14patch1/resource/clusterrolebinding/create_test.go
@@ -1,0 +1,244 @@
+package clusterrolebinding
+
+import (
+	"context"
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/micrologger/microloggertest"
+	apiv1 "k8s.io/api/rbac/v1beta1"
+	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func Test_Resource_ClusterRoleBinding_newCreateChange(t *testing.T) {
+	testCases := []struct {
+		Obj                              interface{}
+		CurrentState                     interface{}
+		DesiredState                     interface{}
+		ExpectedClusterRoleBindingsNames []string
+	}{
+		// Test 1, in case current state and desired state are empty the create
+		// state should be empty.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState:                     []*apiv1.ClusterRoleBinding{},
+			DesiredState:                     []*apiv1.ClusterRoleBinding{},
+			ExpectedClusterRoleBindingsNames: []string{},
+		},
+
+		// Test 2, in case current state equals desired state the create state
+		// should be empty.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState: []*apiv1.ClusterRoleBinding{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "cluster-role-binding-1",
+					},
+				},
+			},
+			DesiredState: []*apiv1.ClusterRoleBinding{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "cluster-role-binding-1",
+					},
+				},
+			},
+			ExpectedClusterRoleBindingsNames: []string{},
+		},
+
+		// Test 3, in case current state misses one item of desired state the create
+		// state should contain the missing item of the desired state.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState: []*apiv1.ClusterRoleBinding{},
+			DesiredState: []*apiv1.ClusterRoleBinding{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "cluster-role-binding-1",
+					},
+				},
+			},
+			ExpectedClusterRoleBindingsNames: []string{
+				"cluster-role-binding-1",
+			},
+		},
+
+		// Test 4, in case current state misses items of desired state the create
+		// state should contain the missing items of the desired state.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState: []*apiv1.ClusterRoleBinding{},
+			DesiredState: []*apiv1.ClusterRoleBinding{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "cluster-role-binding-1",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "cluster-role-binding-2",
+					},
+				},
+			},
+			ExpectedClusterRoleBindingsNames: []string{
+				"cluster-role-binding-1",
+				"cluster-role-binding-2",
+			},
+		},
+
+		// Test 5, in case current state contains one item not being in desired
+		// state the create state should not contain the missing item of the desired
+		// state.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState: []*apiv1.ClusterRoleBinding{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "cluster-role-binding-1",
+					},
+				},
+			},
+			DesiredState:                     []*apiv1.ClusterRoleBinding{},
+			ExpectedClusterRoleBindingsNames: []string{},
+		},
+
+		// Test 6, in case current state contains items not being in desired state
+		// the create state should not contain the missing items of the desired
+		// state.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState: []*apiv1.ClusterRoleBinding{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "cluster-role-binding-1",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "cluster-role-binding-2",
+					},
+				},
+			},
+			DesiredState:                     []*apiv1.ClusterRoleBinding{},
+			ExpectedClusterRoleBindingsNames: []string{},
+		},
+
+		// Test 7, in case current state contains some items of desired state the
+		// create state should contain the items being in desired state which are
+		// not in create state.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState: []*apiv1.ClusterRoleBinding{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "cluster-role-binding-1",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "cluster-role-binding-2",
+					},
+				},
+			},
+			DesiredState: []*apiv1.ClusterRoleBinding{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "cluster-role-binding-1",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "cluster-role-binding-2",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "cluster-role-binding-3",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "cluster-role-binding-4",
+					},
+				},
+			},
+			ExpectedClusterRoleBindingsNames: []string{
+				"cluster-role-binding-3",
+				"cluster-role-binding-4",
+			},
+		},
+	}
+
+	var err error
+	var newResource *Resource
+	{
+		resourceConfig := Config{
+			K8sClient: fake.NewSimpleClientset(),
+			Logger:    microloggertest.New(),
+		}
+		newResource, err = New(resourceConfig)
+		if err != nil {
+			t.Fatal("expected", nil, "got", err)
+		}
+	}
+
+	for i, tc := range testCases {
+		result, err := newResource.newCreateChange(context.TODO(), tc.Obj, tc.CurrentState, tc.DesiredState)
+		if err != nil {
+			t.Fatalf("case %d expected %#v got %#v", i+1, nil, err)
+		}
+
+		clusterRoleBindings, ok := result.([]*apiv1.ClusterRoleBinding)
+		if !ok {
+			t.Fatalf("case %d expected %T got %T", i+1, []*apiv1.ClusterRoleBinding{}, result)
+		}
+
+		if len(clusterRoleBindings) != len(tc.ExpectedClusterRoleBindingsNames) {
+			t.Fatalf("case %d expected %d cluster role bindings got %d", i+1, len(tc.ExpectedClusterRoleBindingsNames), len(clusterRoleBindings))
+		}
+	}
+}

--- a/service/controller/v14patch1/resource/clusterrolebinding/current.go
+++ b/service/controller/v14patch1/resource/clusterrolebinding/current.go
@@ -1,0 +1,52 @@
+package clusterrolebinding
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/giantswarm/microerror"
+	apiv1 "k8s.io/api/rbac/v1beta1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/giantswarm/kvm-operator/service/controller/v14/key"
+)
+
+func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interface{}, error) {
+	customObject, err := key.ToCustomObject(obj)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+	r.logger.LogCtx(ctx, "level", "debug", "message", "looking for a list of cluster role bindings in the Kubernetes API")
+
+	var currentClusterRoleBinding []*apiv1.ClusterRoleBinding
+	{
+		clusterRoleBinding, err := r.k8sClient.RbacV1beta1().ClusterRoleBindings().Get(key.ClusterRoleBindingName(customObject), apismetav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			r.logger.LogCtx(ctx, "level", "debug", "message", "did not find cluster role binding in the Kubernetes API")
+			// fall through
+		} else if err != nil {
+			return nil, microerror.Mask(err)
+		} else {
+			r.logger.LogCtx(ctx, "level", "debug", "message", "found a list of cluster role binding in the Kubernetes API")
+
+			currentClusterRoleBinding = append(currentClusterRoleBinding, clusterRoleBinding)
+		}
+
+		clusterRoleBindingPSP, err := r.k8sClient.RbacV1beta1().ClusterRoleBindings().Get(key.ClusterRoleBindingPSPName(customObject), apismetav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			r.logger.LogCtx(ctx, "level", "debug", "message", "did not find cluster role binding psp in the Kubernetes API")
+			// fall through
+		} else if err != nil {
+			return nil, microerror.Mask(err)
+		} else {
+			r.logger.LogCtx(ctx, "level", "debug", "message", "found a list of cluster role binding psp in the Kubernetes API")
+
+			currentClusterRoleBinding = append(currentClusterRoleBinding, clusterRoleBindingPSP)
+		}
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("found a list of %d cluster role bindings in the Kubernetes API", len(currentClusterRoleBinding)))
+
+	return currentClusterRoleBinding, nil
+}

--- a/service/controller/v14patch1/resource/clusterrolebinding/delete.go
+++ b/service/controller/v14patch1/resource/clusterrolebinding/delete.go
@@ -1,0 +1,75 @@
+package clusterrolebinding
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/operatorkit/controller"
+	apiv1 "k8s.io/api/rbac/v1beta1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func (r *Resource) ApplyDeleteChange(ctx context.Context, obj, deleteChange interface{}) error {
+	clusterRoleBindingsToDelete, err := toClusterRoleBindings(deleteChange)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	if len(clusterRoleBindingsToDelete) != 0 {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "deleting the cluster role bindings in the Kubernetes API")
+
+		// Delete the cluster role bindings in the Kubernetes API.
+		for _, clusterRoleBinding := range clusterRoleBindingsToDelete {
+			err := r.k8sClient.RbacV1beta1().ClusterRoleBindings().Delete(clusterRoleBinding.Name, &apismetav1.DeleteOptions{})
+			if apierrors.IsNotFound(err) {
+			} else if err != nil {
+				return microerror.Mask(err)
+			}
+		}
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", "deleted the cluster role bindings in the Kubernetes API")
+	} else {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "the cluster role bindings do not need to be deleted from the Kubernetes API")
+	}
+
+	return nil
+}
+
+func (r *Resource) NewDeletePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*controller.Patch, error) {
+	delete, err := r.newDeleteChangeForDeletePatch(ctx, obj, currentState, desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	patch := controller.NewPatch()
+	patch.SetDeleteChange(delete)
+
+	return patch, nil
+}
+
+func (r *Resource) newDeleteChangeForDeletePatch(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, error) {
+	currentClusterRoleBindings, err := toClusterRoleBindings(currentState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+	desiredClusterRoleBindings, err := toClusterRoleBindings(desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", "finding out which cluster role bindings have to be deleted")
+
+	var clusterRoleBindingsToDelete []*apiv1.ClusterRoleBinding
+
+	for _, currentClusterRoleBinding := range currentClusterRoleBindings {
+		if containsClusterRoleBinding(desiredClusterRoleBindings, currentClusterRoleBinding) {
+			clusterRoleBindingsToDelete = append(clusterRoleBindingsToDelete, currentClusterRoleBinding)
+		}
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("found %d cluster role bindings that have to be deleted", len(clusterRoleBindingsToDelete)))
+
+	return clusterRoleBindingsToDelete, nil
+}

--- a/service/controller/v14patch1/resource/clusterrolebinding/delete_test.go
+++ b/service/controller/v14patch1/resource/clusterrolebinding/delete_test.go
@@ -1,0 +1,291 @@
+package clusterrolebinding
+
+import (
+	"context"
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/micrologger/microloggertest"
+	apiv1 "k8s.io/api/rbac/v1beta1"
+	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func Test_Resource_ClusterRoleBinding_newDeleteChange(t *testing.T) {
+	testCases := []struct {
+		Obj                             interface{}
+		CurrentState                    interface{}
+		DesiredState                    interface{}
+		ExpectedClusterRoleBindingNames []string
+	}{
+		// Test 1, in case current state and desired state are empty the delete
+		// state should be empty.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState:                    []*apiv1.ClusterRoleBinding{},
+			DesiredState:                    []*apiv1.ClusterRoleBinding{},
+			ExpectedClusterRoleBindingNames: []string{},
+		},
+
+		// Test 2, in case current state has one item and equals desired state the
+		// delete state should equal the current state.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState: []*apiv1.ClusterRoleBinding{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "cluster-role-binding-1",
+					},
+				},
+			},
+			DesiredState: []*apiv1.ClusterRoleBinding{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "cluster-role-binding-1",
+					},
+				},
+			},
+			ExpectedClusterRoleBindingNames: []string{
+				"cluster-role-binding-1",
+			},
+		},
+
+		// Test 3, in case current state misses one item of desired state the delete
+		// state should not contain the missing item of the desired state.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState: []*apiv1.ClusterRoleBinding{},
+			DesiredState: []*apiv1.ClusterRoleBinding{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "cluster-role-binding-1",
+					},
+				},
+			},
+			ExpectedClusterRoleBindingNames: []string{},
+		},
+
+		// Test 4, in case current state misses items of desired state the delete
+		// state should not contain the missing items of the desired state.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState: []*apiv1.ClusterRoleBinding{},
+			DesiredState: []*apiv1.ClusterRoleBinding{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "cluster-role-binding-1",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "cluster-role-binding-2",
+					},
+				},
+			},
+			ExpectedClusterRoleBindingNames: []string{},
+		},
+
+		// Test 5, in case current state contains one item and desired state is
+		// empty the delete state should be empty.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState: []*apiv1.ClusterRoleBinding{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "cluster-role-binding-1",
+					},
+				},
+			},
+			DesiredState:                    []*apiv1.ClusterRoleBinding{},
+			ExpectedClusterRoleBindingNames: []string{},
+		},
+
+		// Test 6, in case current state contains items and desired state is empty
+		// the delete state should be empty.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState: []*apiv1.ClusterRoleBinding{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "cluster-role-binding-1",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "cluster-role-binding-2",
+					},
+				},
+			},
+			DesiredState:                    []*apiv1.ClusterRoleBinding{},
+			ExpectedClusterRoleBindingNames: []string{},
+		},
+
+		// Test 7, in case all items of current state are in desired state and
+		// desired state contains more items not being in current state the create
+		// state should contain all items being in current state.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState: []*apiv1.ClusterRoleBinding{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "cluster-role-binding-1",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "cluster-role-binding-2",
+					},
+				},
+			},
+			DesiredState: []*apiv1.ClusterRoleBinding{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "cluster-role-binding-1",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "cluster-role-binding-2",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "cluster-role-binding-3",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "cluster-role-binding-4",
+					},
+				},
+			},
+			ExpectedClusterRoleBindingNames: []string{
+				"cluster-role-binding-1",
+				"cluster-role-binding-2",
+			},
+		},
+
+		// Test 8, in case all items of desired state are in current state and
+		// current state contains more items not being in desired state the create
+		// state should contain all items being in desired state.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState: []*apiv1.ClusterRoleBinding{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "cluster-role-binding-1",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "cluster-role-binding-2",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "cluster-role-binding-3",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "cluster-role-binding-4",
+					},
+				},
+			},
+			DesiredState: []*apiv1.ClusterRoleBinding{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "cluster-role-binding-1",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "cluster-role-binding-2",
+					},
+				},
+			},
+			ExpectedClusterRoleBindingNames: []string{
+				"cluster-role-binding-1",
+				"cluster-role-binding-2",
+			},
+		},
+	}
+
+	var err error
+	var newResource *Resource
+	{
+		resourceConfig := Config{
+			K8sClient: fake.NewSimpleClientset(),
+			Logger:    microloggertest.New(),
+		}
+
+		newResource, err = New(resourceConfig)
+		if err != nil {
+			t.Fatal("expected", nil, "got", err)
+		}
+	}
+
+	for i, tc := range testCases {
+		result, err := newResource.newDeleteChangeForDeletePatch(context.TODO(), tc.Obj, tc.CurrentState, tc.DesiredState)
+		if err != nil {
+			t.Fatalf("case %d expected %#v got %#v", i+1, nil, err)
+		}
+
+		clusterRoleBindings, ok := result.([]*apiv1.ClusterRoleBinding)
+		if !ok {
+			t.Fatalf("case %d expected %T got %T", i+1, []*apiv1.ClusterRoleBinding{}, result)
+		}
+
+		if len(clusterRoleBindings) != len(tc.ExpectedClusterRoleBindingNames) {
+			t.Fatalf("case %d expected %d cluster role bindings got %d", i+1, len(tc.ExpectedClusterRoleBindingNames), len(clusterRoleBindings))
+		}
+	}
+}

--- a/service/controller/v14patch1/resource/clusterrolebinding/desired.go
+++ b/service/controller/v14patch1/resource/clusterrolebinding/desired.go
@@ -1,0 +1,95 @@
+package clusterrolebinding
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/microerror"
+	apiv1 "k8s.io/api/rbac/v1beta1"
+	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/giantswarm/kvm-operator/service/controller/v14/key"
+)
+
+func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interface{}, error) {
+	customObject, err := key.ToCustomObject(obj)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", "computing the new cluster role bindings")
+
+	clusterRoleBindings, err := r.newClusterRoleBindings(customObject)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("computed the %d new cluster role bindings", len(clusterRoleBindings)))
+
+	return clusterRoleBindings, nil
+}
+
+func (r *Resource) newClusterRoleBindings(customObject v1alpha1.KVMConfig) ([]*apiv1.ClusterRoleBinding, error) {
+	var clusterRoleBindings []*apiv1.ClusterRoleBinding
+
+	generalClusterRoleBinding := &apiv1.ClusterRoleBinding{
+		TypeMeta: apismetav1.TypeMeta{
+			Kind:       "ClusterRoleBinding",
+			APIVersion: apiv1.GroupName,
+		},
+		ObjectMeta: apismetav1.ObjectMeta{
+			Name: key.ClusterRoleBindingName(customObject),
+			Labels: map[string]string{
+				"app": "kvm-operator",
+				"giantswarm.io/cluster-id":  key.ClusterID(customObject),
+				"giantswarm.io/customer-id": key.ClusterCustomer(customObject),
+			},
+		},
+		Subjects: []apiv1.Subject{
+			{
+				Kind:      apiv1.ServiceAccountKind,
+				Namespace: key.ClusterID(customObject),
+				Name:      key.ClusterID(customObject),
+			},
+		},
+		RoleRef: apiv1.RoleRef{
+			APIGroup: apiv1.GroupName,
+			Kind:     "ClusterRole",
+			Name:     "kvm-operator",
+		},
+	}
+
+	clusterRoleBindings = append(clusterRoleBindings, generalClusterRoleBinding)
+
+	pspClusterRoleBinding := &apiv1.ClusterRoleBinding{
+		TypeMeta: apismetav1.TypeMeta{
+			Kind:       "ClusterRoleBinding",
+			APIVersion: apiv1.GroupName,
+		},
+		ObjectMeta: apismetav1.ObjectMeta{
+			Name: key.ClusterRoleBindingPSPName(customObject),
+			Labels: map[string]string{
+				"app": "kvm-operator",
+				"giantswarm.io/cluster-id":  key.ClusterID(customObject),
+				"giantswarm.io/customer-id": key.ClusterCustomer(customObject),
+			},
+		},
+		Subjects: []apiv1.Subject{
+			{
+				Kind:      apiv1.ServiceAccountKind,
+				Namespace: key.ClusterID(customObject),
+				Name:      key.ClusterID(customObject),
+			},
+		},
+		RoleRef: apiv1.RoleRef{
+			APIGroup: apiv1.GroupName,
+			Kind:     "ClusterRole",
+			Name:     "kvm-operator-psp",
+		},
+	}
+
+	clusterRoleBindings = append(clusterRoleBindings, pspClusterRoleBinding)
+
+	return clusterRoleBindings, nil
+}

--- a/service/controller/v14patch1/resource/clusterrolebinding/desired_test.go
+++ b/service/controller/v14patch1/resource/clusterrolebinding/desired_test.go
@@ -1,0 +1,79 @@
+package clusterrolebinding
+
+import (
+	"context"
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/micrologger/microloggertest"
+	apiv1 "k8s.io/api/rbac/v1beta1"
+	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func Test_Resource_ClusterRoleBinding_GetDesiredState(t *testing.T) {
+	testCases := []struct {
+		Obj                         interface{}
+		ExpectedClusterRoleBindings []*apiv1.ClusterRoleBinding
+	}{
+		// Test 1, check it returns a couple of cluster role bindings
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			ExpectedClusterRoleBindings: []*apiv1.ClusterRoleBinding{
+				{
+					TypeMeta: apismetav1.TypeMeta{
+						Kind:       "ClusterRoleBinding",
+						APIVersion: apiv1.GroupName,
+					},
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "general-cluster-role-binding",
+					},
+				},
+				{
+					TypeMeta: apismetav1.TypeMeta{
+						Kind:       "ClusterRoleBinding",
+						APIVersion: apiv1.GroupName,
+					},
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "psp-cluster-role-binding",
+					},
+				},
+			},
+		},
+	}
+
+	var err error
+	var newResource *Resource
+	{
+		resourceConfig := Config{
+			K8sClient: fake.NewSimpleClientset(),
+			Logger:    microloggertest.New(),
+		}
+		newResource, err = New(resourceConfig)
+		if err != nil {
+			t.Fatal("expected", nil, "got", err)
+		}
+	}
+
+	for i, tc := range testCases {
+		result, err := newResource.GetDesiredState(context.TODO(), tc.Obj)
+		if err != nil {
+			t.Fatalf("case %d expected %#v got %#v", i+1, nil, err)
+		}
+
+		clusterRoleBindings, ok := result.([]*apiv1.ClusterRoleBinding)
+		if !ok {
+			t.Fatalf("case %d expected %T got %T", i+1, []*apiv1.ClusterRoleBinding{}, result)
+		}
+
+		if len(clusterRoleBindings) != len(tc.ExpectedClusterRoleBindings) {
+			t.Fatalf("case %d expected %d cluster role bindings got %d", i+1, len(tc.ExpectedClusterRoleBindings), len(clusterRoleBindings))
+		}
+	}
+}

--- a/service/controller/v14patch1/resource/clusterrolebinding/error.go
+++ b/service/controller/v14patch1/resource/clusterrolebinding/error.go
@@ -1,0 +1,30 @@
+package clusterrolebinding
+
+import "github.com/giantswarm/microerror"
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var notFoundError = &microerror.Error{
+	Kind: "notFoundError",
+}
+
+// IsNotFound asserts notFoundError.
+func IsNotFound(err error) bool {
+	return microerror.Cause(err) == notFoundError
+}
+
+var wrongTypeError = &microerror.Error{
+	Kind: "wrongTypeError",
+}
+
+// IsWrongTypeError asserts wrongTypeError.
+func IsWrongTypeError(err error) bool {
+	return microerror.Cause(err) == wrongTypeError
+}

--- a/service/controller/v14patch1/resource/clusterrolebinding/resource.go
+++ b/service/controller/v14patch1/resource/clusterrolebinding/resource.go
@@ -1,0 +1,86 @@
+package clusterrolebinding
+
+import (
+	"reflect"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	apiv1 "k8s.io/api/rbac/v1beta1"
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	// Name is the identifier of the resource.
+	Name = "clusterrolebindingv14"
+)
+
+// Config represents the configuration used to create a new config map resource.
+type Config struct {
+	K8sClient kubernetes.Interface
+	Logger    micrologger.Logger
+}
+
+// Resource implements the config map resource.
+type Resource struct {
+	k8sClient kubernetes.Interface
+	logger    micrologger.Logger
+}
+
+// New creates a new configured config map resource.
+func New(config Config) (*Resource, error) {
+	if config.K8sClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "config.K8sClient must not be empty")
+	}
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "config.Logger must not be empty")
+	}
+
+	newService := &Resource{
+		k8sClient: config.K8sClient,
+		logger:    config.Logger,
+	}
+
+	return newService, nil
+}
+
+func (r *Resource) Name() string {
+	return Name
+}
+
+func containsClusterRoleBinding(list []*apiv1.ClusterRoleBinding, item *apiv1.ClusterRoleBinding) bool {
+	_, err := getClusterRoleBindingByName(list, item.Name)
+	if IsNotFound(err) {
+		return false
+	} else if err != nil {
+		return false
+	}
+
+	return true
+}
+
+func getClusterRoleBindingByName(list []*apiv1.ClusterRoleBinding, name string) (*apiv1.ClusterRoleBinding, error) {
+	for _, l := range list {
+		if l.Name == name {
+			return l, nil
+		}
+	}
+
+	return nil, microerror.Maskf(notFoundError, "cluster role binding '%s' not found", name)
+}
+
+func isClusterRoleBindingModified(a, b *apiv1.ClusterRoleBinding) bool {
+	return !reflect.DeepEqual(a.Subjects, b.Subjects) || !reflect.DeepEqual(a.RoleRef, b.RoleRef)
+}
+
+func toClusterRoleBindings(v interface{}) ([]*apiv1.ClusterRoleBinding, error) {
+	if v == nil {
+		return nil, nil
+	}
+
+	clusterRoleBindings, ok := v.([]*apiv1.ClusterRoleBinding)
+	if !ok {
+		return nil, microerror.Maskf(wrongTypeError, "expected '%T', got '%T'", []*apiv1.ClusterRoleBinding{}, v)
+	}
+
+	return clusterRoleBindings, nil
+}

--- a/service/controller/v14patch1/resource/clusterrolebinding/update.go
+++ b/service/controller/v14patch1/resource/clusterrolebinding/update.go
@@ -1,0 +1,85 @@
+package clusterrolebinding
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/operatorkit/controller"
+	apiv1 "k8s.io/api/rbac/v1beta1"
+)
+
+func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateChange interface{}) error {
+	clusterRoleBindingsToUpdate, err := toClusterRoleBindings(updateChange)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	if len(clusterRoleBindingsToUpdate) != 0 {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "updating the cluster role bindings in the Kubernetes API")
+
+		// Create the cluster role bindings in the Kubernetes API.
+		for _, clusterRoleBinding := range clusterRoleBindingsToUpdate {
+			_, err := r.k8sClient.RbacV1beta1().ClusterRoleBindings().Update(clusterRoleBinding)
+			if err != nil {
+				return microerror.Mask(err)
+			}
+		}
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", "updated the cluster role bindings in the Kubernetes API")
+	} else {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "the cluster role bindings do not need to be updated in the Kubernetes API")
+	}
+
+	return nil
+}
+
+func (r *Resource) NewUpdatePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*controller.Patch, error) {
+	create, err := r.newCreateChange(ctx, obj, currentState, desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+	update, err := r.newUpdateChange(ctx, obj, currentState, desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	patch := controller.NewPatch()
+	patch.SetCreateChange(create)
+	patch.SetUpdateChange(update)
+
+	return patch, nil
+}
+
+func (r *Resource) newUpdateChange(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, error) {
+	currentClusterRoleBindings, err := toClusterRoleBindings(currentState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+	desiredClusterRoleBindings, err := toClusterRoleBindings(desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	var clusterRoleBindingsToUpdate []*apiv1.ClusterRoleBinding
+	{
+		r.logger.LogCtx(ctx, "level", "debug", "message", "finding out which cluster role bindings have to be updated")
+
+		for _, clusterRoleBinding := range currentClusterRoleBindings {
+			desiredClusterRoleBinding, err := getClusterRoleBindingByName(desiredClusterRoleBindings, clusterRoleBinding.Name)
+			if IsNotFound(err) {
+				continue
+			} else if err != nil {
+				return nil, microerror.Mask(err)
+			}
+
+			if isClusterRoleBindingModified(desiredClusterRoleBinding, clusterRoleBinding) {
+				clusterRoleBindingsToUpdate = append(clusterRoleBindingsToUpdate, desiredClusterRoleBinding)
+			}
+		}
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("found %d cluster role bindings that have to be updated", len(clusterRoleBindingsToUpdate)))
+	}
+
+	return clusterRoleBindingsToUpdate, nil
+}

--- a/service/controller/v14patch1/resource/clusterrolebinding/update_test.go
+++ b/service/controller/v14patch1/resource/clusterrolebinding/update_test.go
@@ -1,0 +1,207 @@
+package clusterrolebinding
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/micrologger/microloggertest"
+	apiv1 "k8s.io/api/rbac/v1beta1"
+	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func Test_Resource_ClusterRoleBinding_newUpdateChange(t *testing.T) {
+	testCases := []struct {
+		Ctx                                context.Context
+		Obj                                interface{}
+		CurrentState                       interface{}
+		DesiredState                       interface{}
+		ExpectedClusterRoleBindinsToUpdate []*apiv1.ClusterRoleBinding
+	}{
+		// Test 1, in case current state and desired state are empty the update
+		// state should be empty.
+		{
+			Ctx: context.TODO(),
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState:                       []*apiv1.ClusterRoleBinding{},
+			DesiredState:                       []*apiv1.ClusterRoleBinding{},
+			ExpectedClusterRoleBindinsToUpdate: nil,
+		},
+
+		// Test 2, in case current state and desired state are equal the update
+		// state should be empty.
+		{
+			Ctx: context.TODO(),
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState: []*apiv1.ClusterRoleBinding{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "cluster-role-binding-1",
+					},
+					Subjects: []apiv1.Subject{
+						{
+							Kind:      apiv1.ServiceAccountKind,
+							Namespace: "my-cluster",
+							Name:      "my-cluster",
+						},
+					},
+					RoleRef: apiv1.RoleRef{
+						APIGroup: apiv1.GroupName,
+						Kind:     "ClusterRole",
+						Name:     "cluster-role",
+					},
+				},
+			},
+			DesiredState: []*apiv1.ClusterRoleBinding{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "cluster-role-binding-1",
+					},
+					Subjects: []apiv1.Subject{
+						{
+							Kind:      apiv1.ServiceAccountKind,
+							Namespace: "my-cluster",
+							Name:      "my-cluster",
+						},
+					},
+					RoleRef: apiv1.RoleRef{
+						APIGroup: apiv1.GroupName,
+						Kind:     "ClusterRole",
+						Name:     "cluster-role",
+					},
+				},
+			},
+			ExpectedClusterRoleBindinsToUpdate: nil,
+		},
+
+		// Test 3, in case current state contains two items and desired state is
+		// contains the same state but one object is modified internally the update
+		// state should contain the the modified item from the current state.
+		{
+			Ctx: context.TODO(),
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState: []*apiv1.ClusterRoleBinding{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "cluster-role-binding-1",
+					},
+					Subjects: []apiv1.Subject{
+						{
+							Kind:      apiv1.ServiceAccountKind,
+							Namespace: "my-cluster",
+							Name:      "my-cluster",
+						},
+					},
+					RoleRef: apiv1.RoleRef{
+						APIGroup: apiv1.GroupName,
+						Kind:     "ClusterRole",
+						Name:     "cluster-role-1",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "cluster-role-binding-2",
+					},
+					Subjects: []apiv1.Subject{
+						{
+							Kind:      apiv1.ServiceAccountKind,
+							Namespace: "my-cluster",
+							Name:      "my-cluster",
+						},
+					},
+					RoleRef: apiv1.RoleRef{
+						APIGroup: apiv1.GroupName,
+						Kind:     "ClusterRole",
+						Name:     "cluster-role-2",
+					},
+				},
+			},
+			DesiredState: []*apiv1.ClusterRoleBinding{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "cluster-role-binding-1",
+					},
+					Subjects: []apiv1.Subject{
+						{
+							Kind:      apiv1.ServiceAccountKind,
+							Namespace: "my-cluster",
+							Name:      "my-cluster",
+						},
+					},
+					RoleRef: apiv1.RoleRef{
+						APIGroup: apiv1.GroupName,
+						Kind:     "ClusterRole",
+						Name:     "cluster-role-3",
+					},
+				},
+			},
+			ExpectedClusterRoleBindinsToUpdate: []*apiv1.ClusterRoleBinding{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "cluster-role-binding-1",
+					},
+					Subjects: []apiv1.Subject{
+						{
+							Kind:      apiv1.ServiceAccountKind,
+							Namespace: "my-cluster",
+							Name:      "my-cluster",
+						},
+					},
+					RoleRef: apiv1.RoleRef{
+						APIGroup: apiv1.GroupName,
+						Kind:     "ClusterRole",
+						Name:     "cluster-role-3",
+					},
+				},
+			},
+		},
+	}
+
+	var err error
+	var newResource *Resource
+	{
+		resourceConfig := Config{
+			K8sClient: fake.NewSimpleClientset(),
+			Logger:    microloggertest.New(),
+		}
+		newResource, err = New(resourceConfig)
+		if err != nil {
+			t.Fatal("expected", nil, "got", err)
+		}
+	}
+
+	for i, tc := range testCases {
+		updateState, err := newResource.newUpdateChange(tc.Ctx, tc.Obj, tc.CurrentState, tc.DesiredState)
+		if err != nil {
+			t.Fatalf("case %d expected %#v got %#v", i+1, nil, err)
+		}
+
+		clusterRoleBindingsToUpdate, ok := updateState.([]*apiv1.ClusterRoleBinding)
+		if !ok {
+			t.Fatalf("case %d expected %T got %T", i+1, []*apiv1.ClusterRoleBinding{}, updateState)
+		}
+		if !reflect.DeepEqual(clusterRoleBindingsToUpdate, tc.ExpectedClusterRoleBindinsToUpdate) {
+			t.Fatalf("case %d expected %#v got %#v", i+1, tc.ExpectedClusterRoleBindinsToUpdate, clusterRoleBindingsToUpdate)
+		}
+	}
+}

--- a/service/controller/v14patch1/resource/configmap/create.go
+++ b/service/controller/v14patch1/resource/configmap/create.go
@@ -1,0 +1,69 @@
+package configmap
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/giantswarm/microerror"
+	apiv1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+
+	"github.com/giantswarm/kvm-operator/service/controller/v14/key"
+)
+
+func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange interface{}) error {
+	customObject, err := key.ToCustomObject(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	configMapsToCreate, err := toConfigMaps(createChange)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	// Create the config maps in the Kubernetes API.
+	if len(configMapsToCreate) != 0 {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "creating the config maps in the Kubernetes API")
+
+		namespace := key.ClusterNamespace(customObject)
+		for _, configMap := range configMapsToCreate {
+			_, err := r.k8sClient.CoreV1().ConfigMaps(namespace).Create(configMap)
+			if apierrors.IsAlreadyExists(err) {
+				// fall through
+			} else if err != nil {
+				return microerror.Mask(err)
+			}
+		}
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", "created the config maps in the Kubernetes API")
+	} else {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "the config maps do not need to be created in the Kubernetes API")
+	}
+
+	return nil
+}
+
+func (r *Resource) newCreateChange(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, error) {
+	currentConfigMaps, err := toConfigMaps(currentState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+	desiredConfigMaps, err := toConfigMaps(desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", "finding out which config maps have to be created")
+
+	var configMapsToCreate []*apiv1.ConfigMap
+
+	for _, desiredConfigMap := range desiredConfigMaps {
+		if !containsConfigMap(currentConfigMaps, desiredConfigMap) {
+			configMapsToCreate = append(configMapsToCreate, desiredConfigMap)
+		}
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("found %d config maps that have to be created", len(configMapsToCreate)))
+
+	return configMapsToCreate, nil
+}

--- a/service/controller/v14patch1/resource/configmap/create_test.go
+++ b/service/controller/v14patch1/resource/configmap/create_test.go
@@ -1,0 +1,250 @@
+package configmap
+
+import (
+	"context"
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/certs/certstest"
+	"github.com/giantswarm/micrologger/microloggertest"
+	"github.com/giantswarm/randomkeys/randomkeystest"
+	apiv1 "k8s.io/api/core/v1"
+	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/giantswarm/kvm-operator/service/controller/v14/cloudconfig/cloudconfigtest"
+)
+
+func Test_Resource_CloudConfig_newCreateChange(t *testing.T) {
+	testCases := []struct {
+		Obj                    interface{}
+		CurrentState           interface{}
+		DesiredState           interface{}
+		ExpectedConfigMapNames []string
+	}{
+		// Test 1, in case current state and desired state are empty the create
+		// state should be empty.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState:           []*apiv1.ConfigMap{},
+			DesiredState:           []*apiv1.ConfigMap{},
+			ExpectedConfigMapNames: []string{},
+		},
+
+		// Test 2, in case current state equals desired state the create state
+		// should be empty.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState: []*apiv1.ConfigMap{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "config-map-1",
+					},
+				},
+			},
+			DesiredState: []*apiv1.ConfigMap{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "config-map-1",
+					},
+				},
+			},
+			ExpectedConfigMapNames: []string{},
+		},
+
+		// Test 3, in case current state misses one item of desired state the create
+		// state should contain the missing item of the desired state.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState: []*apiv1.ConfigMap{},
+			DesiredState: []*apiv1.ConfigMap{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "config-map-1",
+					},
+				},
+			},
+			ExpectedConfigMapNames: []string{
+				"config-map-1",
+			},
+		},
+
+		// Test 4, in case current state misses items of desired state the create
+		// state should contain the missing items of the desired state.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState: []*apiv1.ConfigMap{},
+			DesiredState: []*apiv1.ConfigMap{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "config-map-1",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "config-map-2",
+					},
+				},
+			},
+			ExpectedConfigMapNames: []string{
+				"config-map-1",
+				"config-map-2",
+			},
+		},
+
+		// Test 5, in case current state contains one item not being in desired
+		// state the create state should not contain the missing item of the desired
+		// state.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState: []*apiv1.ConfigMap{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "config-map-1",
+					},
+				},
+			},
+			DesiredState:           []*apiv1.ConfigMap{},
+			ExpectedConfigMapNames: []string{},
+		},
+
+		// Test 6, in case current state contains items not being in desired state
+		// the create state should not contain the missing items of the desired
+		// state.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState: []*apiv1.ConfigMap{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "config-map-1",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "config-map-2",
+					},
+				},
+			},
+			DesiredState:           []*apiv1.ConfigMap{},
+			ExpectedConfigMapNames: []string{},
+		},
+
+		// Test 7, in case current state contains some items of desired state the
+		// create state should contain the items being in desired state which are
+		// not in create state.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState: []*apiv1.ConfigMap{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "config-map-1",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "config-map-2",
+					},
+				},
+			},
+			DesiredState: []*apiv1.ConfigMap{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "config-map-1",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "config-map-2",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "config-map-3",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "config-map-4",
+					},
+				},
+			},
+			ExpectedConfigMapNames: []string{
+				"config-map-3",
+				"config-map-4",
+			},
+		},
+	}
+
+	var err error
+	var newResource *Resource
+	{
+		resourceConfig := Config{}
+		resourceConfig.CertsSearcher = certstest.NewSearcher()
+		resourceConfig.CloudConfig = cloudconfigtest.New()
+		resourceConfig.K8sClient = fake.NewSimpleClientset()
+		resourceConfig.KeyWatcher = randomkeystest.NewSearcher()
+		resourceConfig.Logger = microloggertest.New()
+		newResource, err = New(resourceConfig)
+		if err != nil {
+			t.Fatal("expected", nil, "got", err)
+		}
+	}
+
+	for i, tc := range testCases {
+		result, err := newResource.newCreateChange(context.TODO(), tc.Obj, tc.CurrentState, tc.DesiredState)
+		if err != nil {
+			t.Fatalf("case %d expected %#v got %#v", i+1, nil, err)
+		}
+
+		configMaps, ok := result.([]*apiv1.ConfigMap)
+		if !ok {
+			t.Fatalf("case %d expected %T got %T", i+1, []*apiv1.ConfigMap{}, result)
+		}
+
+		if len(configMaps) != len(tc.ExpectedConfigMapNames) {
+			t.Fatalf("case %d expected %d config maps got %d", i+1, len(tc.ExpectedConfigMapNames), len(configMaps))
+		}
+	}
+}

--- a/service/controller/v14patch1/resource/configmap/current.go
+++ b/service/controller/v14patch1/resource/configmap/current.go
@@ -1,0 +1,50 @@
+package configmap
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/operatorkit/controller/context/resourcecanceledcontext"
+	apiv1 "k8s.io/api/core/v1"
+	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/giantswarm/kvm-operator/service/controller/v14/key"
+)
+
+func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interface{}, error) {
+	customObject, err := key.ToCustomObject(obj)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	if key.IsDeleted(customObject) {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "redirecting responsibility of deletion of config maps to namespace termination")
+		resourcecanceledcontext.SetCanceled(ctx)
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+
+		return nil, nil
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", "looking for a list of config maps in the Kubernetes API")
+
+	var currentConfigMaps []*apiv1.ConfigMap
+	{
+		namespace := key.ClusterNamespace(customObject)
+		configMapList, err := r.k8sClient.CoreV1().ConfigMaps(namespace).List(apismetav1.ListOptions{})
+		if err != nil {
+			return nil, microerror.Mask(err)
+		} else {
+			r.logger.LogCtx(ctx, "level", "debug", "message", "found a list of config maps in the Kubernetes API")
+
+			for _, item := range configMapList.Items {
+				c := item
+				currentConfigMaps = append(currentConfigMaps, &c)
+			}
+		}
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("found a list of %d config maps in the Kubernetes API", len(currentConfigMaps)))
+
+	return currentConfigMaps, nil
+}

--- a/service/controller/v14patch1/resource/configmap/delete.go
+++ b/service/controller/v14patch1/resource/configmap/delete.go
@@ -1,0 +1,108 @@
+package configmap
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/operatorkit/controller"
+	apiv1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/giantswarm/kvm-operator/service/controller/v14/key"
+)
+
+func (r *Resource) ApplyDeleteChange(ctx context.Context, obj, deleteChange interface{}) error {
+	customObject, err := key.ToCustomObject(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	configMapsToDelete, err := toConfigMaps(deleteChange)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	if len(configMapsToDelete) != 0 {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "deleting the config maps in the Kubernetes API")
+
+		// Create the config maps in the Kubernetes API.
+		namespace := key.ClusterNamespace(customObject)
+		for _, configMap := range configMapsToDelete {
+			err := r.k8sClient.CoreV1().ConfigMaps(namespace).Delete(configMap.Name, &apismetav1.DeleteOptions{})
+			if apierrors.IsNotFound(err) {
+				// fall through
+			} else if err != nil {
+				return microerror.Mask(err)
+			}
+		}
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", "deleted the config maps in the Kubernetes API")
+	} else {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "the config maps do not need to be deleted from the Kubernetes API")
+	}
+
+	return nil
+}
+
+func (r *Resource) NewDeletePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*controller.Patch, error) {
+	delete, err := r.newDeleteChangeForDeletePatch(ctx, obj, currentState, desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	patch := controller.NewPatch()
+	patch.SetDeleteChange(delete)
+
+	return patch, nil
+}
+
+func (r *Resource) newDeleteChangeForDeletePatch(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, error) {
+	currentConfigMaps, err := toConfigMaps(currentState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+	desiredConfigMaps, err := toConfigMaps(desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", "finding out which config maps have to be deleted")
+
+	var configMapsToDelete []*apiv1.ConfigMap
+
+	for _, currentConfigMap := range currentConfigMaps {
+		if containsConfigMap(desiredConfigMaps, currentConfigMap) {
+			configMapsToDelete = append(configMapsToDelete, currentConfigMap)
+		}
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("found %d config maps that have to be deleted", len(configMapsToDelete)))
+
+	return configMapsToDelete, nil
+}
+
+func (r *Resource) newDeleteChangeForUpdatePatch(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, error) {
+	currentConfigMaps, err := toConfigMaps(currentState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+	desiredConfigMaps, err := toConfigMaps(desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", "finding out which config maps have to be deleted")
+
+	var configMapsToDelete []*apiv1.ConfigMap
+
+	for _, currentConfigMap := range currentConfigMaps {
+		if !containsConfigMap(desiredConfigMaps, currentConfigMap) {
+			configMapsToDelete = append(configMapsToDelete, currentConfigMap)
+		}
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("found %d config maps that have to be deleted", len(configMapsToDelete)))
+
+	return configMapsToDelete, nil
+}

--- a/service/controller/v14patch1/resource/configmap/delete_test.go
+++ b/service/controller/v14patch1/resource/configmap/delete_test.go
@@ -1,0 +1,296 @@
+package configmap
+
+import (
+	"context"
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/certs/certstest"
+	"github.com/giantswarm/micrologger/microloggertest"
+	"github.com/giantswarm/randomkeys/randomkeystest"
+	apiv1 "k8s.io/api/core/v1"
+	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/giantswarm/kvm-operator/service/controller/v14/cloudconfig/cloudconfigtest"
+)
+
+func Test_Resource_CloudConfig_newDeleteChange(t *testing.T) {
+	testCases := []struct {
+		Obj                    interface{}
+		CurrentState           interface{}
+		DesiredState           interface{}
+		ExpectedConfigMapNames []string
+	}{
+		// Test 1, in case current state and desired state are empty the delete
+		// state should be empty.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState:           []*apiv1.ConfigMap{},
+			DesiredState:           []*apiv1.ConfigMap{},
+			ExpectedConfigMapNames: []string{},
+		},
+
+		// Test 2, in case current state has one item and equals desired state the
+		// delete state should equal the current state.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState: []*apiv1.ConfigMap{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "config-map-1",
+					},
+				},
+			},
+			DesiredState: []*apiv1.ConfigMap{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "config-map-1",
+					},
+				},
+			},
+			ExpectedConfigMapNames: []string{
+				"config-map-1",
+			},
+		},
+
+		// Test 3, in case current state misses one item of desired state the delete
+		// state should not contain the missing item of the desired state.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState: []*apiv1.ConfigMap{},
+			DesiredState: []*apiv1.ConfigMap{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "config-map-1",
+					},
+				},
+			},
+			ExpectedConfigMapNames: []string{},
+		},
+
+		// Test 4, in case current state misses items of desired state the delete
+		// state should not contain the missing items of the desired state.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState: []*apiv1.ConfigMap{},
+			DesiredState: []*apiv1.ConfigMap{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "config-map-1",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "config-map-2",
+					},
+				},
+			},
+			ExpectedConfigMapNames: []string{},
+		},
+
+		// Test 5, in case current state contains one item and desired state is
+		// empty the delete state should be empty.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState: []*apiv1.ConfigMap{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "config-map-1",
+					},
+				},
+			},
+			DesiredState:           []*apiv1.ConfigMap{},
+			ExpectedConfigMapNames: []string{},
+		},
+
+		// Test 6, in case current state contains items and desired state is empty
+		// the delete state should be empty.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState: []*apiv1.ConfigMap{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "config-map-1",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "config-map-2",
+					},
+				},
+			},
+			DesiredState:           []*apiv1.ConfigMap{},
+			ExpectedConfigMapNames: []string{},
+		},
+
+		// Test 7, in case all items of current state are in desired state and
+		// desired state contains more items not being in current state the create
+		// state should contain all items being in current state.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState: []*apiv1.ConfigMap{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "config-map-1",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "config-map-2",
+					},
+				},
+			},
+			DesiredState: []*apiv1.ConfigMap{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "config-map-1",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "config-map-2",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "config-map-3",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "config-map-4",
+					},
+				},
+			},
+			ExpectedConfigMapNames: []string{
+				"config-map-1",
+				"config-map-2",
+			},
+		},
+
+		// Test 8, in case all items of desired state are in current state and
+		// current state contains more items not being in desired state the create
+		// state should contain all items being in desired state.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState: []*apiv1.ConfigMap{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "config-map-1",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "config-map-2",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "config-map-3",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "config-map-4",
+					},
+				},
+			},
+			DesiredState: []*apiv1.ConfigMap{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "config-map-1",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "config-map-2",
+					},
+				},
+			},
+			ExpectedConfigMapNames: []string{
+				"config-map-1",
+				"config-map-2",
+			},
+		},
+	}
+
+	var err error
+	var newResource *Resource
+	{
+		resourceConfig := Config{}
+		resourceConfig.CertsSearcher = certstest.NewSearcher()
+		resourceConfig.CloudConfig = cloudconfigtest.New()
+		resourceConfig.K8sClient = fake.NewSimpleClientset()
+		resourceConfig.KeyWatcher = randomkeystest.NewSearcher()
+		resourceConfig.Logger = microloggertest.New()
+		newResource, err = New(resourceConfig)
+		if err != nil {
+			t.Fatal("expected", nil, "got", err)
+		}
+	}
+
+	for i, tc := range testCases {
+		result, err := newResource.newDeleteChangeForDeletePatch(context.TODO(), tc.Obj, tc.CurrentState, tc.DesiredState)
+		if err != nil {
+			t.Fatalf("case %d expected %#v got %#v", i+1, nil, err)
+		}
+
+		configMaps, ok := result.([]*apiv1.ConfigMap)
+		if !ok {
+			t.Fatalf("case %d expected %T got %T", i+1, []*apiv1.ConfigMap{}, result)
+		}
+
+		if len(configMaps) != len(tc.ExpectedConfigMapNames) {
+			t.Fatalf("case %d expected %d config maps got %d", i+1, len(tc.ExpectedConfigMapNames), len(configMaps))
+		}
+	}
+}

--- a/service/controller/v14patch1/resource/configmap/desired.go
+++ b/service/controller/v14patch1/resource/configmap/desired.go
@@ -1,0 +1,100 @@
+package configmap
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/microerror"
+	apiv1 "k8s.io/api/core/v1"
+	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/giantswarm/kvm-operator/service/controller/v14/key"
+)
+
+func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interface{}, error) {
+	customObject, err := key.ToCustomObject(obj)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", "computing the new config maps")
+
+	configMaps, err := r.newConfigMaps(customObject)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("computed the %d new config maps", len(configMaps)))
+
+	return configMaps, nil
+}
+
+func (r *Resource) newConfigMaps(customObject v1alpha1.KVMConfig) ([]*apiv1.ConfigMap, error) {
+	var configMaps []*apiv1.ConfigMap
+
+	certs, err := r.certsSearcher.SearchCluster(key.ClusterID(customObject))
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	keys, err := r.keyWatcher.SearchCluster(key.ClusterID(customObject))
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	for _, node := range customObject.Spec.Cluster.Masters {
+		template, err := r.cloudConfig.NewMasterTemplate(customObject, certs, node, keys)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+
+		configMap, err := r.newConfigMap(customObject, template, node, key.MasterID)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+
+		configMaps = append(configMaps, configMap)
+	}
+
+	for _, node := range customObject.Spec.Cluster.Workers {
+		template, err := r.cloudConfig.NewWorkerTemplate(customObject, certs, node)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+
+		configMap, err := r.newConfigMap(customObject, template, node, key.WorkerID)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+
+		configMaps = append(configMaps, configMap)
+	}
+
+	return configMaps, nil
+}
+
+// newConfigMap creates a new Kubernetes configmap using the provided
+// information. customObject is used for name and label creation. params serves
+// as structure being injected into the template execution to interpolate
+// variables. prefix can be either "master" or "worker" and is used to prefix
+// the configmap name.
+func (r *Resource) newConfigMap(customObject v1alpha1.KVMConfig, template string, node v1alpha1.ClusterNode, prefix string) (*apiv1.ConfigMap, error) {
+	var newConfigMap *apiv1.ConfigMap
+	{
+		newConfigMap = &apiv1.ConfigMap{
+			ObjectMeta: apismetav1.ObjectMeta{
+				Name: key.ConfigMapName(customObject, node, prefix),
+				Labels: map[string]string{
+					"cluster":  key.ClusterID(customObject),
+					"customer": key.ClusterCustomer(customObject),
+				},
+			},
+			Data: map[string]string{
+				KeyUserData: template,
+			},
+		}
+	}
+
+	return newConfigMap, nil
+}

--- a/service/controller/v14patch1/resource/configmap/desired_test.go
+++ b/service/controller/v14patch1/resource/configmap/desired_test.go
@@ -1,0 +1,145 @@
+package configmap
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/certs/certstest"
+	"github.com/giantswarm/micrologger/microloggertest"
+	"github.com/giantswarm/randomkeys/randomkeystest"
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/giantswarm/kvm-operator/service/controller/v14/cloudconfig/cloudconfigtest"
+)
+
+func Test_Resource_CloudConfig_GetDesiredState(t *testing.T) {
+	testCases := []struct {
+		Obj                 interface{}
+		ExpectedMasterCount int
+		ExpectedWorkerCount int
+	}{
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+						Masters: []v1alpha1.ClusterNode{
+							{},
+						},
+						Workers: []v1alpha1.ClusterNode{
+							{},
+						},
+					},
+				},
+			},
+			ExpectedMasterCount: 1,
+			ExpectedWorkerCount: 1,
+		},
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+						Masters: []v1alpha1.ClusterNode{
+							{},
+						},
+						Workers: []v1alpha1.ClusterNode{
+							{},
+							{},
+							{},
+						},
+					},
+				},
+			},
+			ExpectedMasterCount: 1,
+			ExpectedWorkerCount: 3,
+		},
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+						Masters: []v1alpha1.ClusterNode{
+							{},
+							{},
+							{},
+						},
+						Workers: []v1alpha1.ClusterNode{
+							{},
+							{},
+							{},
+						},
+					},
+				},
+			},
+			ExpectedMasterCount: 3,
+			ExpectedWorkerCount: 3,
+		},
+	}
+
+	var err error
+	var newResource *Resource
+	{
+		resourceConfig := Config{}
+		resourceConfig.CertsSearcher = certstest.NewSearcher()
+		resourceConfig.CloudConfig = cloudconfigtest.New()
+		resourceConfig.K8sClient = fake.NewSimpleClientset()
+		resourceConfig.KeyWatcher = randomkeystest.NewSearcher()
+		resourceConfig.Logger = microloggertest.New()
+		newResource, err = New(resourceConfig)
+		if err != nil {
+			t.Fatal("expected", nil, "got", err)
+		}
+	}
+
+	for i, tc := range testCases {
+		result, err := newResource.GetDesiredState(context.TODO(), tc.Obj)
+		if err != nil {
+			t.Fatalf("case %d expected %#v got %#v", i+1, nil, err)
+		}
+
+		configMaps, ok := result.([]*apiv1.ConfigMap)
+		if !ok {
+			t.Fatalf("case %d expected %T got %T", i+1, []*apiv1.ConfigMap{}, result)
+		}
+
+		if testGetMasterCount(configMaps) != tc.ExpectedMasterCount {
+			t.Fatalf("case %d expected %d master nodes got %d", i+1, tc.ExpectedMasterCount, testGetMasterCount(configMaps))
+		}
+
+		if testGetWorkerCount(configMaps) != tc.ExpectedWorkerCount {
+			t.Fatalf("case %d expected %d worker nodes got %d", i+1, tc.ExpectedWorkerCount, testGetWorkerCount(configMaps))
+		}
+
+		if len(configMaps) != tc.ExpectedMasterCount+tc.ExpectedWorkerCount {
+			t.Fatalf("case %d expected %d nodes got %d", i+1, tc.ExpectedMasterCount+tc.ExpectedWorkerCount, len(configMaps))
+		}
+	}
+}
+
+func testGetMasterCount(configMaps []*apiv1.ConfigMap) int {
+	var count int
+
+	for _, c := range configMaps {
+		if strings.HasPrefix(c.Name, "master-") {
+			count++
+		}
+	}
+
+	return count
+}
+
+func testGetWorkerCount(configMaps []*apiv1.ConfigMap) int {
+	var count int
+
+	for _, c := range configMaps {
+		if strings.HasPrefix(c.Name, "worker-") {
+			count++
+		}
+	}
+
+	return count
+}

--- a/service/controller/v14patch1/resource/configmap/error.go
+++ b/service/controller/v14patch1/resource/configmap/error.go
@@ -1,0 +1,30 @@
+package configmap
+
+import "github.com/giantswarm/microerror"
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var notFoundError = &microerror.Error{
+	Kind: "notFoundError",
+}
+
+// IsNotFound asserts notFoundError.
+func IsNotFound(err error) bool {
+	return microerror.Cause(err) == notFoundError
+}
+
+var wrongTypeError = &microerror.Error{
+	Kind: "wrongTypeError",
+}
+
+// IsWrongTypeError asserts wrongTypeError.
+func IsWrongTypeError(err error) bool {
+	return microerror.Cause(err) == wrongTypeError
+}

--- a/service/controller/v14patch1/resource/configmap/resource.go
+++ b/service/controller/v14patch1/resource/configmap/resource.go
@@ -1,0 +1,111 @@
+package configmap
+
+import (
+	"reflect"
+
+	"github.com/giantswarm/certs"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/giantswarm/randomkeys"
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/giantswarm/kvm-operator/service/controller/v14/cloudconfig"
+)
+
+const (
+	KeyUserData = "user_data"
+	// Name is the identifier of the resource.
+	Name = "configmapv14"
+)
+
+// Config represents the configuration used to create a new config map resource.
+type Config struct {
+	// Dependencies.
+	CertsSearcher certs.Interface
+	CloudConfig   *cloudconfig.CloudConfig
+	K8sClient     kubernetes.Interface
+	KeyWatcher    randomkeys.Interface
+	Logger        micrologger.Logger
+}
+
+// Resource implements the config map resource.
+type Resource struct {
+	// Dependencies.
+	certsSearcher certs.Interface
+	cloudConfig   *cloudconfig.CloudConfig
+	k8sClient     kubernetes.Interface
+	keyWatcher    randomkeys.Interface
+	logger        micrologger.Logger
+}
+
+// New creates a new configured config map resource.
+func New(config Config) (*Resource, error) {
+	// Dependencies.
+	if config.CertsSearcher == nil {
+		return nil, microerror.Maskf(invalidConfigError, "config.CertsSearcher must not be empty")
+	}
+	if config.CloudConfig == nil {
+		return nil, microerror.Maskf(invalidConfigError, "config.CloudConfig must not be empty")
+	}
+	if config.K8sClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "config.K8sClient must not be empty")
+	}
+	if config.KeyWatcher == nil {
+		return nil, microerror.Maskf(invalidConfigError, "config.KeyWatcher must not be empty")
+	}
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "config.Logger must not be empty")
+	}
+
+	newService := &Resource{
+		// Dependencies.
+		certsSearcher: config.CertsSearcher,
+		cloudConfig:   config.CloudConfig,
+		k8sClient:     config.K8sClient,
+		keyWatcher:    config.KeyWatcher,
+		logger:        config.Logger,
+	}
+
+	return newService, nil
+}
+
+func (r *Resource) Name() string {
+	return Name
+}
+
+func containsConfigMap(list []*apiv1.ConfigMap, item *apiv1.ConfigMap) bool {
+	_, err := getConfigMapByName(list, item.Name)
+	if err != nil {
+		return false
+	}
+
+	return true
+}
+
+func getConfigMapByName(list []*apiv1.ConfigMap, name string) (*apiv1.ConfigMap, error) {
+	for _, l := range list {
+		if l.Name == name {
+			return l, nil
+		}
+	}
+
+	return nil, microerror.Mask(notFoundError)
+}
+
+func isConfigMapModified(a, b *apiv1.ConfigMap) bool {
+	return !reflect.DeepEqual(a.Data, b.Data)
+}
+
+func toConfigMaps(v interface{}) ([]*apiv1.ConfigMap, error) {
+	if v == nil {
+		return nil, nil
+	}
+
+	configMaps, ok := v.([]*apiv1.ConfigMap)
+	if !ok {
+		return nil, microerror.Maskf(wrongTypeError, "expected '%T', got '%T'", []*apiv1.ConfigMap{}, v)
+	}
+
+	return configMaps, nil
+}

--- a/service/controller/v14patch1/resource/configmap/update.go
+++ b/service/controller/v14patch1/resource/configmap/update.go
@@ -1,0 +1,97 @@
+package configmap
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/operatorkit/controller"
+	apiv1 "k8s.io/api/core/v1"
+
+	"github.com/giantswarm/kvm-operator/service/controller/v14/key"
+)
+
+func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateChange interface{}) error {
+	customObject, err := key.ToCustomObject(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	configMapsToUpdate, err := toConfigMaps(updateChange)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	if len(configMapsToUpdate) != 0 {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "updating the config maps in the Kubernetes API")
+
+		// Create the config maps in the Kubernetes API.
+		namespace := key.ClusterNamespace(customObject)
+		for _, configMap := range configMapsToUpdate {
+			_, err := r.k8sClient.CoreV1().ConfigMaps(namespace).Update(configMap)
+			if err != nil {
+				return microerror.Mask(err)
+			}
+		}
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", "updated the config maps in the Kubernetes API")
+	} else {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "the config maps do not need to be updated in the Kubernetes API")
+	}
+
+	return nil
+}
+
+func (r *Resource) NewUpdatePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*controller.Patch, error) {
+	create, err := r.newCreateChange(ctx, obj, currentState, desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+	delete, err := r.newDeleteChangeForUpdatePatch(ctx, obj, currentState, desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+	update, err := r.newUpdateChange(ctx, obj, currentState, desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	patch := controller.NewPatch()
+	patch.SetCreateChange(create)
+	patch.SetDeleteChange(delete)
+	patch.SetUpdateChange(update)
+
+	return patch, nil
+}
+
+func (r *Resource) newUpdateChange(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, error) {
+	currentConfigMaps, err := toConfigMaps(currentState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+	desiredConfigMaps, err := toConfigMaps(desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	var configMapsToUpdate []*apiv1.ConfigMap
+	{
+		r.logger.LogCtx(ctx, "level", "debug", "message", "finding out which config maps have to be updated")
+
+		for _, currentConfigMap := range currentConfigMaps {
+			desiredConfigMap, err := getConfigMapByName(desiredConfigMaps, currentConfigMap.Name)
+			if IsNotFound(err) {
+				continue
+			} else if err != nil {
+				return nil, microerror.Mask(err)
+			}
+
+			if isConfigMapModified(desiredConfigMap, currentConfigMap) {
+				configMapsToUpdate = append(configMapsToUpdate, desiredConfigMap)
+			}
+		}
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("found %d config maps that have to be updated", len(configMapsToUpdate)))
+	}
+
+	return configMapsToUpdate, nil
+}

--- a/service/controller/v14patch1/resource/configmap/update_test.go
+++ b/service/controller/v14patch1/resource/configmap/update_test.go
@@ -1,0 +1,171 @@
+package configmap
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/certs/certstest"
+	"github.com/giantswarm/micrologger/microloggertest"
+	"github.com/giantswarm/randomkeys/randomkeystest"
+	apiv1 "k8s.io/api/core/v1"
+	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/giantswarm/kvm-operator/service/controller/v14/cloudconfig/cloudconfigtest"
+)
+
+func Test_Resource_CloudConfig_newUpdateChange(t *testing.T) {
+	testCases := []struct {
+		Ctx                                  context.Context
+		Obj                                  interface{}
+		CurrentState                         interface{}
+		DesiredState                         interface{}
+		ExpectedConfigMapsToUpdate           []*apiv1.ConfigMap
+		ExpectedMessageContextConfigMapNames []string
+	}{
+		// Test 0, in case current state and desired state are empty the update
+		// state should be empty.
+		{
+			Ctx: context.TODO(),
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState:                         []*apiv1.ConfigMap{},
+			DesiredState:                         []*apiv1.ConfigMap{},
+			ExpectedConfigMapsToUpdate:           nil,
+			ExpectedMessageContextConfigMapNames: nil,
+		},
+
+		// Test 1, in case current state and desired state are equal the update
+		// state should be empty.
+		{
+			Ctx: context.TODO(),
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState: []*apiv1.ConfigMap{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "config-map-1",
+					},
+					Data: map[string]string{
+						"key1": "val1",
+					},
+				},
+			},
+			DesiredState: []*apiv1.ConfigMap{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "config-map-1",
+					},
+					Data: map[string]string{
+						"key1": "val1",
+					},
+				},
+			},
+			ExpectedConfigMapsToUpdate:           nil,
+			ExpectedMessageContextConfigMapNames: nil,
+		},
+
+		// Test 2, in case current state contains two items and desired state is
+		// contains the same state but one object is modified internally the update
+		// state should contain the the modified item from the current state.
+		{
+			Ctx: context.TODO(),
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState: []*apiv1.ConfigMap{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "config-map-1",
+					},
+					Data: map[string]string{
+						"key1": "val1",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "config-map-2",
+					},
+					Data: map[string]string{
+						"key2": "val2-modified",
+					},
+				},
+			},
+			DesiredState: []*apiv1.ConfigMap{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "config-map-1",
+					},
+					Data: map[string]string{
+						"key1": "val1",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "config-map-2",
+					},
+					Data: map[string]string{
+						"key2": "val2",
+					},
+				},
+			},
+			ExpectedConfigMapsToUpdate: []*apiv1.ConfigMap{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "config-map-2",
+					},
+					Data: map[string]string{
+						"key2": "val2",
+					},
+				},
+			},
+			ExpectedMessageContextConfigMapNames: nil,
+		},
+	}
+
+	var err error
+	var newResource *Resource
+	{
+		resourceConfig := Config{}
+		resourceConfig.CertsSearcher = certstest.NewSearcher()
+		resourceConfig.CloudConfig = cloudconfigtest.New()
+		resourceConfig.K8sClient = fake.NewSimpleClientset()
+		resourceConfig.KeyWatcher = randomkeystest.NewSearcher()
+		resourceConfig.Logger = microloggertest.New()
+		newResource, err = New(resourceConfig)
+		if err != nil {
+			t.Fatal("expected", nil, "got", err)
+		}
+	}
+
+	for i, tc := range testCases {
+		updateState, err := newResource.newUpdateChange(tc.Ctx, tc.Obj, tc.CurrentState, tc.DesiredState)
+		if err != nil {
+			t.Fatalf("case %d expected %#v got %#v", i, nil, err)
+		}
+
+		configMapsToUpdate, ok := updateState.([]*apiv1.ConfigMap)
+		if !ok {
+			t.Fatalf("case %d expected %T got %T", i, []*apiv1.ConfigMap{}, updateState)
+		}
+		if !reflect.DeepEqual(configMapsToUpdate, tc.ExpectedConfigMapsToUpdate) {
+			t.Fatalf("case %d expected %#v got %#v", i, tc.ExpectedConfigMapsToUpdate, configMapsToUpdate)
+		}
+	}
+}

--- a/service/controller/v14patch1/resource/deployment/create.go
+++ b/service/controller/v14patch1/resource/deployment/create.go
@@ -1,0 +1,68 @@
+package deployment
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/giantswarm/microerror"
+	"k8s.io/api/extensions/v1beta1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+
+	"github.com/giantswarm/kvm-operator/service/controller/v14/key"
+)
+
+func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange interface{}) error {
+	customObject, err := key.ToCustomObject(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	deploymentsToCreate, err := toDeployments(createChange)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	if len(deploymentsToCreate) != 0 {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "creating the deployments in the Kubernetes API")
+
+		namespace := key.ClusterNamespace(customObject)
+		for _, deployment := range deploymentsToCreate {
+			_, err := r.k8sClient.Extensions().Deployments(namespace).Create(deployment)
+			if apierrors.IsAlreadyExists(err) {
+				// fall through
+			} else if err != nil {
+				return microerror.Mask(err)
+			}
+		}
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", "created the deployments in the Kubernetes API")
+	} else {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "the deployments do not need to be created in the Kubernetes API")
+	}
+
+	return nil
+}
+
+func (r *Resource) newCreateChange(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, error) {
+	currentDeployments, err := toDeployments(currentState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+	desiredDeployments, err := toDeployments(desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", "finding out which deployments have to be created")
+
+	var deploymentsToCreate []*v1beta1.Deployment
+
+	for _, desiredDeployment := range desiredDeployments {
+		if !containsDeployment(currentDeployments, desiredDeployment) {
+			deploymentsToCreate = append(deploymentsToCreate, desiredDeployment)
+		}
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("found %d deployments that have to be created", len(deploymentsToCreate)))
+
+	return deploymentsToCreate, nil
+}

--- a/service/controller/v14patch1/resource/deployment/create_test.go
+++ b/service/controller/v14patch1/resource/deployment/create_test.go
@@ -1,0 +1,243 @@
+package deployment
+
+import (
+	"context"
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/micrologger/microloggertest"
+	"k8s.io/api/extensions/v1beta1"
+	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func Test_Resource_Deployment_newCreateChange(t *testing.T) {
+	testCases := []struct {
+		Obj                     interface{}
+		CurrentState            interface{}
+		DesiredState            interface{}
+		ExpectedDeploymentNames []string
+	}{
+		// Test 1, in case current state and desired state are empty the create
+		// state should be empty.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState:            []*v1beta1.Deployment{},
+			DesiredState:            []*v1beta1.Deployment{},
+			ExpectedDeploymentNames: []string{},
+		},
+
+		// Test 2, in case current state equals desired state the create state
+		// should be empty.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState: []*v1beta1.Deployment{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "deployment-1",
+					},
+				},
+			},
+			DesiredState: []*v1beta1.Deployment{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "deployment-1",
+					},
+				},
+			},
+			ExpectedDeploymentNames: []string{},
+		},
+
+		// Test 3, in case current state misses one item of desired state the create
+		// state should contain the missing item of the desired state.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState: []*v1beta1.Deployment{},
+			DesiredState: []*v1beta1.Deployment{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "deployment-1",
+					},
+				},
+			},
+			ExpectedDeploymentNames: []string{
+				"deployment-1",
+			},
+		},
+
+		// Test 4, in case current state misses items of desired state the create
+		// state should contain the missing items of the desired state.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState: []*v1beta1.Deployment{},
+			DesiredState: []*v1beta1.Deployment{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "deployment-1",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "deployment-2",
+					},
+				},
+			},
+			ExpectedDeploymentNames: []string{
+				"deployment-1",
+				"deployment-2",
+			},
+		},
+
+		// Test 5, in case current state contains one item not being in desired
+		// state the create state should not contain the missing item of the desired
+		// state.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState: []*v1beta1.Deployment{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "deployment-1",
+					},
+				},
+			},
+			DesiredState:            []*v1beta1.Deployment{},
+			ExpectedDeploymentNames: []string{},
+		},
+
+		// Test 6, in case current state contains items not being in desired state
+		// the create state should not contain the missing items of the desired
+		// state.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState: []*v1beta1.Deployment{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "deployment-1",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "deployment-2",
+					},
+				},
+			},
+			DesiredState:            []*v1beta1.Deployment{},
+			ExpectedDeploymentNames: []string{},
+		},
+
+		// Test 7, in case current state contains some items of desired state the
+		// create state should contain the items being in desired state which are
+		// not in create state.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState: []*v1beta1.Deployment{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "deployment-1",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "deployment-2",
+					},
+				},
+			},
+			DesiredState: []*v1beta1.Deployment{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "deployment-1",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "deployment-2",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "deployment-3",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "deployment-4",
+					},
+				},
+			},
+			ExpectedDeploymentNames: []string{
+				"deployment-3",
+				"deployment-4",
+			},
+		},
+	}
+
+	var err error
+	var newResource *Resource
+	{
+		resourceConfig := DefaultConfig()
+		resourceConfig.K8sClient = fake.NewSimpleClientset()
+		resourceConfig.Logger = microloggertest.New()
+		newResource, err = New(resourceConfig)
+		if err != nil {
+			t.Fatal("expected", nil, "got", err)
+		}
+	}
+
+	for i, tc := range testCases {
+		result, err := newResource.newCreateChange(context.TODO(), tc.Obj, tc.CurrentState, tc.DesiredState)
+		if err != nil {
+			t.Fatalf("case %d expected %#v got %#v", i+1, nil, err)
+		}
+
+		deployments, ok := result.([]*v1beta1.Deployment)
+		if !ok {
+			t.Fatalf("case %d expected %T got %T", i+1, []*v1beta1.Deployment{}, result)
+		}
+
+		if len(deployments) != len(tc.ExpectedDeploymentNames) {
+			t.Fatalf("case %d expected %d config maps got %d", i+1, len(tc.ExpectedDeploymentNames), len(deployments))
+		}
+	}
+}

--- a/service/controller/v14patch1/resource/deployment/current.go
+++ b/service/controller/v14patch1/resource/deployment/current.go
@@ -1,0 +1,80 @@
+package deployment
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/microerror"
+	"github.com/prometheus/client_golang/prometheus"
+	"k8s.io/api/extensions/v1beta1"
+	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/giantswarm/kvm-operator/service/controller/v14/key"
+	"github.com/giantswarm/kvm-operator/service/metric"
+)
+
+func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interface{}, error) {
+	customObject, err := key.ToCustomObject(obj)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", "looking for a list of deployments in the Kubernetes API")
+
+	var currentDeployments []*v1beta1.Deployment
+	{
+		namespace := key.ClusterNamespace(customObject)
+		deploymentList, err := r.k8sClient.Extensions().Deployments(namespace).List(apismetav1.ListOptions{})
+		if err != nil {
+			return nil, microerror.Mask(err)
+		} else {
+			r.logger.LogCtx(ctx, "level", "debug", "message", "found a list of deployments in the Kubernetes API")
+
+			for _, item := range deploymentList.Items {
+				d := item
+				currentDeployments = append(currentDeployments, &d)
+			}
+
+			r.updateVersionBundleVersionGauge(ctx, customObject, metric.VersionBundleVersionGauge, currentDeployments)
+		}
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("found a list of %d deployments in the Kubernetes API", len(currentDeployments)))
+
+	return currentDeployments, nil
+}
+
+func (r *Resource) updateVersionBundleVersionGauge(ctx context.Context, customObject v1alpha1.KVMConfig, gauge *prometheus.GaugeVec, deployments []*v1beta1.Deployment) {
+	versionCounts := map[string]float64{}
+
+	for _, d := range deployments {
+		version, ok := d.Annotations[key.VersionBundleVersionAnnotation]
+		if !ok {
+			r.logger.LogCtx(ctx, "level", "warning", "message", fmt.Sprintf("cannot update current deployment: annotation '%s' must not be empty", key.VersionBundleVersionAnnotation))
+			continue
+		} else {
+			count, ok := versionCounts[version]
+			if !ok {
+				versionCounts[version] = 1
+			} else {
+				versionCounts[version] = count + 1
+			}
+		}
+	}
+
+	for version, count := range versionCounts {
+		split := strings.Split(version, ".")
+		if len(split) != 3 {
+			r.logger.LogCtx(ctx, "level", "warning", "message", fmt.Sprintf("cannot update current deployment: invalid version format, expected '<major>.<minor>.<patch>', got '%s'", version))
+			continue
+		}
+
+		major := split[0]
+		minor := split[1]
+		patch := split[2]
+
+		gauge.WithLabelValues(major, minor, patch).Set(count)
+	}
+}

--- a/service/controller/v14patch1/resource/deployment/delete.go
+++ b/service/controller/v14patch1/resource/deployment/delete.go
@@ -1,0 +1,121 @@
+package deployment
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/operatorkit/controller"
+	"k8s.io/api/extensions/v1beta1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/giantswarm/kvm-operator/service/controller/v14/key"
+)
+
+func (r *Resource) ApplyDeleteChange(ctx context.Context, obj, deleteChange interface{}) error {
+	customObject, err := key.ToCustomObject(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	deploymentsToDelete, err := toDeployments(deleteChange)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	if len(deploymentsToDelete) != 0 {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "deleting the deployments in the Kubernetes API")
+
+		for _, deployment := range deploymentsToDelete {
+			n := key.ClusterNamespace(customObject)
+			err := r.k8sClient.Extensions().Deployments(n).Delete(deployment.Name, newDeleteOptions())
+			if apierrors.IsNotFound(err) {
+				// fall through
+			} else if err != nil {
+				return microerror.Mask(err)
+			}
+		}
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", "deleted the deployments in the Kubernetes API")
+	} else {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "the deployments do not need to be deleted from the Kubernetes API")
+	}
+
+	return nil
+}
+
+func (r *Resource) NewDeletePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*controller.Patch, error) {
+	delete, err := r.newDeleteChangeForDeletePatch(ctx, obj, currentState, desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	patch := controller.NewPatch()
+	patch.SetDeleteChange(delete)
+
+	return patch, nil
+}
+
+// newDeleteChangeForDeletePatch is used on delete events to get rid of all
+// deployments.
+func (r *Resource) newDeleteChangeForDeletePatch(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, error) {
+	currentDeployments, err := toDeployments(currentState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+	desiredDeployments, err := toDeployments(desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", "finding out which deployments have to be deleted")
+
+	var deploymentsToDelete []*v1beta1.Deployment
+
+	for _, currentDeployment := range currentDeployments {
+		if containsDeployment(desiredDeployments, currentDeployment) {
+			deploymentsToDelete = append(deploymentsToDelete, currentDeployment)
+		}
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("found %d deployments that have to be deleted", len(deploymentsToDelete)))
+
+	return deploymentsToDelete, nil
+}
+
+// newDeleteChangeForUpdatePatch is used on update events to scale down
+// deployments.
+func (r *Resource) newDeleteChangeForUpdatePatch(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, error) {
+	currentDeployments, err := toDeployments(currentState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+	desiredDeployments, err := toDeployments(desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", "finding out which deployments have to be deleted")
+
+	var deploymentsToDelete []*v1beta1.Deployment
+
+	for _, currentDeployment := range currentDeployments {
+		if !containsDeployment(desiredDeployments, currentDeployment) {
+			deploymentsToDelete = append(deploymentsToDelete, currentDeployment)
+		}
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("found %d deployments that have to be deleted", len(deploymentsToDelete)))
+
+	return deploymentsToDelete, nil
+}
+
+func newDeleteOptions() *metav1.DeleteOptions {
+	propagation := metav1.DeletePropagationForeground
+
+	options := &metav1.DeleteOptions{
+		PropagationPolicy: &propagation,
+	}
+
+	return options
+}

--- a/service/controller/v14patch1/resource/deployment/delete_test.go
+++ b/service/controller/v14patch1/resource/deployment/delete_test.go
@@ -1,0 +1,289 @@
+package deployment
+
+import (
+	"context"
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/micrologger/microloggertest"
+	"k8s.io/api/extensions/v1beta1"
+	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func Test_Resource_Deployment_newDeleteChange(t *testing.T) {
+	testCases := []struct {
+		Obj                     interface{}
+		CurrentState            interface{}
+		DesiredState            interface{}
+		ExpectedDeploymentNames []string
+	}{
+		// Test 1, in case current state and desired state are empty the delete
+		// state should be empty.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState:            []*v1beta1.Deployment{},
+			DesiredState:            []*v1beta1.Deployment{},
+			ExpectedDeploymentNames: []string{},
+		},
+
+		// Test 2, in case current state has one item and equals desired state the
+		// delete state should equal the current state.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState: []*v1beta1.Deployment{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "deployment-1",
+					},
+				},
+			},
+			DesiredState: []*v1beta1.Deployment{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "deployment-1",
+					},
+				},
+			},
+			ExpectedDeploymentNames: []string{
+				"deployment-1",
+			},
+		},
+
+		// Test 3, in case current state misses one item of desired state the delete
+		// state should not contain the missing item of the desired state.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState: []*v1beta1.Deployment{},
+			DesiredState: []*v1beta1.Deployment{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "deployment-1",
+					},
+				},
+			},
+			ExpectedDeploymentNames: []string{},
+		},
+
+		// Test 4, in case current state misses items of desired state the delete
+		// state should not contain the missing items of the desired state.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState: []*v1beta1.Deployment{},
+			DesiredState: []*v1beta1.Deployment{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "deployment-1",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "deployment-2",
+					},
+				},
+			},
+			ExpectedDeploymentNames: []string{},
+		},
+
+		// Test 5, in case current state contains one item and desired state is
+		// empty the delete state should be empty.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState: []*v1beta1.Deployment{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "deployment-1",
+					},
+				},
+			},
+			DesiredState:            []*v1beta1.Deployment{},
+			ExpectedDeploymentNames: []string{},
+		},
+
+		// Test 6, in case current state contains items and desired state is empty
+		// the delete state should be empty.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState: []*v1beta1.Deployment{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "deployment-1",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "deployment-2",
+					},
+				},
+			},
+			DesiredState:            []*v1beta1.Deployment{},
+			ExpectedDeploymentNames: []string{},
+		},
+
+		// Test 7, in case all items of current state are in desired state and
+		// desired state contains more items not being in current state the create
+		// state should contain all items being in current state.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState: []*v1beta1.Deployment{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "deployment-1",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "deployment-2",
+					},
+				},
+			},
+			DesiredState: []*v1beta1.Deployment{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "deployment-1",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "deployment-2",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "deployment-3",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "deployment-4",
+					},
+				},
+			},
+			ExpectedDeploymentNames: []string{
+				"deployment-1",
+				"deployment-2",
+			},
+		},
+
+		// Test 8, in case all items of desired state are in current state and
+		// current state contains more items not being in desired state the create
+		// state should contain all items being in desired state.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState: []*v1beta1.Deployment{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "deployment-1",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "deployment-2",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "deployment-3",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "deployment-4",
+					},
+				},
+			},
+			DesiredState: []*v1beta1.Deployment{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "deployment-1",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "deployment-2",
+					},
+				},
+			},
+			ExpectedDeploymentNames: []string{
+				"deployment-1",
+				"deployment-2",
+			},
+		},
+	}
+
+	var err error
+	var newResource *Resource
+	{
+		resourceConfig := DefaultConfig()
+		resourceConfig.K8sClient = fake.NewSimpleClientset()
+		resourceConfig.Logger = microloggertest.New()
+		newResource, err = New(resourceConfig)
+		if err != nil {
+			t.Fatal("expected", nil, "got", err)
+		}
+	}
+
+	for i, tc := range testCases {
+		result, err := newResource.newDeleteChangeForDeletePatch(context.TODO(), tc.Obj, tc.CurrentState, tc.DesiredState)
+		if err != nil {
+			t.Fatalf("case %d expected %#v got %#v", i+1, nil, err)
+		}
+
+		deployments, ok := result.([]*v1beta1.Deployment)
+		if !ok {
+			t.Fatalf("case %d expected %T got %T", i+1, []*v1beta1.Deployment{}, result)
+		}
+
+		if len(deployments) != len(tc.ExpectedDeploymentNames) {
+			t.Fatalf("case %d expected %d config maps got %d", i+1, len(tc.ExpectedDeploymentNames), len(deployments))
+		}
+	}
+}

--- a/service/controller/v14patch1/resource/deployment/desired.go
+++ b/service/controller/v14patch1/resource/deployment/desired.go
@@ -1,0 +1,40 @@
+package deployment
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/giantswarm/microerror"
+	"k8s.io/api/extensions/v1beta1"
+
+	"github.com/giantswarm/kvm-operator/service/controller/v14/key"
+)
+
+func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interface{}, error) {
+	customObject, err := key.ToCustomObject(obj)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", "computing the new deployments")
+
+	var deployments []*v1beta1.Deployment
+
+	{
+		masterDeployments, err := newMasterDeployments(customObject)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+		deployments = append(deployments, masterDeployments...)
+
+		workerDeployments, err := newWorkerDeployments(customObject)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+		deployments = append(deployments, workerDeployments...)
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("computed the %d new deployments", len(deployments)))
+
+	return deployments, nil
+}

--- a/service/controller/v14patch1/resource/deployment/desired_test.go
+++ b/service/controller/v14patch1/resource/deployment/desired_test.go
@@ -1,0 +1,364 @@
+package deployment
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/micrologger/microloggertest"
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/api/extensions/v1beta1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func Test_Resource_Deployment_GetDesiredState(t *testing.T) {
+	testCases := []struct {
+		Obj                      interface{}
+		ExpectedMasterCount      int
+		ExpectedWorkerCount      int
+		ExpectedMastersResources []apiv1.ResourceRequirements
+		ExpectedWorkersResources []apiv1.ResourceRequirements
+	}{
+		// Test 0 ensures there is one deployment for master and worker each when
+		// there is one master and one worker node in the custom object.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+						Masters: []v1alpha1.ClusterNode{
+							{},
+						},
+						Workers: []v1alpha1.ClusterNode{
+							{},
+						},
+					},
+					KVM: v1alpha1.KVMConfigSpecKVM{
+						K8sKVM: v1alpha1.KVMConfigSpecKVMK8sKVM{
+							StorageType: "hostPath",
+						},
+						Masters: []v1alpha1.KVMConfigSpecKVMNode{
+							{CPUs: 1, Memory: "1G"},
+						},
+						Workers: []v1alpha1.KVMConfigSpecKVMNode{
+							{CPUs: 4, Memory: "8G"},
+						},
+					},
+				},
+			},
+			ExpectedMasterCount: 1,
+			ExpectedWorkerCount: 1,
+			ExpectedMastersResources: []apiv1.ResourceRequirements{
+				{
+					Requests: apiv1.ResourceList{
+						apiv1.ResourceCPU:    resource.MustParse("1"),
+						apiv1.ResourceMemory: resource.MustParse("2G"),
+					},
+					Limits: apiv1.ResourceList{
+						apiv1.ResourceCPU:    resource.MustParse("1"),
+						apiv1.ResourceMemory: resource.MustParse("2G"),
+					},
+				},
+			},
+			ExpectedWorkersResources: []apiv1.ResourceRequirements{
+				{
+					Requests: apiv1.ResourceList{
+						apiv1.ResourceCPU:    resource.MustParse("4"),
+						apiv1.ResourceMemory: resource.MustParse("9728M"),
+					},
+					Limits: apiv1.ResourceList{
+						apiv1.ResourceCPU:    resource.MustParse("4"),
+						apiv1.ResourceMemory: resource.MustParse("9728M"),
+					},
+				},
+			},
+		},
+
+		// Test 1 ensures there is one deployment for master and worker each when
+		// there is one master and three worker nodes in the custom object.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+						Masters: []v1alpha1.ClusterNode{
+							{},
+						},
+						Workers: []v1alpha1.ClusterNode{
+							{},
+							{},
+							{},
+						},
+					},
+					KVM: v1alpha1.KVMConfigSpecKVM{
+						K8sKVM: v1alpha1.KVMConfigSpecKVMK8sKVM{
+							StorageType: "hostPath",
+						},
+						Masters: []v1alpha1.KVMConfigSpecKVMNode{
+							{CPUs: 1, Memory: "1G"},
+						},
+						Workers: []v1alpha1.KVMConfigSpecKVMNode{
+							{CPUs: 4, Memory: "8G"},
+							{CPUs: 4, Memory: "8G"},
+							{CPUs: 4, Memory: "8G"},
+						},
+					},
+				},
+			},
+			ExpectedMasterCount: 1,
+			ExpectedWorkerCount: 3,
+			ExpectedMastersResources: []apiv1.ResourceRequirements{
+				{
+					Requests: apiv1.ResourceList{
+						apiv1.ResourceCPU:    resource.MustParse("1"),
+						apiv1.ResourceMemory: resource.MustParse("2G"),
+					},
+					Limits: apiv1.ResourceList{
+						apiv1.ResourceCPU:    resource.MustParse("1"),
+						apiv1.ResourceMemory: resource.MustParse("2G"),
+					},
+				},
+			},
+			ExpectedWorkersResources: []apiv1.ResourceRequirements{
+				{
+					Requests: apiv1.ResourceList{
+						apiv1.ResourceCPU:    resource.MustParse("4"),
+						apiv1.ResourceMemory: resource.MustParse("9728M"),
+					},
+					Limits: apiv1.ResourceList{
+						apiv1.ResourceCPU:    resource.MustParse("4"),
+						apiv1.ResourceMemory: resource.MustParse("9728M"),
+					},
+				},
+				{
+					Requests: apiv1.ResourceList{
+						apiv1.ResourceCPU:    resource.MustParse("4"),
+						apiv1.ResourceMemory: resource.MustParse("9728M"),
+					},
+					Limits: apiv1.ResourceList{
+						apiv1.ResourceCPU:    resource.MustParse("4"),
+						apiv1.ResourceMemory: resource.MustParse("9728M"),
+					},
+				},
+				{
+					Requests: apiv1.ResourceList{
+						apiv1.ResourceCPU:    resource.MustParse("4"),
+						apiv1.ResourceMemory: resource.MustParse("9728M"),
+					},
+					Limits: apiv1.ResourceList{
+						apiv1.ResourceCPU:    resource.MustParse("4"),
+						apiv1.ResourceMemory: resource.MustParse("9728M"),
+					},
+				},
+			},
+		},
+
+		// Test 2 ensures there is one deployment for master and worker each when
+		// there are three master and three worker nodes in the custom object.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+						Masters: []v1alpha1.ClusterNode{
+							{},
+							{},
+							{},
+						},
+						Workers: []v1alpha1.ClusterNode{
+							{},
+							{},
+							{},
+						},
+					},
+					KVM: v1alpha1.KVMConfigSpecKVM{
+						K8sKVM: v1alpha1.KVMConfigSpecKVMK8sKVM{
+							StorageType: "hostPath",
+						},
+						Masters: []v1alpha1.KVMConfigSpecKVMNode{
+							{CPUs: 1, Memory: "1G"},
+							{CPUs: 1, Memory: "1G"},
+							{CPUs: 1, Memory: "1G"},
+						},
+						Workers: []v1alpha1.KVMConfigSpecKVMNode{
+							{CPUs: 4, Memory: "8G"},
+							{CPUs: 4, Memory: "8G"},
+							{CPUs: 4, Memory: "8G"},
+						},
+					},
+				},
+			},
+			ExpectedMasterCount: 3,
+			ExpectedWorkerCount: 3,
+			ExpectedMastersResources: []apiv1.ResourceRequirements{
+				{
+					Requests: apiv1.ResourceList{
+						apiv1.ResourceCPU:    resource.MustParse("1"),
+						apiv1.ResourceMemory: resource.MustParse("2G"),
+					},
+					Limits: apiv1.ResourceList{
+						apiv1.ResourceCPU:    resource.MustParse("1"),
+						apiv1.ResourceMemory: resource.MustParse("2G"),
+					},
+				},
+				{
+					Requests: apiv1.ResourceList{
+						apiv1.ResourceCPU:    resource.MustParse("1"),
+						apiv1.ResourceMemory: resource.MustParse("2G"),
+					},
+					Limits: apiv1.ResourceList{
+						apiv1.ResourceCPU:    resource.MustParse("1"),
+						apiv1.ResourceMemory: resource.MustParse("2G"),
+					},
+				},
+				{
+					Requests: apiv1.ResourceList{
+						apiv1.ResourceCPU:    resource.MustParse("1"),
+						apiv1.ResourceMemory: resource.MustParse("2G"),
+					},
+					Limits: apiv1.ResourceList{
+						apiv1.ResourceCPU:    resource.MustParse("1"),
+						apiv1.ResourceMemory: resource.MustParse("2G"),
+					},
+				},
+			},
+			ExpectedWorkersResources: []apiv1.ResourceRequirements{
+				{
+					Requests: apiv1.ResourceList{
+						apiv1.ResourceCPU:    resource.MustParse("4"),
+						apiv1.ResourceMemory: resource.MustParse("9728M"),
+					},
+					Limits: apiv1.ResourceList{
+						apiv1.ResourceCPU:    resource.MustParse("4"),
+						apiv1.ResourceMemory: resource.MustParse("9728M"),
+					},
+				},
+				{
+					Requests: apiv1.ResourceList{
+						apiv1.ResourceCPU:    resource.MustParse("4"),
+						apiv1.ResourceMemory: resource.MustParse("9728M"),
+					},
+					Limits: apiv1.ResourceList{
+						apiv1.ResourceCPU:    resource.MustParse("4"),
+						apiv1.ResourceMemory: resource.MustParse("9728M"),
+					},
+				},
+				{
+					Requests: apiv1.ResourceList{
+						apiv1.ResourceCPU:    resource.MustParse("4"),
+						apiv1.ResourceMemory: resource.MustParse("9728M"),
+					},
+					Limits: apiv1.ResourceList{
+						apiv1.ResourceCPU:    resource.MustParse("4"),
+						apiv1.ResourceMemory: resource.MustParse("9728M"),
+					},
+				},
+			},
+		},
+	}
+
+	var err error
+	var newResource *Resource
+	{
+		resourceConfig := DefaultConfig()
+		resourceConfig.K8sClient = fake.NewSimpleClientset()
+		resourceConfig.Logger = microloggertest.New()
+		newResource, err = New(resourceConfig)
+		if err != nil {
+			t.Fatal("expected", nil, "got", err)
+		}
+	}
+
+	for i, tc := range testCases {
+		result, err := newResource.GetDesiredState(context.TODO(), tc.Obj)
+		if err != nil {
+			t.Fatalf("case %d expected %#v got %#v", i, nil, err)
+		}
+
+		deployments, ok := result.([]*v1beta1.Deployment)
+		if !ok {
+			t.Fatalf("case %d expected %T got %T", i, []*v1beta1.Deployment{}, result)
+		}
+
+		if testGetMasterCount(deployments) != tc.ExpectedMasterCount {
+			t.Fatalf("case %d expected %d master nodes got %d", i, tc.ExpectedMasterCount, testGetMasterCount(deployments))
+		}
+
+		if testGetWorkerCount(deployments) != tc.ExpectedWorkerCount {
+			t.Fatalf("case %d expected %d worker nodes got %d", i, tc.ExpectedWorkerCount, testGetWorkerCount(deployments))
+		}
+
+		if len(deployments) != tc.ExpectedMasterCount+tc.ExpectedWorkerCount {
+			t.Fatalf("case %d expected %d nodes got %d", i, tc.ExpectedMasterCount+tc.ExpectedWorkerCount, len(deployments))
+		}
+
+		for j, r := range testGetK8sMasterKVMResources(deployments) {
+			expectedCPU := tc.ExpectedMastersResources[j].Requests.Cpu()
+			if r.Requests.Cpu().Cmp(*expectedCPU) != 0 {
+				t.Fatalf("case %d expected %#v got %#v", i, expectedCPU, r.Requests.Cpu())
+			}
+			expectedMemory := tc.ExpectedMastersResources[j].Requests.Memory()
+			if r.Requests.Memory().Cmp(*expectedMemory) != 0 {
+				t.Fatalf("case %d expected %#v got %#v", i, expectedMemory, r.Requests.Memory())
+			}
+		}
+
+		for j, r := range testGetK8sWorkerKVMResources(deployments) {
+			expectedCPU := tc.ExpectedWorkersResources[j].Requests.Cpu()
+			if r.Requests.Cpu().Cmp(*expectedCPU) != 0 {
+				t.Fatalf("case %d expected %#v got %#v", i, expectedCPU, r.Requests.Cpu())
+			}
+			expectedMemory := tc.ExpectedWorkersResources[j].Requests.Memory()
+			if r.Requests.Memory().Cmp(*expectedMemory) != 0 {
+				t.Fatalf("case %d expected %#v got %#v", i, expectedMemory, r.Requests.Memory())
+			}
+		}
+	}
+}
+
+func testGetMasterCount(deployments []*v1beta1.Deployment) int {
+	return testGetCountPrefix(deployments, "master-")
+}
+
+func testGetWorkerCount(deployments []*v1beta1.Deployment) int {
+	return testGetCountPrefix(deployments, "worker-")
+}
+
+func testGetCountPrefix(deployments []*v1beta1.Deployment, prefix string) int {
+	var count int
+
+	for _, d := range deployments {
+		if strings.HasPrefix(d.Name, prefix) {
+			count++
+		}
+	}
+
+	return count
+}
+
+func testGetK8sMasterKVMResources(deployments []*v1beta1.Deployment) []apiv1.ResourceRequirements {
+	return testGetK8sKVMResourcesPrefix(deployments, "master-")
+}
+
+func testGetK8sWorkerKVMResources(deployments []*v1beta1.Deployment) []apiv1.ResourceRequirements {
+	return testGetK8sKVMResourcesPrefix(deployments, "worker-")
+}
+
+func testGetK8sKVMResourcesPrefix(deployments []*v1beta1.Deployment, prefix string) []apiv1.ResourceRequirements {
+	var rs []apiv1.ResourceRequirements
+
+	for _, d := range deployments {
+		if !strings.HasPrefix(d.Name, prefix) {
+			continue
+		}
+		for _, c := range d.Spec.Template.Spec.Containers {
+			if c.Name == "k8s-kvm" {
+				rs = append(rs, c.Resources)
+			}
+		}
+	}
+
+	return rs
+}

--- a/service/controller/v14patch1/resource/deployment/error.go
+++ b/service/controller/v14patch1/resource/deployment/error.go
@@ -1,0 +1,39 @@
+package deployment
+
+import "github.com/giantswarm/microerror"
+
+var executionFailedError = &microerror.Error{
+	Kind: "executionFailedError",
+}
+
+// IsExecutionFailed asserts executionFailedError.
+func IsExecutionFailed(err error) bool {
+	return microerror.Cause(err) == executionFailedError
+}
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var notFoundError = &microerror.Error{
+	Kind: "notFoundError",
+}
+
+// IsNotFound asserts notFoundError.
+func IsNotFound(err error) bool {
+	return microerror.Cause(err) == notFoundError
+}
+
+var wrongTypeError = &microerror.Error{
+	Kind: "wrongTypeError",
+}
+
+// IsWrongTypeError asserts wrongTypeError.
+func IsWrongTypeError(err error) bool {
+	return microerror.Cause(err) == wrongTypeError
+}

--- a/service/controller/v14patch1/resource/deployment/master_deployment.go
+++ b/service/controller/v14patch1/resource/deployment/master_deployment.go
@@ -1,0 +1,318 @@
+package deployment
+
+import (
+	"fmt"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/microerror"
+	apiv1 "k8s.io/api/core/v1"
+	extensionsv1 "k8s.io/api/extensions/v1beta1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+
+	"github.com/giantswarm/kvm-operator/service/controller/v14/key"
+)
+
+func newMasterDeployments(customObject v1alpha1.KVMConfig) ([]*extensionsv1.Deployment, error) {
+	var deployments []*extensionsv1.Deployment
+
+	privileged := true
+	replicas := int32(1)
+	podDeletionGracePeriod := int64(key.PodDeletionGracePeriod.Seconds())
+
+	for i, masterNode := range customObject.Spec.Cluster.Masters {
+		capabilities := customObject.Spec.KVM.Masters[i]
+
+		cpuQuantity, err := key.CPUQuantity(capabilities)
+		if err != nil {
+			return nil, microerror.Maskf(err, "creating CPU quantity")
+		}
+
+		memoryQuantity, err := key.MemoryQuantityMaster(capabilities)
+		if err != nil {
+			return nil, microerror.Maskf(err, "creating memory quantity")
+		}
+
+		storageType := key.StorageType(customObject)
+
+		// During migration, some TPOs do not have storage type set.
+		// This specifies a default, until all TPOs have the correct storage type set.
+		// tl;dr - this shouldn't be here. If all TPOs have storageType, remove it.
+		if storageType == "" {
+			storageType = "hostPath"
+		}
+
+		var etcdVolume apiv1.Volume
+		if storageType == "hostPath" {
+			etcdVolume = apiv1.Volume{
+				Name: "etcd-data",
+				VolumeSource: apiv1.VolumeSource{
+					HostPath: &apiv1.HostPathVolumeSource{
+						Path: key.MasterHostPathVolumeDir(key.ClusterID(customObject), key.VMNumber(i)),
+					},
+				},
+			}
+		} else if storageType == "persistentVolume" {
+			etcdVolume = apiv1.Volume{
+				Name: "etcd-data",
+				VolumeSource: apiv1.VolumeSource{
+					PersistentVolumeClaim: &apiv1.PersistentVolumeClaimVolumeSource{
+						ClaimName: key.EtcdPVCName(key.ClusterID(customObject), key.VMNumber(i)),
+					},
+				},
+			}
+		} else {
+			return nil, microerror.Maskf(wrongTypeError, "unknown storageType: '%s'", key.StorageType(customObject))
+		}
+		deployment := &extensionsv1.Deployment{
+			TypeMeta: apismetav1.TypeMeta{
+				Kind:       "deployment",
+				APIVersion: "extensions/v1beta",
+			},
+			ObjectMeta: apismetav1.ObjectMeta{
+				Name: key.DeploymentName(key.MasterID, masterNode.ID),
+				Annotations: map[string]string{
+					key.VersionBundleVersionAnnotation: key.VersionBundleVersion(customObject),
+				},
+				Labels: map[string]string{
+					"cluster":  key.ClusterID(customObject),
+					"customer": key.ClusterCustomer(customObject),
+					"app":      key.MasterID,
+					"node":     masterNode.ID,
+				},
+			},
+			Spec: extensionsv1.DeploymentSpec{
+				Strategy: extensionsv1.DeploymentStrategy{
+					Type: extensionsv1.RecreateDeploymentStrategyType,
+				},
+				Replicas: &replicas,
+				Template: apiv1.PodTemplateSpec{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Annotations: map[string]string{
+							key.AnnotationAPIEndpoint:   key.ClusterAPIEndpoint(customObject),
+							key.AnnotationIp:            "",
+							key.AnnotationService:       key.MasterID,
+							key.AnnotationPodDrained:    "False",
+							key.AnnotationVersionBundle: key.VersionBundleVersion(customObject),
+						},
+						GenerateName: key.MasterID,
+						Labels: map[string]string{
+							"app":               key.MasterID,
+							"cluster":           key.ClusterID(customObject),
+							"customer":          key.ClusterCustomer(customObject),
+							"node":              masterNode.ID,
+							key.PodWatcherLabel: "kvm-operator",
+						},
+					},
+					Spec: apiv1.PodSpec{
+						Affinity:    newMasterPodAfinity(customObject),
+						HostNetwork: true,
+						NodeSelector: map[string]string{
+							"role": key.MasterID,
+						},
+						ServiceAccountName:            key.ServiceAccountName(customObject),
+						TerminationGracePeriodSeconds: &podDeletionGracePeriod,
+						Volumes: []apiv1.Volume{
+							{
+								Name: "cloud-config",
+								VolumeSource: apiv1.VolumeSource{
+									ConfigMap: &apiv1.ConfigMapVolumeSource{
+										LocalObjectReference: apiv1.LocalObjectReference{
+											Name: key.ConfigMapName(customObject, masterNode, key.MasterID),
+										},
+									},
+								},
+							},
+							etcdVolume,
+							{
+								Name: "images",
+								VolumeSource: apiv1.VolumeSource{
+									HostPath: &apiv1.HostPathVolumeSource{
+										Path: key.CoreosImageDir,
+									},
+								},
+							},
+							{
+								Name: "rootfs",
+								VolumeSource: apiv1.VolumeSource{
+									EmptyDir: &apiv1.EmptyDirVolumeSource{},
+								},
+							},
+							{
+								Name: "flannel",
+								VolumeSource: apiv1.VolumeSource{
+									HostPath: &apiv1.HostPathVolumeSource{
+										Path: key.FlannelEnvPathPrefix,
+									},
+								},
+							},
+						},
+						Containers: []apiv1.Container{
+							{
+								Name:            "k8s-endpoint-updater",
+								Image:           key.K8SEndpointUpdaterDocker,
+								ImagePullPolicy: apiv1.PullIfNotPresent,
+								Command: []string{
+									"/bin/sh",
+									"-c",
+									"/opt/k8s-endpoint-updater update --provider.bridge.name=" + key.NetworkBridgeName(customObject) +
+										" --service.kubernetes.cluster.namespace=" + key.ClusterNamespace(customObject) +
+										" --service.kubernetes.cluster.service=" + key.MasterID +
+										" --service.kubernetes.inCluster=true" +
+										" --service.kubernetes.pod.name=${POD_NAME}",
+								},
+								SecurityContext: &apiv1.SecurityContext{
+									Privileged: &privileged,
+								},
+								Env: []apiv1.EnvVar{
+									{
+										Name: "POD_NAME",
+										ValueFrom: &apiv1.EnvVarSource{
+											FieldRef: &apiv1.ObjectFieldSelector{
+												APIVersion: "v1",
+												FieldPath:  "metadata.name",
+											},
+										},
+									},
+								},
+							},
+							{
+								Name:            "k8s-kvm",
+								Image:           key.K8SKVMDockerImage,
+								ImagePullPolicy: apiv1.PullIfNotPresent,
+								SecurityContext: &apiv1.SecurityContext{
+									Privileged: &privileged,
+								},
+								Args: []string{
+									key.MasterID,
+								},
+								Env: []apiv1.EnvVar{
+									{
+										Name:  "CORES",
+										Value: fmt.Sprintf("%d", capabilities.CPUs),
+									},
+									{
+										Name:  "COREOS_VERSION",
+										Value: key.CoreosVersion,
+									},
+									{
+										Name:  "DISK",
+										Value: fmt.Sprintf("%.0fG", capabilities.Disk),
+									},
+									{
+										Name: "HOSTNAME",
+										ValueFrom: &apiv1.EnvVarSource{
+											FieldRef: &apiv1.ObjectFieldSelector{
+												APIVersion: "v1",
+												FieldPath:  "metadata.name",
+											},
+										},
+									},
+									{
+										Name:  "NETWORK_BRIDGE_NAME",
+										Value: key.NetworkBridgeName(customObject),
+									},
+									{
+										Name:  "NETWORK_TAP_NAME",
+										Value: key.NetworkTapName(customObject),
+									},
+									{
+										Name: "MEMORY",
+										// TODO provide memory like disk as float64 and format here.
+										Value: capabilities.Memory,
+									},
+									{
+										Name:  "ROLE",
+										Value: key.MasterID,
+									},
+									{
+										Name:  "CLOUD_CONFIG_PATH",
+										Value: "/cloudconfig/user_data",
+									},
+								},
+								Lifecycle: &apiv1.Lifecycle{
+									PreStop: &apiv1.Handler{
+										Exec: &apiv1.ExecAction{
+											Command: []string{"/qemu-shutdown"},
+										},
+									},
+								},
+								LivenessProbe: &apiv1.Probe{
+									InitialDelaySeconds: key.InitialDelaySeconds,
+									TimeoutSeconds:      key.TimeoutSeconds,
+									PeriodSeconds:       key.PeriodSeconds,
+									FailureThreshold:    key.FailureThreshold,
+									SuccessThreshold:    key.SuccessThreshold,
+									Handler: apiv1.Handler{
+										HTTPGet: &apiv1.HTTPGetAction{
+											Path: key.HealthEndpoint,
+											Port: intstr.IntOrString{IntVal: key.LivenessPort(customObject)},
+											Host: key.ProbeHost,
+										},
+									},
+								},
+								Resources: apiv1.ResourceRequirements{
+									Requests: apiv1.ResourceList{
+										apiv1.ResourceCPU:    cpuQuantity,
+										apiv1.ResourceMemory: memoryQuantity,
+									},
+									Limits: map[apiv1.ResourceName]resource.Quantity{
+										apiv1.ResourceCPU:    cpuQuantity,
+										apiv1.ResourceMemory: memoryQuantity,
+									},
+								},
+								VolumeMounts: []apiv1.VolumeMount{
+									{
+										Name:      "cloud-config",
+										MountPath: "/cloudconfig/",
+									},
+									{
+										Name:      "etcd-data",
+										MountPath: "/etc/kubernetes/data/etcd/",
+									},
+									{
+										Name:      "images",
+										MountPath: "/usr/code/images/",
+									},
+									{
+										Name:      "rootfs",
+										MountPath: "/usr/code/rootfs/",
+									},
+								},
+							},
+							{
+								Name:            "k8s-kvm-health",
+								Image:           key.K8SKVMHealthDocker,
+								ImagePullPolicy: apiv1.PullAlways,
+								Env: []apiv1.EnvVar{
+									{
+										Name:  "LISTEN_ADDRESS",
+										Value: key.HealthListenAddress(customObject),
+									},
+									{
+										Name:  "NETWORK_ENV_FILE_PATH",
+										Value: key.NetworkEnvFilePath(customObject),
+									},
+								},
+								SecurityContext: &apiv1.SecurityContext{
+									Privileged: &privileged,
+								},
+								VolumeMounts: []apiv1.VolumeMount{
+									{
+										Name:      "flannel",
+										MountPath: key.FlannelEnvPathPrefix,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		deployments = append(deployments, deployment)
+	}
+
+	return deployments, nil
+}

--- a/service/controller/v14patch1/resource/deployment/master_pod_affinity.go
+++ b/service/controller/v14patch1/resource/deployment/master_pod_affinity.go
@@ -1,0 +1,38 @@
+package deployment
+
+import (
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	apiv1 "k8s.io/api/core/v1"
+	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/giantswarm/kvm-operator/service/controller/v14/key"
+)
+
+func newMasterPodAfinity(customObject v1alpha1.KVMConfig) *apiv1.Affinity {
+	podAffinity := &apiv1.Affinity{
+		PodAntiAffinity: &apiv1.PodAntiAffinity{
+			RequiredDuringSchedulingIgnoredDuringExecution: []apiv1.PodAffinityTerm{
+				{
+					LabelSelector: &apismetav1.LabelSelector{
+						MatchExpressions: []apismetav1.LabelSelectorRequirement{
+							{
+								Key:      "app",
+								Operator: apismetav1.LabelSelectorOpIn,
+								Values: []string{
+									"master",
+									"worker",
+								},
+							},
+						},
+					},
+					TopologyKey: "kubernetes.io/hostname",
+					Namespaces: []string{
+						key.ClusterID(customObject),
+					},
+				},
+			},
+		},
+	}
+
+	return podAffinity
+}

--- a/service/controller/v14patch1/resource/deployment/resource.go
+++ b/service/controller/v14patch1/resource/deployment/resource.go
@@ -1,0 +1,135 @@
+package deployment
+
+import (
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"k8s.io/api/extensions/v1beta1"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/giantswarm/kvm-operator/service/controller/v14/key"
+)
+
+const (
+	// Name is the identifier of the resource.
+	Name = "deploymentv14"
+)
+
+// Config represents the configuration used to create a new deployment resource.
+type Config struct {
+	// Dependencies.
+	K8sClient kubernetes.Interface
+	Logger    micrologger.Logger
+}
+
+// DefaultConfig provides a default configuration to create a new deployment
+// resource by best effort.
+func DefaultConfig() Config {
+	return Config{
+		// Dependencies.
+		K8sClient: nil,
+		Logger:    nil,
+	}
+}
+
+// Resource implements the deployment resource.
+type Resource struct {
+	// Dependencies.
+	k8sClient kubernetes.Interface
+	logger    micrologger.Logger
+}
+
+// New creates a new configured deployment resource.
+func New(config Config) (*Resource, error) {
+	// Dependencies.
+	if config.K8sClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "config.K8sClient must not be empty")
+	}
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "config.Logger must not be empty")
+	}
+
+	newResource := &Resource{
+		// Dependencies.
+		k8sClient: config.K8sClient,
+		logger:    config.Logger,
+	}
+
+	return newResource, nil
+}
+
+func (r *Resource) Name() string {
+	return Name
+}
+
+func allNumbersEqual(numbers ...int32) bool {
+	if len(numbers) == 0 {
+		return false
+	}
+
+	first := numbers[0]
+
+	for _, n := range numbers {
+		if n != first {
+			return false
+		}
+	}
+
+	return true
+}
+
+func containsDeployment(list []*v1beta1.Deployment, item *v1beta1.Deployment) bool {
+	for _, l := range list {
+		if l.Name == item.Name {
+			return true
+		}
+	}
+
+	return false
+}
+
+func getDeploymentByName(list []*v1beta1.Deployment, name string) (*v1beta1.Deployment, error) {
+	for _, l := range list {
+		if l.Name == name {
+			return l, nil
+		}
+	}
+
+	return nil, microerror.Mask(notFoundError)
+}
+
+func isDeploymentModified(a, b *v1beta1.Deployment) bool {
+	aVersion, ok := a.GetAnnotations()[key.VersionBundleVersionAnnotation]
+	if !ok {
+		return true
+	}
+	if aVersion == "" {
+		return true
+	}
+
+	bVersion, ok := b.GetAnnotations()[key.VersionBundleVersionAnnotation]
+	if !ok {
+		return true
+	}
+	if bVersion == "" {
+		return true
+	}
+
+	if aVersion != bVersion {
+		return true
+	}
+
+	return false
+}
+
+func toDeployments(v interface{}) ([]*v1beta1.Deployment, error) {
+	if v == nil {
+		return nil, nil
+	}
+
+	deployments, ok := v.([]*v1beta1.Deployment)
+	if !ok {
+		return nil, microerror.Maskf(wrongTypeError, "expected '%T', got '%T'", []*v1beta1.Deployment{}, v)
+	}
+
+	return deployments, nil
+}

--- a/service/controller/v14patch1/resource/deployment/update.go
+++ b/service/controller/v14patch1/resource/deployment/update.go
@@ -1,0 +1,122 @@
+package deployment
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/operatorkit/controller"
+	"github.com/giantswarm/operatorkit/controller/context/updateallowedcontext"
+	"k8s.io/api/extensions/v1beta1"
+
+	"github.com/giantswarm/kvm-operator/service/controller/v14/key"
+)
+
+func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateChange interface{}) error {
+	customObject, err := key.ToCustomObject(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	deploymentsToUpdate, err := toDeployments(updateChange)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	if len(deploymentsToUpdate) != 0 {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "updating the deployments in the Kubernetes API")
+
+		namespace := key.ClusterNamespace(customObject)
+		for _, deployment := range deploymentsToUpdate {
+			_, err := r.k8sClient.Extensions().Deployments(namespace).Update(deployment)
+			if err != nil {
+				return microerror.Mask(err)
+			}
+		}
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", "updated the deployments in the Kubernetes API")
+	} else {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "the deployments do not need to be updated in the Kubernetes API")
+	}
+
+	return nil
+}
+
+func (r *Resource) NewUpdatePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*controller.Patch, error) {
+	create, err := r.newCreateChange(ctx, obj, currentState, desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+	delete, err := r.newDeleteChangeForUpdatePatch(ctx, obj, currentState, desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+	update, err := r.newUpdateChange(ctx, obj, currentState, desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	patch := controller.NewPatch()
+	patch.SetCreateChange(create)
+	patch.SetDeleteChange(delete)
+	patch.SetUpdateChange(update)
+
+	return patch, nil
+}
+
+func (r *Resource) newUpdateChange(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, error) {
+	currentDeployments, err := toDeployments(currentState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+	desiredDeployments, err := toDeployments(desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	if updateallowedcontext.IsUpdateAllowed(ctx) {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "finding out which deployments have to be updated")
+
+		// Updates can be quite disruptive. We have to be very careful with updating
+		// resources that potentially imply disrupting customer workloads. We have
+		// to check the state of all deployments before we can safely go ahead with
+		// the update procedure.
+		for _, d := range currentDeployments {
+			allReplicasUp := allNumbersEqual(d.Status.AvailableReplicas, d.Status.ReadyReplicas, d.Status.Replicas, d.Status.UpdatedReplicas)
+			if !allReplicasUp {
+				r.logger.LogCtx(ctx, "level", "info", "message", fmt.Sprintf("cannot update any deployment: deployment '%s' must have all replicas up", d.GetName()))
+				return nil, nil
+			}
+		}
+
+		// We select one deployment to be updated per reconciliation loop. Therefore
+		// we have to check its state on the version bundle level to see if a
+		// deployment is already up to date. We also check if there are any other
+		// changes on the pod specs. In case there are none, we check the next one.
+		// The first one not being up to date will be chosen to be updated next and
+		// the loop will be broken immediatelly.
+		for _, currentDeployment := range currentDeployments {
+			desiredDeployment, err := getDeploymentByName(desiredDeployments, currentDeployment.Name)
+			if IsNotFound(err) {
+				// NOTE that this case indicates we should remove the current deployment
+				// eventually.
+				r.logger.LogCtx(ctx, "level", "warning", "message", fmt.Sprintf("not updating deployment '%s': no desired deployment found", currentDeployment.GetName()))
+				continue
+			} else if err != nil {
+				return nil, microerror.Mask(err)
+			}
+
+			if !isDeploymentModified(desiredDeployment, currentDeployment) {
+				r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("not updating deployment '%s': no changes found", currentDeployment.GetName()))
+				continue
+			}
+
+			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("found deployment '%s' that has to be updated", desiredDeployment.GetName()))
+
+			return []*v1beta1.Deployment{desiredDeployment}, nil
+		}
+	} else {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "not computing update state because deployments are not allowed to be updated")
+	}
+
+	return nil, nil
+}

--- a/service/controller/v14patch1/resource/deployment/update_test.go
+++ b/service/controller/v14patch1/resource/deployment/update_test.go
@@ -1,0 +1,1242 @@
+package deployment
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/micrologger/microloggertest"
+	"github.com/giantswarm/operatorkit/controller/context/updateallowedcontext"
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/api/extensions/v1beta1"
+	extensionsv1 "k8s.io/api/extensions/v1beta1"
+	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/giantswarm/kvm-operator/service/controller/v14/key"
+)
+
+func Test_Resource_Deployment_newUpdateChange(t *testing.T) {
+	testCases := []struct {
+		Ctx                         context.Context
+		Obj                         interface{}
+		CurrentState                interface{}
+		DesiredState                interface{}
+		ExpectedDeploymentsToUpdate []*v1beta1.Deployment
+	}{
+		// Test 0, in case current state and desired state are empty the update
+		// state should be empty.
+		{
+			Ctx: context.TODO(),
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState:                []*v1beta1.Deployment{},
+			DesiredState:                []*v1beta1.Deployment{},
+			ExpectedDeploymentsToUpdate: nil,
+		},
+
+		// Test 1, in case current state and desired state are equal the update
+		// state should be empty.
+		{
+			Ctx: context.TODO(),
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState: []*v1beta1.Deployment{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "deployment-1",
+						Annotations: map[string]string{
+							key.VersionBundleVersionAnnotation: "1.2.0",
+						},
+					},
+					Spec: extensionsv1.DeploymentSpec{
+						Template: apiv1.PodTemplateSpec{
+							Spec: apiv1.PodSpec{
+								Containers: []apiv1.Container{
+									{
+										Name: "deployment-1-container-1",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			DesiredState: []*v1beta1.Deployment{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "deployment-1",
+						Annotations: map[string]string{
+							key.VersionBundleVersionAnnotation: "1.2.0",
+						},
+					},
+					Spec: extensionsv1.DeploymentSpec{
+						Template: apiv1.PodTemplateSpec{
+							Spec: apiv1.PodSpec{
+								Containers: []apiv1.Container{
+									{
+										Name: "deployment-1-container-1",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			ExpectedDeploymentsToUpdate: nil,
+		},
+
+		// Test 2, in case current state is modified, the update state should
+		// be empty in case updates are not allowed.
+		{
+			Ctx: context.TODO(),
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState: []*v1beta1.Deployment{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "deployment-1",
+						Annotations: map[string]string{
+							key.VersionBundleVersionAnnotation: "1.2.0",
+						},
+					},
+					Spec: extensionsv1.DeploymentSpec{
+						Template: apiv1.PodTemplateSpec{
+							Spec: apiv1.PodSpec{
+								Containers: []apiv1.Container{
+									{
+										Name: "deployment-1-container-1",
+									},
+								},
+							},
+						},
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "deployment-2",
+						Annotations: map[string]string{
+							key.VersionBundleVersionAnnotation: "1.2.0",
+						},
+					},
+					Spec: extensionsv1.DeploymentSpec{
+						Template: apiv1.PodTemplateSpec{
+							Spec: apiv1.PodSpec{
+								Containers: []apiv1.Container{
+									{
+										Name: "deployment-2-container-2-modified",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			DesiredState: []*v1beta1.Deployment{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "deployment-1",
+						Annotations: map[string]string{
+							key.VersionBundleVersionAnnotation: "1.2.0",
+						},
+					},
+					Spec: extensionsv1.DeploymentSpec{
+						Template: apiv1.PodTemplateSpec{
+							Spec: apiv1.PodSpec{
+								Containers: []apiv1.Container{
+									{
+										Name: "deployment-1-container-1",
+									},
+								},
+							},
+						},
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "deployment-2",
+						Annotations: map[string]string{
+							key.VersionBundleVersionAnnotation: "1.2.0",
+						},
+					},
+					Spec: extensionsv1.DeploymentSpec{
+						Template: apiv1.PodTemplateSpec{
+							Spec: apiv1.PodSpec{
+								Containers: []apiv1.Container{
+									{
+										Name: "deployment-2-container-2",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			ExpectedDeploymentsToUpdate: nil,
+		},
+
+		// Test 3, is the same as 2 but with the version bundle version being
+		// changed.
+		{
+			Ctx: func() context.Context {
+				ctx := context.Background()
+
+				{
+					ctx = updateallowedcontext.NewContext(ctx, make(chan struct{}))
+					updateallowedcontext.SetUpdateAllowed(ctx)
+				}
+
+				return ctx
+			}(),
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState: []*v1beta1.Deployment{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "deployment-1",
+						Annotations: map[string]string{
+							key.VersionBundleVersionAnnotation: "1.2.0",
+						},
+					},
+					Spec: extensionsv1.DeploymentSpec{
+						Template: apiv1.PodTemplateSpec{
+							Spec: apiv1.PodSpec{
+								Containers: []apiv1.Container{
+									{
+										Name: "deployment-1-container-1",
+									},
+								},
+							},
+						},
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "deployment-2",
+						Annotations: map[string]string{
+							key.VersionBundleVersionAnnotation: "1.1.0",
+						},
+					},
+					Spec: extensionsv1.DeploymentSpec{
+						Template: apiv1.PodTemplateSpec{
+							Spec: apiv1.PodSpec{
+								Containers: []apiv1.Container{
+									{
+										Name: "deployment-2-container-2",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			DesiredState: []*v1beta1.Deployment{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "deployment-1",
+						Annotations: map[string]string{
+							key.VersionBundleVersionAnnotation: "1.2.0",
+						},
+					},
+					Spec: extensionsv1.DeploymentSpec{
+						Template: apiv1.PodTemplateSpec{
+							Spec: apiv1.PodSpec{
+								Containers: []apiv1.Container{
+									{
+										Name: "deployment-1-container-1",
+									},
+								},
+							},
+						},
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "deployment-2",
+						Annotations: map[string]string{
+							key.VersionBundleVersionAnnotation: "1.2.0",
+						},
+					},
+					Spec: extensionsv1.DeploymentSpec{
+						Template: apiv1.PodTemplateSpec{
+							Spec: apiv1.PodSpec{
+								Containers: []apiv1.Container{
+									{
+										Name: "deployment-2-container-2",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			ExpectedDeploymentsToUpdate: []*v1beta1.Deployment{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "deployment-2",
+						Annotations: map[string]string{
+							key.VersionBundleVersionAnnotation: "1.2.0",
+						},
+					},
+					Spec: extensionsv1.DeploymentSpec{
+						Template: apiv1.PodTemplateSpec{
+							Spec: apiv1.PodSpec{
+								Containers: []apiv1.Container{
+									{
+										Name: "deployment-2-container-2",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+
+		// Test 4, is the same as 4 but with the version bundle version being
+		// changed.
+		{
+			Ctx: func() context.Context {
+				ctx := context.Background()
+
+				{
+					ctx = updateallowedcontext.NewContext(ctx, make(chan struct{}))
+					updateallowedcontext.SetUpdateAllowed(ctx)
+				}
+
+				return ctx
+			}(),
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState: []*v1beta1.Deployment{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "deployment-1",
+						Annotations: map[string]string{
+							key.VersionBundleVersionAnnotation: "1.2.0",
+						},
+					},
+					Spec: extensionsv1.DeploymentSpec{
+						Template: apiv1.PodTemplateSpec{
+							Spec: apiv1.PodSpec{
+								Containers: []apiv1.Container{
+									{
+										Name: "deployment-1-container-1",
+									},
+								},
+							},
+						},
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "deployment-2",
+						Annotations: map[string]string{
+							key.VersionBundleVersionAnnotation: "1.2.0",
+						},
+					},
+					Spec: extensionsv1.DeploymentSpec{
+						Template: apiv1.PodTemplateSpec{
+							Spec: apiv1.PodSpec{
+								Containers: []apiv1.Container{
+									{
+										Name: "deployment-2-container-2",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			DesiredState: []*v1beta1.Deployment{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "deployment-1",
+						Annotations: map[string]string{
+							key.VersionBundleVersionAnnotation: "1.2.0",
+						},
+					},
+					Spec: extensionsv1.DeploymentSpec{
+						Template: apiv1.PodTemplateSpec{
+							Spec: apiv1.PodSpec{
+								Containers: []apiv1.Container{
+									{
+										Name: "deployment-1-container-1",
+									},
+								},
+							},
+						},
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "deployment-2",
+						Annotations: map[string]string{
+							key.VersionBundleVersionAnnotation: "1.3.0",
+						},
+					},
+					Spec: extensionsv1.DeploymentSpec{
+						Template: apiv1.PodTemplateSpec{
+							Spec: apiv1.PodSpec{
+								Containers: []apiv1.Container{
+									{
+										Name: "deployment-2-container-2",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			ExpectedDeploymentsToUpdate: []*v1beta1.Deployment{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "deployment-2",
+						Annotations: map[string]string{
+							key.VersionBundleVersionAnnotation: "1.3.0",
+						},
+					},
+					Spec: extensionsv1.DeploymentSpec{
+						Template: apiv1.PodTemplateSpec{
+							Spec: apiv1.PodSpec{
+								Containers: []apiv1.Container{
+									{
+										Name: "deployment-2-container-2",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+
+		// Test 5, when deployments should be updaated but their status is not "safe",
+		// the update state should be empty.
+		{
+			Ctx: func() context.Context {
+				ctx := context.Background()
+
+				{
+					ctx = updateallowedcontext.NewContext(ctx, make(chan struct{}))
+					updateallowedcontext.SetUpdateAllowed(ctx)
+				}
+
+				return ctx
+			}(),
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState: []*v1beta1.Deployment{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "deployment-1",
+						Annotations: map[string]string{
+							key.VersionBundleVersionAnnotation: "1.2.0",
+						},
+					},
+					Spec: extensionsv1.DeploymentSpec{
+						Template: apiv1.PodTemplateSpec{
+							Spec: apiv1.PodSpec{
+								Containers: []apiv1.Container{
+									{
+										Name: "deployment-1-container-1",
+									},
+								},
+							},
+						},
+					},
+					Status: extensionsv1.DeploymentStatus{
+						AvailableReplicas: 1,
+						ReadyReplicas:     2,
+						Replicas:          2,
+						UpdatedReplicas:   2,
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "deployment-2",
+						Annotations: map[string]string{
+							key.VersionBundleVersionAnnotation: "1.2.0",
+						},
+					},
+					Spec: extensionsv1.DeploymentSpec{
+						Template: apiv1.PodTemplateSpec{
+							Spec: apiv1.PodSpec{
+								Containers: []apiv1.Container{
+									{
+										Name: "deployment-2-container-2",
+									},
+								},
+							},
+						},
+					},
+					Status: extensionsv1.DeploymentStatus{
+						AvailableReplicas: 1,
+						ReadyReplicas:     2,
+						Replicas:          2,
+						UpdatedReplicas:   2,
+					},
+				},
+			},
+			DesiredState: []*v1beta1.Deployment{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "deployment-1",
+						Annotations: map[string]string{
+							key.VersionBundleVersionAnnotation: "1.3.0",
+						},
+					},
+					Spec: extensionsv1.DeploymentSpec{
+						Template: apiv1.PodTemplateSpec{
+							Spec: apiv1.PodSpec{
+								Containers: []apiv1.Container{
+									{
+										Name: "deployment-1-container-1",
+									},
+								},
+							},
+						},
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "deployment-2",
+						Annotations: map[string]string{
+							key.VersionBundleVersionAnnotation: "1.3.0",
+						},
+					},
+					Spec: extensionsv1.DeploymentSpec{
+						Template: apiv1.PodTemplateSpec{
+							Spec: apiv1.PodSpec{
+								Containers: []apiv1.Container{
+									{
+										Name: "deployment-2-container-2",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			ExpectedDeploymentsToUpdate: nil,
+		},
+
+		// Test 6, is the same as 5 but with only one deployment not being "safe".
+		{
+			Ctx: func() context.Context {
+				ctx := context.Background()
+
+				{
+					ctx = updateallowedcontext.NewContext(ctx, make(chan struct{}))
+					updateallowedcontext.SetUpdateAllowed(ctx)
+				}
+
+				return ctx
+			}(),
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState: []*v1beta1.Deployment{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "deployment-1",
+						Annotations: map[string]string{
+							key.VersionBundleVersionAnnotation: "1.2.0",
+						},
+					},
+					Spec: extensionsv1.DeploymentSpec{
+						Template: apiv1.PodTemplateSpec{
+							Spec: apiv1.PodSpec{
+								Containers: []apiv1.Container{
+									{
+										Name: "deployment-1-container-1",
+									},
+								},
+							},
+						},
+					},
+					Status: extensionsv1.DeploymentStatus{
+						AvailableReplicas: 1,
+						ReadyReplicas:     2,
+						Replicas:          2,
+						UpdatedReplicas:   2,
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "deployment-2",
+						Annotations: map[string]string{
+							key.VersionBundleVersionAnnotation: "1.2.0",
+						},
+					},
+					Spec: extensionsv1.DeploymentSpec{
+						Template: apiv1.PodTemplateSpec{
+							Spec: apiv1.PodSpec{
+								Containers: []apiv1.Container{
+									{
+										Name: "deployment-2-container-2",
+									},
+								},
+							},
+						},
+					},
+					Status: extensionsv1.DeploymentStatus{
+						AvailableReplicas: 2,
+						ReadyReplicas:     2,
+						Replicas:          2,
+						UpdatedReplicas:   2,
+					},
+				},
+			},
+			DesiredState: []*v1beta1.Deployment{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "deployment-1",
+						Annotations: map[string]string{
+							key.VersionBundleVersionAnnotation: "1.3.0",
+						},
+					},
+					Spec: extensionsv1.DeploymentSpec{
+						Template: apiv1.PodTemplateSpec{
+							Spec: apiv1.PodSpec{
+								Containers: []apiv1.Container{
+									{
+										Name: "deployment-1-container-1",
+									},
+								},
+							},
+						},
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "deployment-2",
+						Annotations: map[string]string{
+							key.VersionBundleVersionAnnotation: "1.3.0",
+						},
+					},
+					Spec: extensionsv1.DeploymentSpec{
+						Template: apiv1.PodTemplateSpec{
+							Spec: apiv1.PodSpec{
+								Containers: []apiv1.Container{
+									{
+										Name: "deployment-2-container-2",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			ExpectedDeploymentsToUpdate: nil,
+		},
+
+		// Test 7, when all deployments are "safe" the update state should only
+		// contain one deployment even though if multiple deployments should be
+		// updated.
+		{
+			Ctx: func() context.Context {
+				ctx := context.Background()
+
+				{
+					ctx = updateallowedcontext.NewContext(ctx, make(chan struct{}))
+					updateallowedcontext.SetUpdateAllowed(ctx)
+				}
+
+				return ctx
+			}(),
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState: []*v1beta1.Deployment{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "deployment-1",
+						Annotations: map[string]string{
+							key.VersionBundleVersionAnnotation: "1.2.0",
+						},
+					},
+					Spec: extensionsv1.DeploymentSpec{
+						Template: apiv1.PodTemplateSpec{
+							Spec: apiv1.PodSpec{
+								Containers: []apiv1.Container{
+									{
+										Name: "deployment-1-container-1",
+									},
+								},
+							},
+						},
+					},
+					Status: extensionsv1.DeploymentStatus{
+						AvailableReplicas: 2,
+						ReadyReplicas:     2,
+						Replicas:          2,
+						UpdatedReplicas:   2,
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "deployment-2",
+						Annotations: map[string]string{
+							key.VersionBundleVersionAnnotation: "1.2.0",
+						},
+					},
+					Spec: extensionsv1.DeploymentSpec{
+						Template: apiv1.PodTemplateSpec{
+							Spec: apiv1.PodSpec{
+								Containers: []apiv1.Container{
+									{
+										Name: "deployment-2-container-2",
+									},
+								},
+							},
+						},
+					},
+					Status: extensionsv1.DeploymentStatus{
+						AvailableReplicas: 2,
+						ReadyReplicas:     2,
+						Replicas:          2,
+						UpdatedReplicas:   2,
+					},
+				},
+			},
+			DesiredState: []*v1beta1.Deployment{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "deployment-1",
+						Annotations: map[string]string{
+							key.VersionBundleVersionAnnotation: "1.3.0",
+						},
+					},
+					Spec: extensionsv1.DeploymentSpec{
+						Template: apiv1.PodTemplateSpec{
+							Spec: apiv1.PodSpec{
+								Containers: []apiv1.Container{
+									{
+										Name: "deployment-1-container-1",
+									},
+								},
+							},
+						},
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "deployment-2",
+						Annotations: map[string]string{
+							key.VersionBundleVersionAnnotation: "1.3.0",
+						},
+					},
+					Spec: extensionsv1.DeploymentSpec{
+						Template: apiv1.PodTemplateSpec{
+							Spec: apiv1.PodSpec{
+								Containers: []apiv1.Container{
+									{
+										Name: "deployment-2-container-2",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			ExpectedDeploymentsToUpdate: []*v1beta1.Deployment{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "deployment-1",
+						Annotations: map[string]string{
+							key.VersionBundleVersionAnnotation: "1.3.0",
+						},
+					},
+					Spec: extensionsv1.DeploymentSpec{
+						Template: apiv1.PodTemplateSpec{
+							Spec: apiv1.PodSpec{
+								Containers: []apiv1.Container{
+									{
+										Name: "deployment-1-container-1",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+
+		// Test 8, is based of 7 where the next deployment is ready to be updated.
+		{
+			Ctx: func() context.Context {
+				ctx := context.Background()
+
+				{
+					ctx = updateallowedcontext.NewContext(ctx, make(chan struct{}))
+					updateallowedcontext.SetUpdateAllowed(ctx)
+				}
+
+				return ctx
+			}(),
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState: []*v1beta1.Deployment{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "deployment-1",
+						Annotations: map[string]string{
+							key.VersionBundleVersionAnnotation: "1.3.0",
+						},
+					},
+					Spec: extensionsv1.DeploymentSpec{
+						Template: apiv1.PodTemplateSpec{
+							Spec: apiv1.PodSpec{
+								Containers: []apiv1.Container{
+									{
+										Name: "deployment-1-container-1",
+									},
+								},
+							},
+						},
+					},
+					Status: extensionsv1.DeploymentStatus{
+						AvailableReplicas: 2,
+						ReadyReplicas:     2,
+						Replicas:          2,
+						UpdatedReplicas:   2,
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "deployment-2",
+						Annotations: map[string]string{
+							key.VersionBundleVersionAnnotation: "1.2.0",
+						},
+					},
+					Spec: extensionsv1.DeploymentSpec{
+						Template: apiv1.PodTemplateSpec{
+							Spec: apiv1.PodSpec{
+								Containers: []apiv1.Container{
+									{
+										Name: "deployment-2-container-2",
+									},
+								},
+							},
+						},
+					},
+					Status: extensionsv1.DeploymentStatus{
+						AvailableReplicas: 2,
+						ReadyReplicas:     2,
+						Replicas:          2,
+						UpdatedReplicas:   2,
+					},
+				},
+			},
+			DesiredState: []*v1beta1.Deployment{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "deployment-1",
+						Annotations: map[string]string{
+							key.VersionBundleVersionAnnotation: "1.3.0",
+						},
+					},
+					Spec: extensionsv1.DeploymentSpec{
+						Template: apiv1.PodTemplateSpec{
+							Spec: apiv1.PodSpec{
+								Containers: []apiv1.Container{
+									{
+										Name: "deployment-1-container-1",
+									},
+								},
+							},
+						},
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "deployment-2",
+						Annotations: map[string]string{
+							key.VersionBundleVersionAnnotation: "1.3.0",
+						},
+					},
+					Spec: extensionsv1.DeploymentSpec{
+						Template: apiv1.PodTemplateSpec{
+							Spec: apiv1.PodSpec{
+								Containers: []apiv1.Container{
+									{
+										Name: "deployment-2-container-2",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			ExpectedDeploymentsToUpdate: []*v1beta1.Deployment{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "deployment-2",
+						Annotations: map[string]string{
+							key.VersionBundleVersionAnnotation: "1.3.0",
+						},
+					},
+					Spec: extensionsv1.DeploymentSpec{
+						Template: apiv1.PodTemplateSpec{
+							Spec: apiv1.PodSpec{
+								Containers: []apiv1.Container{
+									{
+										Name: "deployment-2-container-2",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+
+		// Test 9, is the same as 8 but ensures the update behaviour is preserved
+		// even if no version bundle version annotation is present in the current
+		// state.
+		{
+			Ctx: func() context.Context {
+				ctx := context.Background()
+
+				{
+					ctx = updateallowedcontext.NewContext(ctx, make(chan struct{}))
+					updateallowedcontext.SetUpdateAllowed(ctx)
+				}
+
+				return ctx
+			}(),
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState: []*v1beta1.Deployment{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "deployment-1",
+						Annotations: map[string]string{
+							key.VersionBundleVersionAnnotation: "1.3.0",
+						},
+					},
+					Spec: extensionsv1.DeploymentSpec{
+						Template: apiv1.PodTemplateSpec{
+							Spec: apiv1.PodSpec{
+								Containers: []apiv1.Container{
+									{
+										Name: "deployment-1-container-1",
+									},
+								},
+							},
+						},
+					},
+					Status: extensionsv1.DeploymentStatus{
+						AvailableReplicas: 2,
+						ReadyReplicas:     2,
+						Replicas:          2,
+						UpdatedReplicas:   2,
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "deployment-2",
+					},
+					Spec: extensionsv1.DeploymentSpec{
+						Template: apiv1.PodTemplateSpec{
+							Spec: apiv1.PodSpec{
+								Containers: []apiv1.Container{
+									{
+										Name: "deployment-2-container-2",
+									},
+								},
+							},
+						},
+					},
+					Status: extensionsv1.DeploymentStatus{
+						AvailableReplicas: 2,
+						ReadyReplicas:     2,
+						Replicas:          2,
+						UpdatedReplicas:   2,
+					},
+				},
+			},
+			DesiredState: []*v1beta1.Deployment{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "deployment-1",
+						Annotations: map[string]string{
+							key.VersionBundleVersionAnnotation: "1.3.0",
+						},
+					},
+					Spec: extensionsv1.DeploymentSpec{
+						Template: apiv1.PodTemplateSpec{
+							Spec: apiv1.PodSpec{
+								Containers: []apiv1.Container{
+									{
+										Name: "deployment-1-container-1",
+									},
+								},
+							},
+						},
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "deployment-2",
+						Annotations: map[string]string{
+							key.VersionBundleVersionAnnotation: "1.3.0",
+						},
+					},
+					Spec: extensionsv1.DeploymentSpec{
+						Template: apiv1.PodTemplateSpec{
+							Spec: apiv1.PodSpec{
+								Containers: []apiv1.Container{
+									{
+										Name: "deployment-2-container-2",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			ExpectedDeploymentsToUpdate: []*v1beta1.Deployment{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "deployment-2",
+						Annotations: map[string]string{
+							key.VersionBundleVersionAnnotation: "1.3.0",
+						},
+					},
+					Spec: extensionsv1.DeploymentSpec{
+						Template: apiv1.PodTemplateSpec{
+							Spec: apiv1.PodSpec{
+								Containers: []apiv1.Container{
+									{
+										Name: "deployment-2-container-2",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+
+		// Test 10, is the same as 9 but with an empty version bundle version
+		// annotation.
+		{
+			Ctx: func() context.Context {
+				ctx := context.Background()
+
+				{
+					ctx = updateallowedcontext.NewContext(ctx, make(chan struct{}))
+					updateallowedcontext.SetUpdateAllowed(ctx)
+				}
+
+				return ctx
+			}(),
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState: []*v1beta1.Deployment{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "deployment-1",
+						Annotations: map[string]string{
+							key.VersionBundleVersionAnnotation: "1.3.0",
+						},
+					},
+					Spec: extensionsv1.DeploymentSpec{
+						Template: apiv1.PodTemplateSpec{
+							Spec: apiv1.PodSpec{
+								Containers: []apiv1.Container{
+									{
+										Name: "deployment-1-container-1",
+									},
+								},
+							},
+						},
+					},
+					Status: extensionsv1.DeploymentStatus{
+						AvailableReplicas: 2,
+						ReadyReplicas:     2,
+						Replicas:          2,
+						UpdatedReplicas:   2,
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "deployment-2",
+						Annotations: map[string]string{
+							key.VersionBundleVersionAnnotation: "",
+						},
+					},
+					Spec: extensionsv1.DeploymentSpec{
+						Template: apiv1.PodTemplateSpec{
+							Spec: apiv1.PodSpec{
+								Containers: []apiv1.Container{
+									{
+										Name: "deployment-2-container-2",
+									},
+								},
+							},
+						},
+					},
+					Status: extensionsv1.DeploymentStatus{
+						AvailableReplicas: 2,
+						ReadyReplicas:     2,
+						Replicas:          2,
+						UpdatedReplicas:   2,
+					},
+				},
+			},
+			DesiredState: []*v1beta1.Deployment{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "deployment-1",
+						Annotations: map[string]string{
+							key.VersionBundleVersionAnnotation: "1.3.0",
+						},
+					},
+					Spec: extensionsv1.DeploymentSpec{
+						Template: apiv1.PodTemplateSpec{
+							Spec: apiv1.PodSpec{
+								Containers: []apiv1.Container{
+									{
+										Name: "deployment-1-container-1",
+									},
+								},
+							},
+						},
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "deployment-2",
+						Annotations: map[string]string{
+							key.VersionBundleVersionAnnotation: "1.3.0",
+						},
+					},
+					Spec: extensionsv1.DeploymentSpec{
+						Template: apiv1.PodTemplateSpec{
+							Spec: apiv1.PodSpec{
+								Containers: []apiv1.Container{
+									{
+										Name: "deployment-2-container-2",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			ExpectedDeploymentsToUpdate: []*v1beta1.Deployment{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "deployment-2",
+						Annotations: map[string]string{
+							key.VersionBundleVersionAnnotation: "1.3.0",
+						},
+					},
+					Spec: extensionsv1.DeploymentSpec{
+						Template: apiv1.PodTemplateSpec{
+							Spec: apiv1.PodSpec{
+								Containers: []apiv1.Container{
+									{
+										Name: "deployment-2-container-2",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	var err error
+	var newResource *Resource
+	{
+		resourceConfig := DefaultConfig()
+		resourceConfig.K8sClient = fake.NewSimpleClientset()
+		resourceConfig.Logger = microloggertest.New()
+		newResource, err = New(resourceConfig)
+		if err != nil {
+			t.Fatal("expected", nil, "got", err)
+		}
+	}
+
+	for _, tc := range testCases {
+		updateState, err := newResource.newUpdateChange(tc.Ctx, tc.Obj, tc.CurrentState, tc.DesiredState)
+		if err != nil {
+			t.Fatalf("expected %#v got %#v", nil, err)
+		}
+
+		t.Run("deploymentsToUpdate", func(t *testing.T) {
+			if tc.ExpectedDeploymentsToUpdate == nil {
+				if updateState != nil {
+					t.Fatalf("expected %#v got %#v", nil, updateState)
+				}
+			} else {
+				deploymentsToUpdate, ok := updateState.([]*v1beta1.Deployment)
+				if !ok {
+					t.Fatalf("expected %T got %T", []*v1beta1.Deployment{}, updateState)
+				}
+				if !reflect.DeepEqual(deploymentsToUpdate, tc.ExpectedDeploymentsToUpdate) {
+					t.Fatalf("expected %#v got %#v", tc.ExpectedDeploymentsToUpdate, deploymentsToUpdate)
+				}
+			}
+		})
+	}
+}

--- a/service/controller/v14patch1/resource/deployment/worker_deployment.go
+++ b/service/controller/v14patch1/resource/deployment/worker_deployment.go
@@ -1,0 +1,282 @@
+package deployment
+
+import (
+	"fmt"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/microerror"
+	apiv1 "k8s.io/api/core/v1"
+	extensionsv1 "k8s.io/api/extensions/v1beta1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+
+	"github.com/giantswarm/kvm-operator/service/controller/v14/key"
+)
+
+func newWorkerDeployments(customObject v1alpha1.KVMConfig) ([]*extensionsv1.Deployment, error) {
+	var deployments []*extensionsv1.Deployment
+
+	privileged := true
+	replicas := int32(1)
+	podDeletionGracePeriod := int64(key.PodDeletionGracePeriod.Seconds())
+
+	for i, workerNode := range customObject.Spec.Cluster.Workers {
+		capabilities := customObject.Spec.KVM.Workers[i]
+
+		cpuQuantity, err := key.CPUQuantity(capabilities)
+		if err != nil {
+			return nil, microerror.Maskf(err, "creating CPU quantity")
+		}
+
+		memoryQuantity, err := key.MemoryQuantityWorker(capabilities)
+		if err != nil {
+			return nil, microerror.Maskf(err, "creating memory quantity")
+		}
+
+		deployment := &extensionsv1.Deployment{
+			TypeMeta: apismetav1.TypeMeta{
+				Kind:       "deployment",
+				APIVersion: "extensions/v1beta",
+			},
+			ObjectMeta: apismetav1.ObjectMeta{
+				Name: key.DeploymentName(key.WorkerID, workerNode.ID),
+				Annotations: map[string]string{
+					key.VersionBundleVersionAnnotation: key.VersionBundleVersion(customObject),
+				},
+				Labels: map[string]string{
+					"app":      key.WorkerID,
+					"cluster":  key.ClusterID(customObject),
+					"customer": key.ClusterCustomer(customObject),
+					"node":     workerNode.ID,
+				},
+			},
+			Spec: extensionsv1.DeploymentSpec{
+				Strategy: extensionsv1.DeploymentStrategy{
+					Type: extensionsv1.RecreateDeploymentStrategyType,
+				},
+				Replicas: &replicas,
+				Template: apiv1.PodTemplateSpec{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Annotations: map[string]string{
+							key.AnnotationAPIEndpoint:   key.ClusterAPIEndpoint(customObject),
+							key.AnnotationIp:            "",
+							key.AnnotationService:       key.WorkerID,
+							key.AnnotationPodDrained:    "False",
+							key.AnnotationVersionBundle: key.VersionBundleVersion(customObject),
+						},
+						Name: key.WorkerID,
+						Labels: map[string]string{
+							"cluster":           key.ClusterID(customObject),
+							"customer":          key.ClusterCustomer(customObject),
+							"app":               key.WorkerID,
+							"node":              workerNode.ID,
+							key.PodWatcherLabel: "kvm-operator",
+						},
+					},
+					Spec: apiv1.PodSpec{
+						Affinity:    newWorkerPodAfinity(customObject),
+						HostNetwork: true,
+						NodeSelector: map[string]string{
+							"role": key.WorkerID,
+						},
+						ServiceAccountName:            key.ServiceAccountName(customObject),
+						TerminationGracePeriodSeconds: &podDeletionGracePeriod,
+						Volumes: []apiv1.Volume{
+							{
+								Name: "cloud-config",
+								VolumeSource: apiv1.VolumeSource{
+									ConfigMap: &apiv1.ConfigMapVolumeSource{
+										LocalObjectReference: apiv1.LocalObjectReference{
+											Name: key.ConfigMapName(customObject, workerNode, key.WorkerID),
+										},
+									},
+								},
+							},
+							{
+								Name: "images",
+								VolumeSource: apiv1.VolumeSource{
+									HostPath: &apiv1.HostPathVolumeSource{
+										Path: key.CoreosImageDir,
+									},
+								},
+							},
+							{
+								Name: "rootfs",
+								VolumeSource: apiv1.VolumeSource{
+									EmptyDir: &apiv1.EmptyDirVolumeSource{},
+								},
+							},
+							{
+								Name: "flannel",
+								VolumeSource: apiv1.VolumeSource{
+									HostPath: &apiv1.HostPathVolumeSource{
+										Path: key.FlannelEnvPathPrefix,
+									},
+								},
+							},
+						},
+						Containers: []apiv1.Container{
+							{
+								Name:            "k8s-endpoint-updater",
+								Image:           key.K8SEndpointUpdaterDocker,
+								ImagePullPolicy: apiv1.PullIfNotPresent,
+								Command: []string{
+									"/bin/sh",
+									"-c",
+									"/opt/k8s-endpoint-updater update --provider.bridge.name=" + key.NetworkBridgeName(customObject) +
+										" --service.kubernetes.cluster.namespace=" + key.ClusterNamespace(customObject) +
+										" --service.kubernetes.cluster.service=" + key.WorkerID +
+										" --service.kubernetes.inCluster=true" +
+										" --service.kubernetes.pod.name=${POD_NAME}",
+								},
+								SecurityContext: &apiv1.SecurityContext{
+									Privileged: &privileged,
+								},
+								Env: []apiv1.EnvVar{
+									{
+										Name: "POD_NAME",
+										ValueFrom: &apiv1.EnvVarSource{
+											FieldRef: &apiv1.ObjectFieldSelector{
+												APIVersion: "v1",
+												FieldPath:  "metadata.name",
+											},
+										},
+									},
+								},
+							},
+							{
+								Name:            "k8s-kvm",
+								Image:           key.K8SKVMDockerImage,
+								ImagePullPolicy: apiv1.PullIfNotPresent,
+								SecurityContext: &apiv1.SecurityContext{
+									Privileged: &privileged,
+								},
+								Args: []string{
+									key.WorkerID,
+								},
+								Env: []apiv1.EnvVar{
+									{
+										Name:  "CORES",
+										Value: fmt.Sprintf("%d", capabilities.CPUs),
+									},
+									{
+										Name:  "COREOS_VERSION",
+										Value: key.CoreosVersion,
+									},
+									{
+										Name:  "DISK",
+										Value: fmt.Sprintf("%.0fG", capabilities.Disk),
+									},
+									{
+										Name: "HOSTNAME",
+										ValueFrom: &apiv1.EnvVarSource{
+											FieldRef: &apiv1.ObjectFieldSelector{
+												APIVersion: "v1",
+												FieldPath:  "metadata.name",
+											},
+										},
+									},
+									{
+										Name:  "NETWORK_BRIDGE_NAME",
+										Value: key.NetworkBridgeName(customObject),
+									},
+									{
+										Name:  "NETWORK_TAP_NAME",
+										Value: key.NetworkTapName(customObject),
+									},
+									{
+										Name: "MEMORY",
+										// TODO provide memory like disk as float64 and format here.
+										Value: capabilities.Memory,
+									},
+									{
+										Name:  "ROLE",
+										Value: key.WorkerID,
+									},
+									{
+										Name:  "CLOUD_CONFIG_PATH",
+										Value: "/cloudconfig/user_data",
+									},
+								},
+								Lifecycle: &apiv1.Lifecycle{
+									PreStop: &apiv1.Handler{
+										Exec: &apiv1.ExecAction{
+											Command: []string{"/qemu-shutdown"},
+										},
+									},
+								},
+								LivenessProbe: &apiv1.Probe{
+									InitialDelaySeconds: key.InitialDelaySeconds,
+									TimeoutSeconds:      key.TimeoutSeconds,
+									PeriodSeconds:       key.PeriodSeconds,
+									FailureThreshold:    key.FailureThreshold,
+									SuccessThreshold:    key.SuccessThreshold,
+									Handler: apiv1.Handler{
+										HTTPGet: &apiv1.HTTPGetAction{
+											Path: key.HealthEndpoint,
+											Port: intstr.IntOrString{IntVal: key.LivenessPort(customObject)},
+											Host: key.ProbeHost,
+										},
+									},
+								},
+								Resources: apiv1.ResourceRequirements{
+									Requests: map[apiv1.ResourceName]resource.Quantity{
+										apiv1.ResourceCPU:    cpuQuantity,
+										apiv1.ResourceMemory: memoryQuantity,
+									},
+									Limits: map[apiv1.ResourceName]resource.Quantity{
+										apiv1.ResourceCPU:    cpuQuantity,
+										apiv1.ResourceMemory: memoryQuantity,
+									},
+								},
+								VolumeMounts: []apiv1.VolumeMount{
+									{
+										Name:      "cloud-config",
+										MountPath: "/cloudconfig/",
+									},
+									{
+										Name:      "images",
+										MountPath: "/usr/code/images/",
+									},
+									{
+										Name:      "rootfs",
+										MountPath: "/usr/code/rootfs/",
+									},
+								},
+							},
+							{
+								Name:            "k8s-kvm-health",
+								Image:           key.K8SKVMHealthDocker,
+								ImagePullPolicy: apiv1.PullAlways,
+								Env: []apiv1.EnvVar{
+									{
+										Name:  "LISTEN_ADDRESS",
+										Value: key.HealthListenAddress(customObject),
+									},
+									{
+										Name:  "NETWORK_ENV_FILE_PATH",
+										Value: key.NetworkEnvFilePath(customObject),
+									},
+								},
+								SecurityContext: &apiv1.SecurityContext{
+									Privileged: &privileged,
+								},
+								VolumeMounts: []apiv1.VolumeMount{
+									{
+										Name:      "flannel",
+										MountPath: key.FlannelEnvPathPrefix,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		deployments = append(deployments, deployment)
+	}
+
+	return deployments, nil
+}

--- a/service/controller/v14patch1/resource/deployment/worker_pod_affinity.go
+++ b/service/controller/v14patch1/resource/deployment/worker_pod_affinity.go
@@ -1,0 +1,38 @@
+package deployment
+
+import (
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	apiv1 "k8s.io/api/core/v1"
+	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/giantswarm/kvm-operator/service/controller/v14/key"
+)
+
+func newWorkerPodAfinity(customObject v1alpha1.KVMConfig) *apiv1.Affinity {
+	podAffinity := &apiv1.Affinity{
+		PodAntiAffinity: &apiv1.PodAntiAffinity{
+			RequiredDuringSchedulingIgnoredDuringExecution: []apiv1.PodAffinityTerm{
+				{
+					LabelSelector: &apismetav1.LabelSelector{
+						MatchExpressions: []apismetav1.LabelSelectorRequirement{
+							{
+								Key:      "app",
+								Operator: apismetav1.LabelSelectorOpIn,
+								Values: []string{
+									"master",
+									"worker",
+								},
+							},
+						},
+					},
+					TopologyKey: "kubernetes.io/hostname",
+					Namespaces: []string{
+						key.ClusterID(customObject),
+					},
+				},
+			},
+		},
+	}
+
+	return podAffinity
+}

--- a/service/controller/v14patch1/resource/endpoint/create.go
+++ b/service/controller/v14patch1/resource/endpoint/create.go
@@ -1,0 +1,72 @@
+package endpoint
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/giantswarm/microerror"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+)
+
+func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createState interface{}) error {
+	endpointToCreate, err := toK8sEndpoint(createState)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	if !isEmptyEndpoint(*endpointToCreate) {
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("creating endpoint '%s'", endpointToCreate.GetName()))
+
+		_, err = r.k8sClient.CoreV1().Endpoints(endpointToCreate.Namespace).Create(endpointToCreate)
+		if errors.IsAlreadyExists(err) {
+			// fall through
+		} else if err != nil {
+			return microerror.Mask(err)
+		}
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("created endpoint '%s'", endpointToCreate.GetName()))
+	} else {
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("not creating endpoint '%s'", endpointToCreate.GetName()))
+	}
+
+	return nil
+}
+
+func (r *Resource) newCreateChange(ctx context.Context, obj, currentState, desiredState interface{}) (*corev1.Endpoints, error) {
+	currentEndpoint, err := toEndpoint(currentState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+	desiredEndpoint, err := toEndpoint(desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	var createChange *corev1.Endpoints
+	{
+		var ips []string
+		for _, ip := range desiredEndpoint.IPs {
+			if !containsIP(ips, ip) {
+				ips = append(ips, ip)
+			}
+		}
+
+		endpoint := &Endpoint{
+			IPs:              []string{},
+			ServiceName:      desiredEndpoint.ServiceName,
+			ServiceNamespace: desiredEndpoint.ServiceNamespace,
+		}
+
+		if len(currentEndpoint.IPs) == 0 {
+			endpoint.IPs = ips
+		}
+
+		createChange, err = r.newK8sEndpoint(endpoint)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	return createChange, nil
+}

--- a/service/controller/v14patch1/resource/endpoint/create_test.go
+++ b/service/controller/v14patch1/resource/endpoint/create_test.go
@@ -1,0 +1,244 @@
+package endpoint
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	g8sfake "github.com/giantswarm/apiextensions/pkg/clientset/versioned/fake"
+	"github.com/giantswarm/micrologger/microloggertest"
+	"github.com/giantswarm/operatorkit/controller/context/resourcecanceledcontext"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func Test_Resource_Endpoint_ApplyCreateChange(t *testing.T) {
+	testCases := []struct {
+		CreateState       *corev1.Endpoints
+		ExpectedEndpoints []*corev1.Endpoints
+	}{
+		{
+			CreateState: &corev1.Endpoints{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "TestService",
+					Namespace: "TestNamespace",
+				},
+				Subsets: []corev1.EndpointSubset{
+					{
+						Addresses: []corev1.EndpointAddress{
+							{
+								IP: "1.2.3.4",
+							},
+							{
+								IP: "1.1.1.1",
+							},
+						},
+					},
+				},
+			},
+
+			ExpectedEndpoints: []*corev1.Endpoints{
+				{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "TestService",
+						Namespace: "TestNamespace",
+					},
+					Subsets: []corev1.EndpointSubset{
+						{
+							Addresses: []corev1.EndpointAddress{
+								{
+									IP: "1.2.3.4",
+								},
+								{
+									IP: "1.1.1.1",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	var err error
+
+	for i, tc := range testCases {
+		fakeG8sClient := g8sfake.NewSimpleClientset()
+		fakeK8sClient := fake.NewSimpleClientset()
+
+		var newResource *Resource
+		{
+			c := Config{
+				G8sClient: fakeG8sClient,
+				K8sClient: fakeK8sClient,
+				Logger:    microloggertest.New(),
+			}
+			newResource, err = New(c)
+			if err != nil {
+				t.Fatal("expected", nil, "got", err)
+			}
+		}
+
+		err := newResource.ApplyCreateChange(resourcecanceledcontext.NewContext(context.TODO(), make(chan struct{})), nil, tc.CreateState)
+		if err != nil {
+			t.Fatal("case", i, "expected", nil, "got", err)
+		}
+		for _, k8sEndpoint := range tc.ExpectedEndpoints {
+			returnedEndpoint, err := fakeK8sClient.CoreV1().Endpoints(k8sEndpoint.Namespace).Get(k8sEndpoint.Name, metav1.GetOptions{})
+			if err != nil {
+				t.Fatalf("%d: error returned setting up k8s endpoints: %s\n", i, err)
+			}
+			if !reflect.DeepEqual(k8sEndpoint, returnedEndpoint) {
+				t.Fatalf("case %d expected %#v got %#v", i, k8sEndpoint, returnedEndpoint)
+			}
+		}
+	}
+}
+
+func Test_Resource_Endpoint_newCreateChange(t *testing.T) {
+	testCases := []struct {
+		CurrentState        *Endpoint
+		DesiredState        *Endpoint
+		ExpectedCreateState *corev1.Endpoints
+		Obj                 interface{}
+		SetupService        *corev1.Service
+	}{
+		{
+			CurrentState: &Endpoint{
+				IPs: []string{
+					"1.1.1.1",
+				},
+				ServiceName:      "TestService",
+				ServiceNamespace: "TestNamespace",
+			},
+			DesiredState: &Endpoint{
+				IPs: []string{
+					"1.1.1.1",
+				},
+				ServiceName:      "TestService",
+				ServiceNamespace: "TestNamespace",
+			},
+			SetupService: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "TestService",
+					Namespace: "TestNamespace",
+				},
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{
+							Port: 1234,
+						},
+					},
+				},
+			},
+			ExpectedCreateState: &corev1.Endpoints{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "TestService",
+					Namespace: "TestNamespace",
+				},
+				Subsets: []corev1.EndpointSubset{
+					{
+						Ports: []corev1.EndpointPort{
+							{
+								Port: 1234,
+							},
+						},
+						Addresses: []corev1.EndpointAddress{},
+					},
+				},
+			},
+		},
+		{
+			CurrentState: &Endpoint{
+				IPs:              []string{},
+				ServiceName:      "TestService",
+				ServiceNamespace: "TestNamespace",
+			},
+			DesiredState: &Endpoint{
+				IPs: []string{
+					"1.1.1.1",
+				},
+				ServiceName:      "TestService",
+				ServiceNamespace: "TestNamespace",
+			},
+			SetupService: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "TestService",
+					Namespace: "TestNamespace",
+				},
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{
+							Port: 1234,
+						},
+					},
+				},
+			},
+			ExpectedCreateState: &corev1.Endpoints{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "TestService",
+					Namespace: "TestNamespace",
+				},
+				Subsets: []corev1.EndpointSubset{
+					{
+						Ports: []corev1.EndpointPort{
+							{
+								Port: 1234,
+							},
+						},
+						Addresses: []corev1.EndpointAddress{
+							{
+								IP: "1.1.1.1",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	for i, tc := range testCases {
+		var err error
+
+		fakeG8sClient := g8sfake.NewSimpleClientset()
+		fakeK8sClient := fake.NewSimpleClientset()
+
+		var newResource *Resource
+		{
+			c := Config{
+				G8sClient: fakeG8sClient,
+				K8sClient: fakeK8sClient,
+				Logger:    microloggertest.New(),
+			}
+			newResource, err = New(c)
+			if err != nil {
+				t.Fatal("expected", nil, "got", err)
+			}
+		}
+
+		if tc.SetupService != nil {
+			if _, err := newResource.k8sClient.CoreV1().Services(tc.SetupService.Namespace).Create(tc.SetupService); err != nil {
+				t.Fatalf("%d: error returned setting up k8s service: %s\n", i, err)
+			}
+		}
+
+		result, err := newResource.newCreateChange(context.TODO(), tc.Obj, tc.CurrentState, tc.DesiredState)
+		if err != nil {
+			t.Fatal("case", i, "expected", nil, "got", err)
+		}
+		if !reflect.DeepEqual(tc.ExpectedCreateState, result) {
+			t.Fatalf("case %d expected %#v got %#v", i, tc.ExpectedCreateState, result)
+		}
+	}
+}

--- a/service/controller/v14patch1/resource/endpoint/current.go
+++ b/service/controller/v14patch1/resource/endpoint/current.go
@@ -1,0 +1,71 @@
+package endpoint
+
+import (
+	"context"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/operatorkit/controller/context/resourcecanceledcontext"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interface{}, error) {
+	pod, err := toPod(obj)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	var serviceName string
+	{
+		r.logger.LogCtx(ctx, "level", "debug", "message", "finding annotations")
+
+		_, serviceName, err = getAnnotations(*pod, IPAnnotation, ServiceAnnotation)
+		if IsMissingAnnotationError(err) {
+			r.logger.LogCtx(ctx, "level", "debug", "message", "did not find annotations")
+			resourcecanceledcontext.SetCanceled(ctx)
+			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+
+			return nil, nil
+		} else if err != nil {
+			return nil, microerror.Mask(err)
+		}
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", "found annotations")
+	}
+
+	var endpoint *Endpoint
+	{
+		r.logger.LogCtx(ctx, "level", "debug", "message", "finding endpoint")
+
+		endpoint = &Endpoint{
+			IPs:              []string{},
+			ServiceName:      serviceName,
+			ServiceNamespace: pod.GetNamespace(),
+		}
+
+		k8sEndpoints, err := r.k8sClient.CoreV1().Endpoints(pod.GetNamespace()).Get(serviceName, metav1.GetOptions{})
+		if errors.IsNotFound(err) {
+			// In case the endpoint manifest cannot be found in the Kubernetes API we
+			// return the endpoint structure we dispatch without filling any IP.
+			r.logger.LogCtx(ctx, "level", "debug", "message", "did not find endpoint")
+
+			return endpoint, nil
+		} else if err != nil {
+			return nil, microerror.Mask(err)
+		}
+
+		for _, endpointSubset := range k8sEndpoints.Subsets {
+			for _, endpointAddress := range endpointSubset.Addresses {
+				foundIP := endpointAddress.IP
+
+				if !containsIP(endpoint.IPs, foundIP) {
+					endpoint.IPs = append(endpoint.IPs, foundIP)
+				}
+			}
+		}
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", "found endpoint")
+	}
+
+	return endpoint, nil
+}

--- a/service/controller/v14patch1/resource/endpoint/current_test.go
+++ b/service/controller/v14patch1/resource/endpoint/current_test.go
@@ -1,0 +1,229 @@
+package endpoint
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	g8sfake "github.com/giantswarm/apiextensions/pkg/clientset/versioned/fake"
+	"github.com/giantswarm/micrologger/microloggertest"
+	"github.com/giantswarm/operatorkit/controller/context/resourcecanceledcontext"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func Test_Resource_Endpoint_GetCurrentState(t *testing.T) {
+	testCases := []struct {
+		Obj               interface{}
+		SetupEndpoints    []*corev1.Endpoints
+		ExpectedEndpoints interface{}
+	}{
+		{
+			Obj: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "TestPod",
+					Namespace: "TestNamespace",
+					Annotations: map[string]string{
+						"endpoint.kvm.giantswarm.io/ip":      "1.1.1.1",
+						"endpoint.kvm.giantswarm.io/service": "TestService",
+					},
+				},
+			},
+			ExpectedEndpoints: &Endpoint{
+				IPs:              []string{},
+				ServiceName:      "TestService",
+				ServiceNamespace: "TestNamespace",
+			},
+		},
+		{
+			Obj: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "TestPod",
+					Namespace: "TestNamespace",
+					Annotations: map[string]string{
+						"endpoint.kvm.giantswarm.io/ip": "1.1.1.1",
+					},
+				},
+			},
+			ExpectedEndpoints: nil,
+		},
+		{
+			Obj: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "TestPod",
+					Namespace: "TestNamespace",
+				},
+			},
+			ExpectedEndpoints: nil,
+		},
+		{
+			Obj: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "TestPod",
+					Namespace: "TestNamespace",
+					Annotations: map[string]string{
+						"jabber": "1.1.1.1",
+						"wocky":  "TestService",
+					},
+				},
+			},
+			ExpectedEndpoints: nil,
+		},
+		{
+			Obj: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "TestPod",
+					Namespace: "TestNamespace",
+					Annotations: map[string]string{
+						"endpoint.kvm.giantswarm.io/ip":      "1.1.1.1",
+						"endpoint.kvm.giantswarm.io/service": "TestService",
+					},
+				},
+			},
+			SetupEndpoints: []*corev1.Endpoints{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "TestService",
+						Namespace: "TestNamespace",
+					},
+					Subsets: []corev1.EndpointSubset{
+						{
+							Addresses: []corev1.EndpointAddress{
+								{
+									IP: "1.1.1.1",
+								},
+							},
+						},
+					},
+				},
+			},
+			ExpectedEndpoints: &Endpoint{
+				IPs: []string{
+					"1.1.1.1",
+				},
+				ServiceName:      "TestService",
+				ServiceNamespace: "TestNamespace",
+			},
+		},
+		{
+			Obj: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "TestPod",
+					Namespace: "TestNamespace",
+					Annotations: map[string]string{
+						"endpoint.kvm.giantswarm.io/ip":      "1.1.1.1",
+						"endpoint.kvm.giantswarm.io/service": "TestService",
+					},
+				},
+			},
+			SetupEndpoints: []*corev1.Endpoints{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "TestService",
+						Namespace: "TestNamespace",
+					},
+					Subsets: []corev1.EndpointSubset{
+						{
+							Addresses: []corev1.EndpointAddress{
+								{
+									IP: "1.1.1.1",
+								},
+								{
+									IP: "1.2.3.4",
+								},
+							},
+						},
+					},
+				},
+			},
+			ExpectedEndpoints: &Endpoint{
+				IPs: []string{
+					"1.1.1.1",
+					"1.2.3.4",
+				},
+				ServiceName:      "TestService",
+				ServiceNamespace: "TestNamespace",
+			},
+		},
+		{
+			Obj: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "TestPod",
+					Namespace: "TestNamespace",
+					Annotations: map[string]string{
+						"endpoint.kvm.giantswarm.io/ip":      "1.1.1.1",
+						"endpoint.kvm.giantswarm.io/service": "TestService",
+					},
+				},
+			},
+			SetupEndpoints: []*corev1.Endpoints{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "TestService",
+						Namespace: "TestNamespace",
+					},
+					Subsets: []corev1.EndpointSubset{
+						{
+							Addresses: []corev1.EndpointAddress{
+								{
+									IP: "1.1.1.1",
+								},
+							},
+						},
+						{
+							Addresses: []corev1.EndpointAddress{
+								{
+									IP: "1.1.1.1",
+								},
+								{
+									IP: "1.2.3.4",
+								},
+							},
+						},
+					},
+				},
+			},
+			ExpectedEndpoints: &Endpoint{
+				IPs: []string{
+					"1.1.1.1",
+					"1.2.3.4",
+				},
+				ServiceName:      "TestService",
+				ServiceNamespace: "TestNamespace",
+			},
+		},
+	}
+	var err error
+
+	for i, tc := range testCases {
+		fakeG8sClient := g8sfake.NewSimpleClientset()
+		fakeK8sClient := fake.NewSimpleClientset()
+
+		var newResource *Resource
+		{
+			c := Config{
+				G8sClient: fakeG8sClient,
+				K8sClient: fakeK8sClient,
+				Logger:    microloggertest.New(),
+			}
+			newResource, err = New(c)
+			if err != nil {
+				t.Fatal("expected", nil, "got", err)
+			}
+		}
+
+		for _, k8sEndpoint := range tc.SetupEndpoints {
+			if _, err := fakeK8sClient.CoreV1().Endpoints(k8sEndpoint.Namespace).Create(k8sEndpoint); err != nil {
+				t.Fatalf("%d: error returned setting up k8s endpoint: %s\n", i, err)
+			}
+		}
+		result, err := newResource.GetCurrentState(resourcecanceledcontext.NewContext(context.TODO(), make(chan struct{})), tc.Obj)
+		if err != nil {
+			t.Fatal("case", i, "expected", nil, "got", err)
+		}
+		if !reflect.DeepEqual(tc.ExpectedEndpoints, result) {
+			t.Fatalf("case %d expected %#v got %#v", i, tc.ExpectedEndpoints, result)
+		}
+	}
+}

--- a/service/controller/v14patch1/resource/endpoint/delete.go
+++ b/service/controller/v14patch1/resource/endpoint/delete.go
@@ -1,0 +1,79 @@
+package endpoint
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/operatorkit/controller"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func (r *Resource) ApplyDeleteChange(ctx context.Context, obj, deleteChange interface{}) error {
+	endpointToDelete, err := toK8sEndpoint(deleteChange)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	// The endpoint resource is reconciled by watching pods. Pods get deleted at
+	// times. We do not want to delete the whole endpoint only because one pod is
+	// gone. We only delete the whole endpoint when it does not contain any IP
+	// anymore. Removing IPs is done on update events.
+	if isEmptyEndpoint(*endpointToDelete) {
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleting endpoint '%s'", endpointToDelete.GetName()))
+
+		err = r.k8sClient.CoreV1().Endpoints(endpointToDelete.Namespace).Delete(endpointToDelete.Name, &metav1.DeleteOptions{})
+		if errors.IsNotFound(err) {
+			// fall through
+		} else if err != nil {
+			return microerror.Mask(err)
+		}
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleted endpoint '%s'", endpointToDelete.GetName()))
+	} else {
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("not deleting endpoint '%s'", endpointToDelete.GetName()))
+	}
+
+	return nil
+}
+
+func (r *Resource) NewDeletePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*controller.Patch, error) {
+	deleteChange, err := r.newDeleteChange(ctx, obj, currentState, desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	patch := controller.NewPatch()
+	patch.SetDeleteChange(deleteChange)
+	patch.SetUpdateChange(deleteChange)
+
+	return patch, nil
+}
+
+func (r *Resource) newDeleteChange(ctx context.Context, obj, currentState, desiredState interface{}) (*corev1.Endpoints, error) {
+	currentEndpoint, err := toEndpoint(currentState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+	desiredEndpoint, err := toEndpoint(desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	var deleteChange *corev1.Endpoints
+	{
+		endpoint := &Endpoint{
+			ServiceName:      currentEndpoint.ServiceName,
+			ServiceNamespace: currentEndpoint.ServiceNamespace,
+			IPs:              cutIPs(currentEndpoint.IPs, desiredEndpoint.IPs),
+		}
+		deleteChange, err = r.newK8sEndpoint(endpoint)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	return deleteChange, nil
+}

--- a/service/controller/v14patch1/resource/endpoint/delete_test.go
+++ b/service/controller/v14patch1/resource/endpoint/delete_test.go
@@ -1,0 +1,403 @@
+package endpoint
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	g8sfake "github.com/giantswarm/apiextensions/pkg/clientset/versioned/fake"
+	"github.com/giantswarm/micrologger/microloggertest"
+	"github.com/giantswarm/operatorkit/controller/context/resourcecanceledcontext"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func Test_Resource_Endpoint_ApplyDeleteChange(t *testing.T) {
+	testCases := []struct {
+		DeleteState       *corev1.Endpoints
+		ExpectedEndpoints []*corev1.Endpoints
+		SetupEndpoints    []*corev1.Endpoints
+	}{
+		{
+			DeleteState: &corev1.Endpoints{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "TestService",
+					Namespace: "TestNamespace",
+				},
+				Subsets: []corev1.EndpointSubset{
+					{
+						Addresses: []corev1.EndpointAddress{},
+					},
+				},
+			},
+			ExpectedEndpoints: nil,
+			SetupEndpoints: []*corev1.Endpoints{
+				{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "TestService",
+						Namespace: "TestNamespace",
+					},
+					Subsets: []corev1.EndpointSubset{
+						{
+							Addresses: []corev1.EndpointAddress{
+								{
+									IP: "1.2.3.4",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			DeleteState: &corev1.Endpoints{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "TestService",
+					Namespace: "TestNamespace",
+				},
+				Subsets: []corev1.EndpointSubset{
+					{
+						Addresses: []corev1.EndpointAddress{
+							{
+								IP: "1.2.3.4",
+							},
+						},
+					},
+				},
+			},
+			ExpectedEndpoints: []*corev1.Endpoints{
+				{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "TestService",
+						Namespace: "TestNamespace",
+					},
+					Subsets: []corev1.EndpointSubset{
+						{
+							Addresses: []corev1.EndpointAddress{
+								{
+									IP: "1.2.3.4",
+								},
+							},
+						},
+					},
+				},
+			},
+			SetupEndpoints: []*corev1.Endpoints{
+				{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "TestService",
+						Namespace: "TestNamespace",
+					},
+					Subsets: []corev1.EndpointSubset{
+						{
+							Addresses: []corev1.EndpointAddress{
+								{
+									IP: "1.2.3.4",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	var err error
+
+	for i, tc := range testCases {
+		fakeG8sClient := g8sfake.NewSimpleClientset()
+		fakeK8sClient := fake.NewSimpleClientset()
+
+		var newResource *Resource
+		{
+			c := Config{
+				G8sClient: fakeG8sClient,
+				K8sClient: fakeK8sClient,
+				Logger:    microloggertest.New(),
+			}
+			newResource, err = New(c)
+			if err != nil {
+				t.Fatal("expected", nil, "got", err)
+			}
+		}
+
+		for _, k8sEndpoint := range tc.SetupEndpoints {
+			if _, err := fakeK8sClient.CoreV1().Endpoints(k8sEndpoint.Namespace).Create(k8sEndpoint); err != nil {
+				t.Fatalf("%d: error returned setting up k8s endpoints: %s\n", i, err)
+			}
+		}
+		err := newResource.ApplyDeleteChange(resourcecanceledcontext.NewContext(context.TODO(), make(chan struct{})), nil, tc.DeleteState)
+		if err != nil {
+			t.Fatal("case", i+1, "expected", nil, "got", err)
+		}
+		for _, k8sEndpoint := range tc.ExpectedEndpoints {
+			returnedEndpoint, err := fakeK8sClient.CoreV1().Endpoints(k8sEndpoint.Namespace).Get(k8sEndpoint.Name, metav1.GetOptions{})
+			if err != nil {
+				t.Fatalf("%d: error returned setting up k8s endpoints: %s\n", i+1, err)
+			}
+			if !reflect.DeepEqual(k8sEndpoint, returnedEndpoint) {
+				t.Fatalf("case %d expected %#v got %#v", i+1, k8sEndpoint, returnedEndpoint)
+			}
+		}
+	}
+}
+
+func Test_Resource_Endpoint_newDeleteChange(t *testing.T) {
+	testCases := []struct {
+		CurrentState        *Endpoint
+		DesiredState        *Endpoint
+		ExpectedDeleteState *corev1.Endpoints
+		Obj                 interface{}
+		SetupService        *corev1.Service
+	}{
+		{
+			CurrentState: &Endpoint{
+				IPs: []string{
+					"1.1.1.1",
+				},
+				ServiceName:      "TestService",
+				ServiceNamespace: "TestNamespace",
+			},
+			DesiredState: &Endpoint{
+				IPs: []string{
+					"1.1.1.1",
+				},
+				ServiceName:      "TestService",
+				ServiceNamespace: "TestNamespace",
+			},
+			SetupService: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "TestService",
+					Namespace: "TestNamespace",
+				},
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{
+							Port: 1234,
+						},
+					},
+				},
+			},
+			ExpectedDeleteState: &corev1.Endpoints{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "TestService",
+					Namespace: "TestNamespace",
+				},
+				Subsets: []corev1.EndpointSubset{
+					{
+						Ports: []corev1.EndpointPort{
+							{
+								Port: 1234,
+							},
+						},
+						Addresses: []corev1.EndpointAddress{},
+					},
+				},
+			},
+		},
+		{
+			CurrentState: &Endpoint{
+				IPs: []string{
+					"1.1.1.1",
+					"1.2.3.4",
+				},
+				ServiceName:      "TestService",
+				ServiceNamespace: "TestNamespace",
+			},
+			DesiredState: &Endpoint{
+				IPs: []string{
+					"1.1.1.1",
+				},
+				ServiceName:      "TestService",
+				ServiceNamespace: "TestNamespace",
+			},
+			SetupService: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "TestService",
+					Namespace: "TestNamespace",
+				},
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{
+							Port: 1234,
+						},
+					},
+				},
+			},
+			ExpectedDeleteState: &corev1.Endpoints{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "TestService",
+					Namespace: "TestNamespace",
+				},
+				Subsets: []corev1.EndpointSubset{
+					{
+						Ports: []corev1.EndpointPort{
+							{
+								Port: 1234,
+							},
+						},
+						Addresses: []corev1.EndpointAddress{
+							{
+								IP: "1.2.3.4",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			CurrentState: &Endpoint{
+				IPs: []string{
+					"5.5.5.5",
+					"1.2.3.4",
+				},
+				ServiceName:      "TestService",
+				ServiceNamespace: "TestNamespace",
+			},
+			DesiredState: &Endpoint{
+				IPs: []string{
+					"1.1.1.1",
+				},
+				ServiceName:      "TestService",
+				ServiceNamespace: "TestNamespace",
+			},
+			SetupService: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "TestService",
+					Namespace: "TestNamespace",
+				},
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{
+							Port: 1234,
+						},
+					},
+				},
+			},
+			ExpectedDeleteState: &corev1.Endpoints{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "TestService",
+					Namespace: "TestNamespace",
+				},
+				Subsets: []corev1.EndpointSubset{
+					{
+						Ports: []corev1.EndpointPort{
+							{
+								Port: 1234,
+							},
+						},
+						Addresses: []corev1.EndpointAddress{
+							{
+								IP: "5.5.5.5",
+							},
+							{
+								IP: "1.2.3.4",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			CurrentState: &Endpoint{
+				ServiceName:      "TestService",
+				ServiceNamespace: "TestNamespace",
+			},
+			DesiredState: &Endpoint{
+				IPs: []string{
+					"1.1.1.1",
+				},
+				ServiceName:      "TestService",
+				ServiceNamespace: "TestNamespace",
+			},
+			SetupService: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "TestService",
+					Namespace: "TestNamespace",
+				},
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{
+							Port: 1234,
+						},
+					},
+				},
+			},
+			ExpectedDeleteState: &corev1.Endpoints{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "TestService",
+					Namespace: "TestNamespace",
+				},
+				Subsets: []corev1.EndpointSubset{
+					{
+						Ports: []corev1.EndpointPort{
+							{
+								Port: 1234,
+							},
+						},
+						Addresses: []corev1.EndpointAddress{},
+					},
+				},
+			},
+		},
+	}
+	for i, tc := range testCases {
+		var err error
+
+		fakeG8sClient := g8sfake.NewSimpleClientset()
+		fakeK8sClient := fake.NewSimpleClientset()
+
+		var newResource *Resource
+		{
+			c := Config{
+				G8sClient: fakeG8sClient,
+				K8sClient: fakeK8sClient,
+				Logger:    microloggertest.New(),
+			}
+			newResource, err = New(c)
+			if err != nil {
+				t.Fatal("expected", nil, "got", err)
+			}
+		}
+
+		if tc.SetupService != nil {
+			if _, err := newResource.k8sClient.CoreV1().Services(tc.SetupService.Namespace).Create(tc.SetupService); err != nil {
+				t.Fatalf("%d: error returned setting up k8s service: %s\n", i, err)
+			}
+		}
+		result, err := newResource.newDeleteChange(context.TODO(), tc.Obj, tc.CurrentState, tc.DesiredState)
+		if err != nil {
+			t.Fatal("case", i, "expected", nil, "got", err)
+		}
+		if !reflect.DeepEqual(tc.ExpectedDeleteState, result) {
+			t.Fatalf("case %d expected %#v got %#v", i, tc.ExpectedDeleteState, result)
+		}
+	}
+}

--- a/service/controller/v14patch1/resource/endpoint/desired.go
+++ b/service/controller/v14patch1/resource/endpoint/desired.go
@@ -1,0 +1,28 @@
+package endpoint
+
+import (
+	"context"
+
+	"github.com/giantswarm/microerror"
+)
+
+func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interface{}, error) {
+	pod, err := toPod(obj)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	endpointIP, serviceName, err := getAnnotations(*pod, IPAnnotation, ServiceAnnotation)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+	desiredEndpoint := &Endpoint{
+		IPs: []string{
+			endpointIP,
+		},
+		ServiceName:      serviceName,
+		ServiceNamespace: pod.GetNamespace(),
+	}
+
+	return desiredEndpoint, nil
+}

--- a/service/controller/v14patch1/resource/endpoint/desired_test.go
+++ b/service/controller/v14patch1/resource/endpoint/desired_test.go
@@ -1,0 +1,115 @@
+package endpoint
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	g8sfake "github.com/giantswarm/apiextensions/pkg/clientset/versioned/fake"
+	"github.com/giantswarm/micrologger/microloggertest"
+	"github.com/giantswarm/operatorkit/controller/context/resourcecanceledcontext"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func Test_Resource_Endpoint_GetDesiredState(t *testing.T) {
+	testCases := []struct {
+		Obj                  interface{}
+		ExpectedEndpoint     interface{}
+		ExpectedErrorHandler func(error) bool
+	}{
+		{
+			Obj: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "TestPod",
+					Namespace: "TestNamespace",
+					Annotations: map[string]string{
+						"endpoint.kvm.giantswarm.io/ip":      "1.1.1.1",
+						"endpoint.kvm.giantswarm.io/service": "TestService",
+					},
+				},
+			},
+			ExpectedEndpoint: &Endpoint{
+				IPs: []string{
+					"1.1.1.1",
+				},
+				ServiceName:      "TestService",
+				ServiceNamespace: "TestNamespace",
+			},
+			ExpectedErrorHandler: nil,
+		},
+		{
+			Obj: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "TestPod",
+					Namespace: "TestNamespace",
+					Annotations: map[string]string{
+						"endpoint.kvm.giantswarm.io/ip": "1.1.1.1",
+					},
+				},
+			},
+			ExpectedErrorHandler: IsMissingAnnotationError,
+			ExpectedEndpoint:     nil,
+		},
+		{
+			Obj: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "TestPod",
+					Namespace: "TestNamespace",
+					Annotations: map[string]string{
+						"jabber": "1.1.1.1",
+						"wocky":  "abcd",
+					},
+				},
+			},
+			ExpectedErrorHandler: IsMissingAnnotationError,
+			ExpectedEndpoint:     nil,
+		},
+		{
+			Obj: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "TestPod",
+					Namespace: "TestNamespace",
+				},
+			},
+			ExpectedErrorHandler: IsMissingAnnotationError,
+			ExpectedEndpoint:     nil,
+		},
+	}
+
+	for i, tc := range testCases {
+		var err error
+
+		fakeG8sClient := g8sfake.NewSimpleClientset()
+		fakeK8sClient := fake.NewSimpleClientset()
+
+		var newResource *Resource
+		{
+			c := Config{
+				G8sClient: fakeG8sClient,
+				K8sClient: fakeK8sClient,
+				Logger:    microloggertest.New(),
+			}
+			newResource, err = New(c)
+			if err != nil {
+				t.Fatal("expected", nil, "got", err)
+			}
+		}
+
+		result, err := newResource.GetDesiredState(resourcecanceledcontext.NewContext(context.TODO(), make(chan struct{})), tc.Obj)
+		if err != nil && tc.ExpectedErrorHandler == nil {
+			t.Fatalf("case %d unexpected error returned getting desired state: %s\n", i+1, err)
+		}
+		if err != nil && !tc.ExpectedErrorHandler(err) {
+			t.Fatalf("case %d incorrect error returned getting desired state: %s\n", i+1, err)
+		}
+		if err == nil && tc.ExpectedErrorHandler != nil {
+			t.Fatalf("case %d expected error not returned getting desired state\n", i+1)
+		}
+
+		if !reflect.DeepEqual(tc.ExpectedEndpoint, result) {
+			t.Fatalf("case %d expected %#v got %#v", i+1, tc.ExpectedEndpoint, result)
+		}
+	}
+}

--- a/service/controller/v14patch1/resource/endpoint/error.go
+++ b/service/controller/v14patch1/resource/endpoint/error.go
@@ -1,0 +1,30 @@
+package endpoint
+
+import (
+	"github.com/giantswarm/microerror"
+)
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var wrongTypeError = &microerror.Error{
+	Kind: "wrongTypeError",
+}
+
+func IsWrongTypeError(err error) bool {
+	return microerror.Cause(err) == wrongTypeError
+}
+
+var missingAnnotationError = &microerror.Error{
+	Kind: "missingAnnotationError",
+}
+
+func IsMissingAnnotationError(err error) bool {
+	return microerror.Cause(err) == missingAnnotationError
+}

--- a/service/controller/v14patch1/resource/endpoint/resource.go
+++ b/service/controller/v14patch1/resource/endpoint/resource.go
@@ -1,0 +1,198 @@
+package endpoint
+
+import (
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/giantswarm/apiextensions/pkg/clientset/versioned"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	IPAnnotation      = "endpoint.kvm.giantswarm.io/ip"
+	Name              = "endpointv14"
+	ServiceAnnotation = "endpoint.kvm.giantswarm.io/service"
+)
+
+type Config struct {
+	G8sClient versioned.Interface
+	K8sClient kubernetes.Interface
+	Logger    micrologger.Logger
+}
+
+type Resource struct {
+	g8sClient versioned.Interface
+	k8sClient kubernetes.Interface
+	logger    micrologger.Logger
+}
+
+func New(config Config) (*Resource, error) {
+	if config.G8sClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.G8sClient must not be empty", config)
+	}
+	if config.K8sClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.K8sClient must not be empty", config)
+	}
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+
+	r := &Resource{
+		g8sClient: config.G8sClient,
+		k8sClient: config.K8sClient,
+		logger:    config.Logger,
+	}
+
+	return r, nil
+}
+
+func (r *Resource) Name() string {
+	return Name
+}
+
+func (r *Resource) newK8sEndpoint(endpoint *Endpoint) (*corev1.Endpoints, error) {
+	k8sAddresses := []corev1.EndpointAddress{}
+	for _, endpointIP := range endpoint.IPs {
+		k8sAddress := corev1.EndpointAddress{
+			IP: endpointIP,
+		}
+		k8sAddresses = append(k8sAddresses, k8sAddress)
+	}
+
+	k8sService, err := r.k8sClient.CoreV1().Services(endpoint.ServiceNamespace).Get(endpoint.ServiceName, metav1.GetOptions{})
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	k8sEndpoint := &corev1.Endpoints{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      endpoint.ServiceName,
+			Namespace: endpoint.ServiceNamespace,
+		},
+		Subsets: []corev1.EndpointSubset{
+			{
+				Ports: serviceToPorts(k8sService),
+			},
+		},
+	}
+
+	for i := range k8sEndpoint.Subsets {
+		k8sEndpoint.Subsets[i].Addresses = k8sAddresses
+	}
+
+	return k8sEndpoint, nil
+}
+
+func cutIPs(base []string, cutset []string) []string {
+	resultIPs := []string{}
+	// Deduplicate entries from base.
+	for _, baseIP := range base {
+		if !containsIP(resultIPs, baseIP) {
+			resultIPs = append(resultIPs, baseIP)
+		}
+	}
+	// Cut the cutset out of base.
+	for _, cutsetIP := range cutset {
+		if containsIP(resultIPs, cutsetIP) {
+			resultIPs = removeIP(resultIPs, cutsetIP)
+		}
+	}
+	return resultIPs
+}
+
+func containsIP(ips []string, ip string) bool {
+	for _, foundIP := range ips {
+		if foundIP == ip {
+			return true
+		}
+	}
+	return false
+}
+
+func getAnnotations(pod corev1.Pod, ipAnnotationName string, serviceAnnotationName string) (ipAnnotationValue string, serviceAnnotationValue string, err error) {
+	ipAnnotationValue, ok := pod.GetAnnotations()[ipAnnotationName]
+	if !ok {
+		return "", "", microerror.Maskf(missingAnnotationError, "expected annotation '%s' to be set", ipAnnotationName)
+	}
+	if ipAnnotationValue == "" {
+		return "", "", microerror.Maskf(missingAnnotationError, "empty annotation '%s'", ipAnnotationName)
+	}
+	serviceAnnotationValue, ok = pod.GetAnnotations()[serviceAnnotationName]
+	if !ok {
+		return "", "", microerror.Maskf(missingAnnotationError, "expected annotation '%s' to be set", serviceAnnotationName)
+	}
+	return ipAnnotationValue, serviceAnnotationValue, nil
+}
+
+func isEmptyEndpoint(endpoint corev1.Endpoints) bool {
+	for _, subset := range endpoint.Subsets {
+		if len(subset.Addresses) > 0 {
+			return false
+		}
+	}
+	return true
+}
+
+func removeIP(ips []string, ip string) []string {
+	for index, foundIP := range ips {
+		if foundIP == ip {
+			return append(ips[:index], ips[index+1:]...)
+		}
+	}
+	return ips
+}
+
+func serviceToPorts(s *corev1.Service) []corev1.EndpointPort {
+	var ports []corev1.EndpointPort
+
+	for _, p := range s.Spec.Ports {
+		port := corev1.EndpointPort{
+			Name: p.Name,
+			Port: p.Port,
+		}
+
+		ports = append(ports, port)
+	}
+
+	return ports
+}
+
+func toEndpoint(v interface{}) (*Endpoint, error) {
+	if v == nil {
+		return nil, nil
+	}
+	endpoint, ok := v.(*Endpoint)
+	if !ok {
+		return nil, microerror.Maskf(wrongTypeError, "expected '%T', got '%T'", &Endpoint{}, v)
+	}
+	return endpoint, nil
+}
+
+func toK8sEndpoint(v interface{}) (*corev1.Endpoints, error) {
+	if v == nil {
+		return nil, nil
+	}
+	k8sEndpoint, ok := v.(*corev1.Endpoints)
+	if !ok {
+		return nil, microerror.Maskf(wrongTypeError, "expected '%T', got '%T'", &corev1.Endpoints{}, v)
+	}
+	return k8sEndpoint, nil
+}
+
+func toPod(v interface{}) (*corev1.Pod, error) {
+	if v == nil {
+		return nil, nil
+	}
+
+	pod, ok := v.(*corev1.Pod)
+	if !ok {
+		return nil, microerror.Maskf(wrongTypeError, "expected '%T', got '%T'", &corev1.Pod{}, v)
+	}
+
+	return pod, nil
+}

--- a/service/controller/v14patch1/resource/endpoint/resource_test.go
+++ b/service/controller/v14patch1/resource/endpoint/resource_test.go
@@ -1,0 +1,284 @@
+package endpoint
+
+import (
+	"reflect"
+	"testing"
+
+	g8sfake "github.com/giantswarm/apiextensions/pkg/clientset/versioned/fake"
+	"github.com/giantswarm/micrologger/microloggertest"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func Test_Resource_Endpoint_cutIPs(t *testing.T) {
+	testCases := []struct {
+		name         string
+		base         []string
+		cutset       []string
+		expectedSet  []string
+		errorMatcher func(error) bool
+	}{
+		{
+			name: "case 0: Base has one more address than the cutset",
+			base: []string{
+				"1.1.1.1",
+				"0.0.0.0",
+			},
+			cutset: []string{
+				"1.1.1.1",
+			},
+			expectedSet: []string{
+				"0.0.0.0",
+			},
+			errorMatcher: nil,
+		},
+		{
+			name: "case 1: Base and cutset have the same addresses",
+			base: []string{
+				"1.1.1.1",
+			},
+			cutset: []string{
+				"1.1.1.1",
+			},
+			expectedSet:  []string{},
+			errorMatcher: nil,
+		},
+		{
+			name: "case 2: Cutset has one more address than base",
+			base: []string{
+				"1.1.1.1",
+			},
+			cutset: []string{
+				"1.1.1.1",
+				"0.0.0.0",
+			},
+			expectedSet:  []string{},
+			errorMatcher: nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+
+			resultSet := cutIPs(tc.base, tc.cutset)
+
+			if !reflect.DeepEqual(resultSet, tc.expectedSet) {
+				t.Fatalf("resultSet == %q, want %q", resultSet, tc.expectedSet)
+			}
+		})
+	}
+}
+
+func Test_Resource_Endpoint_newK8sEndpoint(t *testing.T) {
+	testCases := []struct {
+		name                string
+		setupService        *corev1.Service
+		endpoint            *Endpoint
+		expectedK8sEndpoint *corev1.Endpoints
+		errorMatcher        func(error) bool
+	}{
+		{
+			name: "case 0: Without adresses, empty k8sEndpoint desired",
+			setupService: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "TestService",
+					Namespace: "TestNamespace",
+				},
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{},
+				},
+			},
+			endpoint: &Endpoint{
+				ServiceName:      "TestService",
+				ServiceNamespace: "TestNamespace",
+			},
+			expectedK8sEndpoint: &corev1.Endpoints{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "TestService",
+					Namespace: "TestNamespace",
+				},
+				Subsets: []corev1.EndpointSubset{
+					{
+						Addresses: []corev1.EndpointAddress{},
+					},
+				},
+			},
+			errorMatcher: nil,
+		},
+		{
+			name: "case 1: With addresses, no ports",
+			setupService: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "TestService",
+					Namespace: "TestNamespace",
+				},
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{},
+				},
+			},
+			endpoint: &Endpoint{
+				ServiceName:      "TestService",
+				ServiceNamespace: "TestNamespace",
+				IPs: []string{
+					"1.2.3.4",
+				},
+			},
+			expectedK8sEndpoint: &corev1.Endpoints{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "TestService",
+					Namespace: "TestNamespace",
+				},
+				Subsets: []corev1.EndpointSubset{
+					{
+						Addresses: []corev1.EndpointAddress{
+							{
+								IP: "1.2.3.4",
+							},
+						},
+					},
+				},
+			},
+			errorMatcher: nil,
+		},
+		{
+			name: "case 2: With addresses and ports",
+			setupService: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "TestService",
+					Namespace: "TestNamespace",
+				},
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{
+							Port: 22,
+						},
+					},
+				},
+			},
+			endpoint: &Endpoint{
+				ServiceName:      "TestService",
+				ServiceNamespace: "TestNamespace",
+				IPs: []string{
+					"1.2.3.4",
+				},
+			},
+			expectedK8sEndpoint: &corev1.Endpoints{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "TestService",
+					Namespace: "TestNamespace",
+				},
+				Subsets: []corev1.EndpointSubset{
+					{
+						Addresses: []corev1.EndpointAddress{
+							{
+								IP: "1.2.3.4",
+							},
+						},
+						Ports: []corev1.EndpointPort{
+							{
+								Port: 22,
+							},
+						},
+					},
+				},
+			},
+			errorMatcher: nil,
+		},
+		{
+			name: "case 3: Without addresses but ports",
+			setupService: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "TestService",
+					Namespace: "TestNamespace",
+				},
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{
+							Port: 22,
+						},
+					},
+				},
+			},
+			endpoint: &Endpoint{
+				ServiceName:      "TestService",
+				ServiceNamespace: "TestNamespace",
+			},
+			expectedK8sEndpoint: &corev1.Endpoints{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "TestService",
+					Namespace: "TestNamespace",
+				},
+				Subsets: []corev1.EndpointSubset{
+					{
+						Addresses: []corev1.EndpointAddress{},
+						Ports: []corev1.EndpointPort{
+							{
+								Port: 22,
+							},
+						},
+					},
+				},
+			},
+			errorMatcher: nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var err error
+
+			fakeG8sClient := g8sfake.NewSimpleClientset()
+			fakeK8sClient := fake.NewSimpleClientset()
+
+			var newResource *Resource
+			{
+				c := Config{
+					G8sClient: fakeG8sClient,
+					K8sClient: fakeK8sClient,
+					Logger:    microloggertest.New(),
+				}
+				newResource, err = New(c)
+				if err != nil {
+					t.Fatal("expected", nil, "got", err)
+				}
+			}
+
+			if tc.setupService != nil {
+				if _, err := newResource.k8sClient.CoreV1().Services(tc.setupService.Namespace).Create(tc.setupService); err != nil {
+					t.Fatalf(" error returned setting up k8s service: %s\n", err)
+				}
+			}
+
+			k8sEndpoints, err := newResource.newK8sEndpoint(tc.endpoint)
+
+			switch {
+			case err == nil && tc.errorMatcher == nil: // correct; carry on
+			case err != nil && tc.errorMatcher != nil:
+				if !tc.errorMatcher(err) {
+					t.Fatalf("error == %#v, want matching", err)
+				}
+			case err != nil && tc.errorMatcher == nil:
+				t.Fatalf("error == %#v, want nil", err)
+			case err == nil && tc.errorMatcher != nil:
+				t.Fatalf("error == nil, want non-nil")
+			}
+
+			if !reflect.DeepEqual(k8sEndpoints, tc.expectedK8sEndpoint) {
+				t.Fatalf("k8sEndpoint == %q, want %q", k8sEndpoints, tc.expectedK8sEndpoint)
+			}
+		})
+	}
+}

--- a/service/controller/v14patch1/resource/endpoint/spec.go
+++ b/service/controller/v14patch1/resource/endpoint/spec.go
@@ -1,0 +1,7 @@
+package endpoint
+
+type Endpoint struct {
+	IPs              []string
+	ServiceName      string
+	ServiceNamespace string
+}

--- a/service/controller/v14patch1/resource/endpoint/update.go
+++ b/service/controller/v14patch1/resource/endpoint/update.go
@@ -1,0 +1,91 @@
+package endpoint
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/operatorkit/controller"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateState interface{}) error {
+	endpointToUpdate, err := toK8sEndpoint(updateState)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	if !isEmptyEndpoint(*endpointToUpdate) {
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("updating endpoint '%s'", endpointToUpdate.GetName()))
+
+		_, err = r.k8sClient.CoreV1().Endpoints(endpointToUpdate.Namespace).Update(endpointToUpdate)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("updated endpoint '%s'", endpointToUpdate.GetName()))
+	} else {
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("not updating endpoint '%s'", endpointToUpdate.GetName()))
+	}
+
+	return nil
+}
+
+func (r *Resource) NewUpdatePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*controller.Patch, error) {
+	createState, err := r.newCreateChange(ctx, obj, currentState, desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+	updateState, err := r.newUpdateChange(ctx, obj, currentState, desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	patch := controller.NewPatch()
+
+	patch.SetCreateChange(createState)
+	patch.SetUpdateChange(updateState)
+
+	return patch, nil
+}
+
+func (r *Resource) newUpdateChange(ctx context.Context, obj, currentState, desiredState interface{}) (*corev1.Endpoints, error) {
+	currentEndpoint, err := toEndpoint(currentState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+	desiredEndpoint, err := toEndpoint(desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	var updateChange *corev1.Endpoints
+	{
+		var ips []string
+		for _, ip := range currentEndpoint.IPs {
+			ips = append(ips, ip)
+		}
+		for _, ip := range desiredEndpoint.IPs {
+			if !containsIP(ips, ip) {
+				ips = append(ips, ip)
+			}
+		}
+
+		endpoint := &Endpoint{
+			IPs:              []string{},
+			ServiceName:      desiredEndpoint.ServiceName,
+			ServiceNamespace: desiredEndpoint.ServiceNamespace,
+		}
+
+		if len(currentEndpoint.IPs) > 0 {
+			endpoint.IPs = ips
+		}
+
+		updateChange, err = r.newK8sEndpoint(endpoint)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	return updateChange, nil
+}

--- a/service/controller/v14patch1/resource/endpoint/update_test.go
+++ b/service/controller/v14patch1/resource/endpoint/update_test.go
@@ -1,0 +1,269 @@
+package endpoint
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	g8sfake "github.com/giantswarm/apiextensions/pkg/clientset/versioned/fake"
+	"github.com/giantswarm/micrologger/microloggertest"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func Test_Resource_Endpoint_newUpdateChange(t *testing.T) {
+	testCases := []struct {
+		CurrentState        *Endpoint
+		DesiredState        *Endpoint
+		ExpectedCreateState *corev1.Endpoints
+		Obj                 interface{}
+		SetupService        *corev1.Service
+	}{
+		{
+			CurrentState: &Endpoint{
+				IPs: []string{
+					"1.1.1.1",
+				},
+				ServiceName:      "TestService",
+				ServiceNamespace: "TestNamespace",
+			},
+			DesiredState: &Endpoint{
+				IPs: []string{
+					"1.1.1.1",
+				},
+				ServiceName:      "TestService",
+				ServiceNamespace: "TestNamespace",
+			},
+			SetupService: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "TestService",
+					Namespace: "TestNamespace",
+				},
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{
+							Port: 1234,
+						},
+					},
+				},
+			},
+			ExpectedCreateState: &corev1.Endpoints{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "TestService",
+					Namespace: "TestNamespace",
+				},
+				Subsets: []corev1.EndpointSubset{
+					{
+						Ports: []corev1.EndpointPort{
+							{
+								Port: 1234,
+							},
+						},
+						Addresses: []corev1.EndpointAddress{
+							{
+								IP: "1.1.1.1",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			CurrentState: &Endpoint{
+				IPs: []string{
+					"1.1.1.1",
+					"1.2.3.4",
+				},
+				ServiceName:      "TestService",
+				ServiceNamespace: "TestNamespace",
+			},
+			DesiredState: &Endpoint{
+				IPs: []string{
+					"1.1.1.1",
+				},
+				ServiceName:      "TestService",
+				ServiceNamespace: "TestNamespace",
+			},
+			SetupService: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "TestService",
+					Namespace: "TestNamespace",
+				},
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{
+							Port: 1234,
+						},
+					},
+				},
+			},
+			ExpectedCreateState: &corev1.Endpoints{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "TestService",
+					Namespace: "TestNamespace",
+				},
+				Subsets: []corev1.EndpointSubset{
+					{
+						Ports: []corev1.EndpointPort{
+							{
+								Port: 1234,
+							},
+						},
+						Addresses: []corev1.EndpointAddress{
+							{
+								IP: "1.1.1.1",
+							},
+							{
+								IP: "1.2.3.4",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			CurrentState: &Endpoint{
+				IPs: []string{
+					"5.5.5.5",
+					"1.2.3.4",
+				},
+				ServiceName:      "TestService",
+				ServiceNamespace: "TestNamespace",
+			},
+			DesiredState: &Endpoint{
+				IPs: []string{
+					"1.1.1.1",
+				},
+				ServiceName:      "TestService",
+				ServiceNamespace: "TestNamespace",
+			},
+			SetupService: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "TestService",
+					Namespace: "TestNamespace",
+				},
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{
+							Port: 1234,
+						},
+					},
+				},
+			},
+			ExpectedCreateState: &corev1.Endpoints{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "TestService",
+					Namespace: "TestNamespace",
+				},
+				Subsets: []corev1.EndpointSubset{
+					{
+						Ports: []corev1.EndpointPort{
+							{
+								Port: 1234,
+							},
+						},
+						Addresses: []corev1.EndpointAddress{
+							{
+								IP: "5.5.5.5",
+							},
+							{
+								IP: "1.2.3.4",
+							},
+							{
+								IP: "1.1.1.1",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			CurrentState: &Endpoint{
+				ServiceName:      "TestService",
+				ServiceNamespace: "TestNamespace",
+			},
+			DesiredState: &Endpoint{
+				IPs: []string{
+					"1.1.1.1",
+				},
+				ServiceName:      "TestService",
+				ServiceNamespace: "TestNamespace",
+			},
+			SetupService: &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "TestService",
+					Namespace: "TestNamespace",
+				},
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{
+							Port: 1234,
+						},
+					},
+				},
+			},
+			ExpectedCreateState: &corev1.Endpoints{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "TestService",
+					Namespace: "TestNamespace",
+				},
+				Subsets: []corev1.EndpointSubset{
+					{
+						Ports: []corev1.EndpointPort{
+							{
+								Port: 1234,
+							},
+						},
+						Addresses: []corev1.EndpointAddress{},
+					},
+				},
+			},
+		},
+	}
+	for i, tc := range testCases {
+		var err error
+
+		fakeG8sClient := g8sfake.NewSimpleClientset()
+		fakeK8sClient := fake.NewSimpleClientset()
+
+		var newResource *Resource
+		{
+			c := Config{
+				G8sClient: fakeG8sClient,
+				K8sClient: fakeK8sClient,
+				Logger:    microloggertest.New(),
+			}
+			newResource, err = New(c)
+			if err != nil {
+				t.Fatal("expected", nil, "got", err)
+			}
+		}
+
+		if tc.SetupService != nil {
+			if _, err := newResource.k8sClient.CoreV1().Services(tc.SetupService.Namespace).Create(tc.SetupService); err != nil {
+				t.Fatalf("%d: error returned setting up k8s service: %s\n", i, err)
+			}
+		}
+
+		result, err := newResource.newUpdateChange(context.TODO(), tc.Obj, tc.CurrentState, tc.DesiredState)
+		if err != nil {
+			t.Fatal("case", i, "expected", nil, "got", err)
+		}
+		if !reflect.DeepEqual(tc.ExpectedCreateState, result) {
+			t.Fatalf("case %d expected %#v got %#v", i, tc.ExpectedCreateState, result)
+		}
+	}
+}

--- a/service/controller/v14patch1/resource/ingress/api_ingress.go
+++ b/service/controller/v14patch1/resource/ingress/api_ingress.go
@@ -1,0 +1,59 @@
+package ingress
+
+import (
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	extensionsv1 "k8s.io/api/extensions/v1beta1"
+	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+
+	"github.com/giantswarm/kvm-operator/service/controller/v14/key"
+)
+
+func newAPIIngress(customObject v1alpha1.KVMConfig) *extensionsv1.Ingress {
+	ingress := &extensionsv1.Ingress{
+		TypeMeta: apismetav1.TypeMeta{
+			Kind:       "Ingress",
+			APIVersion: "extensions/v1beta",
+		},
+		ObjectMeta: apismetav1.ObjectMeta{
+			Name: APIID,
+			Labels: map[string]string{
+				"cluster":  key.ClusterID(customObject),
+				"customer": key.ClusterCustomer(customObject),
+				"app":      key.MasterID,
+			},
+			Annotations: map[string]string{
+				"nginx.ingress.kubernetes.io/ssl-passthrough": "true",
+			},
+		},
+		Spec: extensionsv1.IngressSpec{
+			TLS: []extensionsv1.IngressTLS{
+				{
+					Hosts: []string{
+						customObject.Spec.Cluster.Kubernetes.API.Domain,
+					},
+				},
+			},
+			Rules: []extensionsv1.IngressRule{
+				{
+					Host: customObject.Spec.Cluster.Kubernetes.API.Domain,
+					IngressRuleValue: extensionsv1.IngressRuleValue{
+						HTTP: &extensionsv1.HTTPIngressRuleValue{
+							Paths: []extensionsv1.HTTPIngressPath{
+								{
+									Path: "/",
+									Backend: extensionsv1.IngressBackend{
+										ServiceName: key.MasterID,
+										ServicePort: intstr.FromInt(customObject.Spec.Cluster.Kubernetes.API.SecurePort),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	return ingress
+}

--- a/service/controller/v14patch1/resource/ingress/create.go
+++ b/service/controller/v14patch1/resource/ingress/create.go
@@ -1,0 +1,68 @@
+package ingress
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/giantswarm/microerror"
+	"k8s.io/api/extensions/v1beta1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+
+	"github.com/giantswarm/kvm-operator/service/controller/v14/key"
+)
+
+func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange interface{}) error {
+	customObject, err := key.ToCustomObject(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	ingressesToCreate, err := toIngresses(createChange)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	if len(ingressesToCreate) != 0 {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "creating the ingresses in the Kubernetes API")
+
+		namespace := key.ClusterNamespace(customObject)
+		for _, ingress := range ingressesToCreate {
+			_, err := r.k8sClient.Extensions().Ingresses(namespace).Create(ingress)
+			if apierrors.IsAlreadyExists(err) {
+				// fall through
+			} else if err != nil {
+				return microerror.Mask(err)
+			}
+		}
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", "created the ingresses in the Kubernetes API")
+	} else {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "the ingresses do not need to be created in the Kubernetes API")
+	}
+
+	return nil
+}
+
+func (r *Resource) newCreateChange(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, error) {
+	currentIngresses, err := toIngresses(currentState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+	desiredIngresses, err := toIngresses(desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", "finding out which ingresses have to be created")
+
+	var ingressesToCreate []*v1beta1.Ingress
+
+	for _, desiredIngress := range desiredIngresses {
+		if !containsIngress(currentIngresses, desiredIngress) {
+			ingressesToCreate = append(ingressesToCreate, desiredIngress)
+		}
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("found %d ingresses that have to be created", len(ingressesToCreate)))
+
+	return ingressesToCreate, nil
+}

--- a/service/controller/v14patch1/resource/ingress/create_test.go
+++ b/service/controller/v14patch1/resource/ingress/create_test.go
@@ -1,0 +1,243 @@
+package ingress
+
+import (
+	"context"
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/micrologger/microloggertest"
+	"k8s.io/api/extensions/v1beta1"
+	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func Test_Resource_Ingress_newCreateChange(t *testing.T) {
+	testCases := []struct {
+		Obj                  interface{}
+		CurrentState         interface{}
+		DesiredState         interface{}
+		ExpectedIngressNames []string
+	}{
+		// Test 1, in case current state and desired state are empty the create
+		// state should be empty.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState:         []*v1beta1.Ingress{},
+			DesiredState:         []*v1beta1.Ingress{},
+			ExpectedIngressNames: []string{},
+		},
+
+		// Test 2, in case current state equals desired state the create state
+		// should be empty.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState: []*v1beta1.Ingress{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "ingress-1",
+					},
+				},
+			},
+			DesiredState: []*v1beta1.Ingress{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "ingress-1",
+					},
+				},
+			},
+			ExpectedIngressNames: []string{},
+		},
+
+		// Test 3, in case current state misses one item of desired state the create
+		// state should contain the missing item of the desired state.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState: []*v1beta1.Ingress{},
+			DesiredState: []*v1beta1.Ingress{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "ingress-1",
+					},
+				},
+			},
+			ExpectedIngressNames: []string{
+				"ingress-1",
+			},
+		},
+
+		// Test 4, in case current state misses items of desired state the create
+		// state should contain the missing items of the desired state.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState: []*v1beta1.Ingress{},
+			DesiredState: []*v1beta1.Ingress{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "ingress-1",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "ingress-2",
+					},
+				},
+			},
+			ExpectedIngressNames: []string{
+				"ingress-1",
+				"ingress-2",
+			},
+		},
+
+		// Test 5, in case current state contains one item not being in desired
+		// state the create state should not contain the missing item of the desired
+		// state.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState: []*v1beta1.Ingress{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "ingress-1",
+					},
+				},
+			},
+			DesiredState:         []*v1beta1.Ingress{},
+			ExpectedIngressNames: []string{},
+		},
+
+		// Test 6, in case current state contains items not being in desired state
+		// the create state should not contain the missing items of the desired
+		// state.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState: []*v1beta1.Ingress{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "ingress-1",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "ingress-2",
+					},
+				},
+			},
+			DesiredState:         []*v1beta1.Ingress{},
+			ExpectedIngressNames: []string{},
+		},
+
+		// Test 7, in case current state contains some items of desired state the
+		// create state should contain the items being in desired state which are
+		// not in create state.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState: []*v1beta1.Ingress{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "ingress-1",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "ingress-2",
+					},
+				},
+			},
+			DesiredState: []*v1beta1.Ingress{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "ingress-1",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "ingress-2",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "ingress-3",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "ingress-4",
+					},
+				},
+			},
+			ExpectedIngressNames: []string{
+				"ingress-3",
+				"ingress-4",
+			},
+		},
+	}
+
+	var err error
+	var newResource *Resource
+	{
+		resourceConfig := DefaultConfig()
+		resourceConfig.K8sClient = fake.NewSimpleClientset()
+		resourceConfig.Logger = microloggertest.New()
+		newResource, err = New(resourceConfig)
+		if err != nil {
+			t.Fatal("expected", nil, "got", err)
+		}
+	}
+
+	for i, tc := range testCases {
+		result, err := newResource.newCreateChange(context.TODO(), tc.Obj, tc.CurrentState, tc.DesiredState)
+		if err != nil {
+			t.Fatalf("case %d expected %#v got %#v", i+1, nil, err)
+		}
+
+		configMaps, ok := result.([]*v1beta1.Ingress)
+		if !ok {
+			t.Fatalf("case %d expected %T got %T", i+1, []*v1beta1.Ingress{}, result)
+		}
+
+		if len(configMaps) != len(tc.ExpectedIngressNames) {
+			t.Fatalf("case %d expected %d config maps got %d", i+1, len(tc.ExpectedIngressNames), len(configMaps))
+		}
+	}
+}

--- a/service/controller/v14patch1/resource/ingress/current.go
+++ b/service/controller/v14patch1/resource/ingress/current.go
@@ -1,0 +1,72 @@
+package ingress
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/operatorkit/controller/context/finalizerskeptcontext"
+	"github.com/giantswarm/operatorkit/controller/context/resourcecanceledcontext"
+	"k8s.io/api/extensions/v1beta1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/giantswarm/kvm-operator/service/controller/v14/key"
+)
+
+func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interface{}, error) {
+	customObject, err := key.ToCustomObject(obj)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", "looking for ingresses in the Kubernetes API")
+
+	var ingresses []*v1beta1.Ingress
+
+	namespace := key.ClusterNamespace(customObject)
+	ingressNames := []string{
+		APIID,
+		EtcdID,
+	}
+
+	for _, name := range ingressNames {
+		manifest, err := r.k8sClient.Extensions().Ingresses(namespace).Get(name, metav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			r.logger.LogCtx(ctx, "level", "debug", "message", "did not find a ingress in the Kubernetes API")
+			// fall through
+		} else if err != nil {
+			return nil, microerror.Mask(err)
+		} else {
+			r.logger.LogCtx(ctx, "level", "debug", "message", "found a ingress in the Kubernetes API")
+			ingresses = append(ingresses, manifest)
+		}
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("found %d ingresses in the Kubernetes API", len(ingresses)))
+
+	// In case a cluster deletion happens, we want to delete the guest cluster
+	// ingresses. We still need to use the ingresses for ingress routing in order
+	// to drain nodes on KVM though. So as long as pods are there we delay the
+	// deletion of the ingresses here in order to still be able to route traffic
+	// to the guest cluster API. As soon as the draining was done and the pods got
+	// removed we get an empty list here after the delete event got replayed. Then
+	// we just remove the ingresses as usual.
+	if key.IsDeleted(customObject) {
+		n := key.ClusterNamespace(customObject)
+		list, err := r.k8sClient.CoreV1().Pods(n).List(metav1.ListOptions{})
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+		if len(list.Items) != 0 {
+			r.logger.LogCtx(ctx, "level", "debug", "message", "cannot finish deletion of ingresses due to existing pods")
+			resourcecanceledcontext.SetCanceled(ctx)
+			finalizerskeptcontext.SetKept(ctx)
+			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+
+			return nil, nil
+		}
+	}
+
+	return ingresses, nil
+}

--- a/service/controller/v14patch1/resource/ingress/delete.go
+++ b/service/controller/v14patch1/resource/ingress/delete.go
@@ -1,0 +1,82 @@
+package ingress
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/operatorkit/controller"
+	"k8s.io/api/extensions/v1beta1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/giantswarm/kvm-operator/service/controller/v14/key"
+)
+
+func (r *Resource) ApplyDeleteChange(ctx context.Context, obj, deleteChange interface{}) error {
+	customObject, err := key.ToCustomObject(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	ingressesToDelete, err := toIngresses(deleteChange)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	if len(ingressesToDelete) != 0 {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "deleting the ingresses in the Kubernetes API")
+
+		namespace := key.ClusterNamespace(customObject)
+		for _, ingress := range ingressesToDelete {
+			err := r.k8sClient.Extensions().Ingresses(namespace).Delete(ingress.Name, &apismetav1.DeleteOptions{})
+			if apierrors.IsNotFound(err) {
+				// fall through
+			} else if err != nil {
+				return microerror.Mask(err)
+			}
+		}
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", "deleted the ingresses in the Kubernetes API")
+	} else {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "the ingresses do not need to be deleted from the Kubernetes API")
+	}
+
+	return nil
+}
+
+func (r *Resource) NewDeletePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*controller.Patch, error) {
+	delete, err := r.newDeleteChange(ctx, obj, currentState, desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	patch := controller.NewPatch()
+	patch.SetDeleteChange(delete)
+
+	return patch, nil
+}
+
+func (r *Resource) newDeleteChange(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, error) {
+	currentIngresses, err := toIngresses(currentState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+	desiredIngresses, err := toIngresses(desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", "finding out which ingresses have to be deleted")
+
+	var ingressesToDelete []*v1beta1.Ingress
+
+	for _, currentIngress := range currentIngresses {
+		if containsIngress(desiredIngresses, currentIngress) {
+			ingressesToDelete = append(ingressesToDelete, currentIngress)
+		}
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("found %d ingresses that have to be deleted", len(ingressesToDelete)))
+
+	return ingressesToDelete, nil
+}

--- a/service/controller/v14patch1/resource/ingress/delete_test.go
+++ b/service/controller/v14patch1/resource/ingress/delete_test.go
@@ -1,0 +1,289 @@
+package ingress
+
+import (
+	"context"
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/micrologger/microloggertest"
+	"k8s.io/api/extensions/v1beta1"
+	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func Test_Resource_Ingress_newDeleteChange(t *testing.T) {
+	testCases := []struct {
+		Obj                  interface{}
+		CurrentState         interface{}
+		DesiredState         interface{}
+		ExpectedIngressNames []string
+	}{
+		// Test 1, in case current state and desired state are empty the delete
+		// state should be empty.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState:         []*v1beta1.Ingress{},
+			DesiredState:         []*v1beta1.Ingress{},
+			ExpectedIngressNames: []string{},
+		},
+
+		// Test 2, in case current state has one item and equals desired state the
+		// delete state should equal the current state.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState: []*v1beta1.Ingress{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "ingress-1",
+					},
+				},
+			},
+			DesiredState: []*v1beta1.Ingress{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "ingress-1",
+					},
+				},
+			},
+			ExpectedIngressNames: []string{
+				"ingress-1",
+			},
+		},
+
+		// Test 3, in case current state misses one item of desired state the delete
+		// state should not contain the missing item of the desired state.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState: []*v1beta1.Ingress{},
+			DesiredState: []*v1beta1.Ingress{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "ingress-1",
+					},
+				},
+			},
+			ExpectedIngressNames: []string{},
+		},
+
+		// Test 4, in case current state misses items of desired state the delete
+		// state should not contain the missing items of the desired state.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState: []*v1beta1.Ingress{},
+			DesiredState: []*v1beta1.Ingress{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "ingress-1",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "ingress-2",
+					},
+				},
+			},
+			ExpectedIngressNames: []string{},
+		},
+
+		// Test 5, in case current state contains one item and desired state is
+		// empty the delete state should be empty.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState: []*v1beta1.Ingress{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "ingress-1",
+					},
+				},
+			},
+			DesiredState:         []*v1beta1.Ingress{},
+			ExpectedIngressNames: []string{},
+		},
+
+		// Test 6, in case current state contains items and desired state is empty
+		// the delete state should be empty.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState: []*v1beta1.Ingress{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "ingress-1",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "ingress-2",
+					},
+				},
+			},
+			DesiredState:         []*v1beta1.Ingress{},
+			ExpectedIngressNames: []string{},
+		},
+
+		// Test 7, in case all items of current state are in desired state and
+		// desired state contains more items not being in current state the create
+		// state should contain all items being in current state.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState: []*v1beta1.Ingress{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "ingress-1",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "ingress-2",
+					},
+				},
+			},
+			DesiredState: []*v1beta1.Ingress{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "ingress-1",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "ingress-2",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "ingress-3",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "ingress-4",
+					},
+				},
+			},
+			ExpectedIngressNames: []string{
+				"ingress-1",
+				"ingress-2",
+			},
+		},
+
+		// Test 8, in case all items of desired state are in current state and
+		// current state contains more items not being in desired state the create
+		// state should contain all items being in desired state.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState: []*v1beta1.Ingress{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "ingress-1",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "ingress-2",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "ingress-3",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "ingress-4",
+					},
+				},
+			},
+			DesiredState: []*v1beta1.Ingress{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "ingress-1",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "ingress-2",
+					},
+				},
+			},
+			ExpectedIngressNames: []string{
+				"ingress-1",
+				"ingress-2",
+			},
+		},
+	}
+
+	var err error
+	var newResource *Resource
+	{
+		resourceConfig := DefaultConfig()
+		resourceConfig.K8sClient = fake.NewSimpleClientset()
+		resourceConfig.Logger = microloggertest.New()
+		newResource, err = New(resourceConfig)
+		if err != nil {
+			t.Fatal("expected", nil, "got", err)
+		}
+	}
+
+	for i, tc := range testCases {
+		result, err := newResource.newDeleteChange(context.TODO(), tc.Obj, tc.CurrentState, tc.DesiredState)
+		if err != nil {
+			t.Fatalf("case %d expected %#v got %#v", i+1, nil, err)
+		}
+
+		configMaps, ok := result.([]*v1beta1.Ingress)
+		if !ok {
+			t.Fatalf("case %d expected %T got %T", i+1, []*v1beta1.Ingress{}, result)
+		}
+
+		if len(configMaps) != len(tc.ExpectedIngressNames) {
+			t.Fatalf("case %d expected %d config maps got %d", i+1, len(tc.ExpectedIngressNames), len(configMaps))
+		}
+	}
+}

--- a/service/controller/v14patch1/resource/ingress/desired.go
+++ b/service/controller/v14patch1/resource/ingress/desired.go
@@ -1,0 +1,29 @@
+package ingress
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/giantswarm/microerror"
+	"k8s.io/api/extensions/v1beta1"
+
+	"github.com/giantswarm/kvm-operator/service/controller/v14/key"
+)
+
+func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interface{}, error) {
+	customObject, err := key.ToCustomObject(obj)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", "computing the new ingresses")
+
+	var ingresses []*v1beta1.Ingress
+
+	ingresses = append(ingresses, newAPIIngress(customObject))
+	ingresses = append(ingresses, newEtcdIngress(customObject))
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("computed the %d new ingresses", len(ingresses)))
+
+	return ingresses, nil
+}

--- a/service/controller/v14patch1/resource/ingress/desired_test.go
+++ b/service/controller/v14patch1/resource/ingress/desired_test.go
@@ -1,0 +1,145 @@
+package ingress
+
+import (
+	"context"
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/micrologger/microloggertest"
+	"k8s.io/api/extensions/v1beta1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func Test_Resource_Ingress_GetDesiredState(t *testing.T) {
+	testCases := []struct {
+		Obj               interface{}
+		ExpectedAPICount  int
+		ExpectedEtcdCount int
+	}{
+		// Test 1 ensures there is one ingress for master and worker each when there
+		// is one master and one worker node in the custom object.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+						Masters: []v1alpha1.ClusterNode{
+							{},
+						},
+						Workers: []v1alpha1.ClusterNode{
+							{},
+						},
+					},
+				},
+			},
+			ExpectedAPICount:  1,
+			ExpectedEtcdCount: 1,
+		},
+
+		// Test 2 ensures there is one ingress for master and worker each when there
+		// is one master and three worker nodes in the custom object.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+						Masters: []v1alpha1.ClusterNode{
+							{},
+						},
+						Workers: []v1alpha1.ClusterNode{
+							{},
+							{},
+							{},
+						},
+					},
+				},
+			},
+			ExpectedAPICount:  1,
+			ExpectedEtcdCount: 1,
+		},
+
+		// Test 3 ensures there is one ingress for master and worker each when there
+		// are three master and three worker nodes in the custom object.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+						Masters: []v1alpha1.ClusterNode{
+							{},
+							{},
+							{},
+						},
+						Workers: []v1alpha1.ClusterNode{
+							{},
+							{},
+							{},
+						},
+					},
+				},
+			},
+			ExpectedAPICount:  1,
+			ExpectedEtcdCount: 1,
+		},
+	}
+
+	var err error
+	var newResource *Resource
+	{
+		resourceConfig := DefaultConfig()
+		resourceConfig.K8sClient = fake.NewSimpleClientset()
+		resourceConfig.Logger = microloggertest.New()
+		newResource, err = New(resourceConfig)
+		if err != nil {
+			t.Fatal("expected", nil, "got", err)
+		}
+	}
+
+	for i, tc := range testCases {
+		result, err := newResource.GetDesiredState(context.TODO(), tc.Obj)
+		if err != nil {
+			t.Fatalf("case %d expected %#v got %#v", i+1, nil, err)
+		}
+
+		ingresses, ok := result.([]*v1beta1.Ingress)
+		if !ok {
+			t.Fatalf("case %d expected %T got %T", i+1, []*v1beta1.Ingress{}, result)
+		}
+
+		if testGetAPICount(ingresses) != tc.ExpectedAPICount {
+			t.Fatalf("case %d expected %d master nodes got %d", i+1, tc.ExpectedAPICount, testGetAPICount(ingresses))
+		}
+
+		if testGetEtcdCount(ingresses) != tc.ExpectedEtcdCount {
+			t.Fatalf("case %d expected %d worker nodes got %d", i+1, tc.ExpectedEtcdCount, testGetEtcdCount(ingresses))
+		}
+
+		if len(ingresses) != tc.ExpectedAPICount+tc.ExpectedEtcdCount {
+			t.Fatalf("case %d expected %d nodes got %d", i+1, tc.ExpectedAPICount+tc.ExpectedEtcdCount, len(ingresses))
+		}
+	}
+}
+
+func testGetAPICount(ingresses []*v1beta1.Ingress) int {
+	var count int
+
+	for _, i := range ingresses {
+		if i.Name == "api" {
+			count++
+		}
+	}
+
+	return count
+}
+
+func testGetEtcdCount(ingresses []*v1beta1.Ingress) int {
+	var count int
+
+	for _, i := range ingresses {
+		if i.Name == "etcd" {
+			count++
+		}
+	}
+
+	return count
+}

--- a/service/controller/v14patch1/resource/ingress/error.go
+++ b/service/controller/v14patch1/resource/ingress/error.go
@@ -1,0 +1,21 @@
+package ingress
+
+import "github.com/giantswarm/microerror"
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var wrongTypeError = &microerror.Error{
+	Kind: "wrongTypeError",
+}
+
+// IsWrongTypeError asserts wrongTypeError.
+func IsWrongTypeError(err error) bool {
+	return microerror.Cause(err) == wrongTypeError
+}

--- a/service/controller/v14patch1/resource/ingress/etcd_ingress.go
+++ b/service/controller/v14patch1/resource/ingress/etcd_ingress.go
@@ -1,0 +1,59 @@
+package ingress
+
+import (
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	extensionsv1 "k8s.io/api/extensions/v1beta1"
+	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+
+	"github.com/giantswarm/kvm-operator/service/controller/v14/key"
+)
+
+func newEtcdIngress(customObject v1alpha1.KVMConfig) *extensionsv1.Ingress {
+	ingress := &extensionsv1.Ingress{
+		TypeMeta: apismetav1.TypeMeta{
+			Kind:       "Ingress",
+			APIVersion: "extensions/v1beta",
+		},
+		ObjectMeta: apismetav1.ObjectMeta{
+			Name: EtcdID,
+			Labels: map[string]string{
+				"cluster":  key.ClusterID(customObject),
+				"customer": key.ClusterCustomer(customObject),
+				"app":      key.MasterID,
+			},
+			Annotations: map[string]string{
+				"nginx.ingress.kubernetes.io/ssl-passthrough": "true",
+			},
+		},
+		Spec: extensionsv1.IngressSpec{
+			TLS: []extensionsv1.IngressTLS{
+				{
+					Hosts: []string{
+						customObject.Spec.Cluster.Etcd.Domain,
+					},
+				},
+			},
+			Rules: []extensionsv1.IngressRule{
+				{
+					Host: customObject.Spec.Cluster.Etcd.Domain,
+					IngressRuleValue: extensionsv1.IngressRuleValue{
+						HTTP: &extensionsv1.HTTPIngressRuleValue{
+							Paths: []extensionsv1.HTTPIngressPath{
+								{
+									Path: "/",
+									Backend: extensionsv1.IngressBackend{
+										ServiceName: key.MasterID,
+										ServicePort: intstr.FromInt(2379),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	return ingress
+}

--- a/service/controller/v14patch1/resource/ingress/resource.go
+++ b/service/controller/v14patch1/resource/ingress/resource.go
@@ -1,0 +1,85 @@
+package ingress
+
+import (
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"k8s.io/api/extensions/v1beta1"
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	APIID  = "api"
+	EtcdID = "etcd"
+	// Name is the identifier of the resource.
+	Name = "ingressv14"
+)
+
+// Config represents the configuration used to create a new ingress resource.
+type Config struct {
+	// Dependencies.
+	K8sClient kubernetes.Interface
+	Logger    micrologger.Logger
+}
+
+// DefaultConfig provides a default configuration to create a new ingress
+// resource by best effort.
+func DefaultConfig() Config {
+	return Config{
+		// Dependencies.
+		K8sClient: nil,
+		Logger:    nil,
+	}
+}
+
+// Resource implements the ingress resource.
+type Resource struct {
+	// Dependencies.
+	k8sClient kubernetes.Interface
+	logger    micrologger.Logger
+}
+
+// New creates a new configured ingress resource.
+func New(config Config) (*Resource, error) {
+	// Dependencies.
+	if config.K8sClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "config.K8sClient must not be empty")
+	}
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "config.Logger must not be empty")
+	}
+
+	newResource := &Resource{
+		// Dependencies.
+		k8sClient: config.K8sClient,
+		logger:    config.Logger,
+	}
+
+	return newResource, nil
+}
+
+func (r *Resource) Name() string {
+	return Name
+}
+
+func containsIngress(list []*v1beta1.Ingress, item *v1beta1.Ingress) bool {
+	for _, l := range list {
+		if l.Name == item.Name {
+			return true
+		}
+	}
+
+	return false
+}
+
+func toIngresses(v interface{}) ([]*v1beta1.Ingress, error) {
+	if v == nil {
+		return nil, nil
+	}
+
+	ingresses, ok := v.([]*v1beta1.Ingress)
+	if !ok {
+		return nil, microerror.Maskf(wrongTypeError, "expected '%T', got '%T'", []*v1beta1.Ingress{}, v)
+	}
+
+	return ingresses, nil
+}

--- a/service/controller/v14patch1/resource/ingress/update.go
+++ b/service/controller/v14patch1/resource/ingress/update.go
@@ -1,0 +1,34 @@
+package ingress
+
+import (
+	"context"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/operatorkit/controller"
+)
+
+func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateChange interface{}) error {
+	return nil
+}
+
+func (r *Resource) NewUpdatePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*controller.Patch, error) {
+	create, err := r.newCreateChange(ctx, obj, currentState, desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	update, err := r.newUpdateChange(ctx, obj, currentState, desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	patch := controller.NewPatch()
+	patch.SetCreateChange(create)
+	patch.SetUpdateChange(update)
+
+	return patch, nil
+}
+
+func (r *Resource) newUpdateChange(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, error) {
+	return nil, nil
+}

--- a/service/controller/v14patch1/resource/namespace/create.go
+++ b/service/controller/v14patch1/resource/namespace/create.go
@@ -1,0 +1,55 @@
+package namespace
+
+import (
+	"context"
+
+	"github.com/giantswarm/microerror"
+	apiv1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+)
+
+func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange interface{}) error {
+	namespaceToCreate, err := toNamespace(createChange)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	if namespaceToCreate != nil {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "creating the namespace in the Kubernetes API")
+
+		_, err = r.k8sClient.CoreV1().Namespaces().Create(namespaceToCreate)
+		if apierrors.IsAlreadyExists(err) {
+			// fall through
+		} else if err != nil {
+			return microerror.Mask(err)
+		}
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", "created the namespace in the Kubernetes API")
+	} else {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "the namespace does not need to be created in the Kubernetes API")
+	}
+
+	return nil
+}
+
+func (r *Resource) newCreateChange(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, error) {
+	currentNamespace, err := toNamespace(currentState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+	desiredNamespace, err := toNamespace(desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", "finding out if the namespace has to be created")
+
+	var namespaceToCreate *apiv1.Namespace
+	if currentNamespace == nil {
+		namespaceToCreate = desiredNamespace
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", "found out if the namespace has to be created")
+
+	return namespaceToCreate, nil
+}

--- a/service/controller/v14patch1/resource/namespace/create_test.go
+++ b/service/controller/v14patch1/resource/namespace/create_test.go
@@ -1,0 +1,124 @@
+package namespace
+
+import (
+	"context"
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/micrologger/microloggertest"
+	apiv1 "k8s.io/api/core/v1"
+	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func Test_Resource_Namespace_newCreateChange(t *testing.T) {
+	testCases := []struct {
+		Obj               interface{}
+		Cur               interface{}
+		Des               interface{}
+		ExpectedNamespace *apiv1.Namespace
+	}{
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "foobar",
+					},
+				},
+			},
+			Cur: &apiv1.Namespace{
+				TypeMeta: apismetav1.TypeMeta{
+					Kind:       "Namespace",
+					APIVersion: "v1",
+				},
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name: "al9qy",
+					Labels: map[string]string{
+						"cluster":  "al9qy",
+						"customer": "test-customer",
+					},
+				},
+			},
+			Des: &apiv1.Namespace{
+				TypeMeta: apismetav1.TypeMeta{
+					Kind:       "Namespace",
+					APIVersion: "v1",
+				},
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name: "al9qy",
+					Labels: map[string]string{
+						"cluster":  "al9qy",
+						"customer": "test-customer",
+					},
+				},
+			},
+			ExpectedNamespace: nil,
+		},
+
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "foobar",
+					},
+				},
+			},
+			Cur: nil,
+			Des: &apiv1.Namespace{
+				TypeMeta: apismetav1.TypeMeta{
+					Kind:       "Namespace",
+					APIVersion: "v1",
+				},
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name: "al9qy",
+					Labels: map[string]string{
+						"cluster":  "al9qy",
+						"customer": "test-customer",
+					},
+				},
+			},
+			ExpectedNamespace: &apiv1.Namespace{
+				TypeMeta: apismetav1.TypeMeta{
+					Kind:       "Namespace",
+					APIVersion: "v1",
+				},
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name: "al9qy",
+					Labels: map[string]string{
+						"cluster":  "al9qy",
+						"customer": "test-customer",
+					},
+				},
+			},
+		},
+	}
+
+	var err error
+	var newResource *Resource
+	{
+		resourceConfig := DefaultConfig()
+		resourceConfig.K8sClient = fake.NewSimpleClientset()
+		resourceConfig.Logger = microloggertest.New()
+		newResource, err = New(resourceConfig)
+		if err != nil {
+			t.Fatal("expected", nil, "got", err)
+		}
+	}
+
+	for i, tc := range testCases {
+		result, err := newResource.newCreateChange(context.TODO(), tc.Obj, tc.Cur, tc.Des)
+		if err != nil {
+			t.Fatal("case", i+1, "expected", nil, "got", err)
+		}
+		if tc.ExpectedNamespace == nil {
+			if tc.ExpectedNamespace != result {
+				t.Fatal("case", i+1, "expected", tc.ExpectedNamespace, "got", result)
+			}
+		} else {
+			name := result.(*apiv1.Namespace).Name
+			if tc.ExpectedNamespace.Name != name {
+				t.Fatal("case", i+1, "expected", tc.ExpectedNamespace.Name, "got", name)
+			}
+		}
+	}
+}

--- a/service/controller/v14patch1/resource/namespace/current.go
+++ b/service/controller/v14patch1/resource/namespace/current.go
@@ -1,0 +1,75 @@
+package namespace
+
+import (
+	"context"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/operatorkit/controller/context/finalizerskeptcontext"
+	"github.com/giantswarm/operatorkit/controller/context/reconciliationcanceledcontext"
+	"github.com/giantswarm/operatorkit/controller/context/resourcecanceledcontext"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/giantswarm/kvm-operator/service/controller/v14/key"
+)
+
+func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interface{}, error) {
+	customObject, err := key.ToCustomObject(obj)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", "looking for the namespace in the Kubernetes API")
+
+	// Lookup the current state of the namespace.
+	var namespace *corev1.Namespace
+	{
+		manifest, err := r.k8sClient.CoreV1().Namespaces().Get(key.ClusterNamespace(customObject), metav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			r.logger.LogCtx(ctx, "level", "debug", "message", "did not find the namespace in the Kubernetes API")
+			// fall through
+		} else if err != nil {
+			return nil, microerror.Mask(err)
+		} else {
+			r.logger.LogCtx(ctx, "level", "debug", "message", "found the namespace in the Kubernetes API")
+			namespace = manifest
+		}
+	}
+
+	// In case the namespace is already terminating we do not need to do any
+	// further work. Then we cancel the reconciliation to prevent the current and
+	// any further resource from being processed.
+	if namespace != nil && namespace.Status.Phase == "Terminating" {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "namespace is in state 'Terminating'")
+		reconciliationcanceledcontext.SetCanceled(ctx)
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling reconciliation")
+
+		return nil, nil
+	}
+
+	// In case a cluster deletion happens, we want to delete the guest cluster
+	// namespace. We still need to use the namespace for resource creation in
+	// order to drain nodes on KVM though. So as long as pods are there we delay
+	// the deletion of the namespace here in order to still be able to create
+	// resources in it. As soon as the draining was done and the pods got removed
+	// we get an empty list here after the delete event got replayed. Then we just
+	// remove the namespace as usual.
+	if key.IsDeleted(customObject) {
+		n := key.ClusterNamespace(customObject)
+		list, err := r.k8sClient.CoreV1().Pods(n).List(metav1.ListOptions{})
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+		if len(list.Items) != 0 {
+			r.logger.LogCtx(ctx, "level", "debug", "message", "cannot finish deletion of namespace due to existing pods")
+			resourcecanceledcontext.SetCanceled(ctx)
+			finalizerskeptcontext.SetKept(ctx)
+			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+
+			return nil, nil
+		}
+	}
+
+	return namespace, nil
+}

--- a/service/controller/v14patch1/resource/namespace/current_test.go
+++ b/service/controller/v14patch1/resource/namespace/current_test.go
@@ -1,0 +1,52 @@
+package namespace
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/micrologger/microloggertest"
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func Test_Resource_Namespace_GetCurrentState(t *testing.T) {
+	testCases := []struct {
+		Obj               interface{}
+		ExpectedNamespace *apiv1.Namespace
+	}{
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			ExpectedNamespace: nil,
+		},
+	}
+
+	var err error
+	var newResource *Resource
+	{
+		resourceConfig := DefaultConfig()
+		resourceConfig.K8sClient = fake.NewSimpleClientset()
+		resourceConfig.Logger = microloggertest.New()
+		newResource, err = New(resourceConfig)
+		if err != nil {
+			t.Fatal("expected", nil, "got", err)
+		}
+	}
+
+	for i, tc := range testCases {
+		result, err := newResource.GetCurrentState(context.TODO(), tc.Obj)
+		if err != nil {
+			t.Fatal("case", i+1, "expected", nil, "got", err)
+		}
+		if !reflect.DeepEqual(tc.ExpectedNamespace, result) {
+			t.Fatalf("case %d expected %#v got %#v", i+1, tc.ExpectedNamespace, result)
+		}
+	}
+}

--- a/service/controller/v14patch1/resource/namespace/delete.go
+++ b/service/controller/v14patch1/resource/namespace/delete.go
@@ -1,0 +1,72 @@
+package namespace
+
+import (
+	"context"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/operatorkit/controller"
+	"github.com/giantswarm/operatorkit/controller/context/reconciliationcanceledcontext"
+	apiv1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func (r *Resource) ApplyDeleteChange(ctx context.Context, obj, deleteChange interface{}) error {
+	namespaceToDelete, err := toNamespace(deleteChange)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	if namespaceToDelete != nil {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "deleting the namespace in the Kubernetes API")
+
+		err = r.k8sClient.CoreV1().Namespaces().Delete(namespaceToDelete.Name, &apismetav1.DeleteOptions{})
+		if apierrors.IsNotFound(err) {
+			// fall through
+		} else if err != nil {
+			return microerror.Mask(err)
+		}
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", "deleted the namespace in the Kubernetes API")
+		reconciliationcanceledcontext.SetCanceled(ctx)
+		r.logger.LogCtx(ctx, "level", "debug", "message", "canceling reconciliation")
+	} else {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "the namespace does not need to be deleted from the Kubernetes API")
+	}
+
+	return nil
+}
+
+func (r *Resource) NewDeletePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*controller.Patch, error) {
+	delete, err := r.newDeleteChange(ctx, obj, currentState, desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	patch := controller.NewPatch()
+	patch.SetDeleteChange(delete)
+
+	return patch, nil
+}
+
+func (r *Resource) newDeleteChange(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, error) {
+	currentNamespace, err := toNamespace(currentState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+	desiredNamespace, err := toNamespace(desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", "finding out if the namespace has to be deleted")
+
+	var namespaceToDelete *apiv1.Namespace
+	if currentNamespace != nil {
+		namespaceToDelete = desiredNamespace
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", "found out if the namespace has to be deleted")
+
+	return namespaceToDelete, nil
+}

--- a/service/controller/v14patch1/resource/namespace/delete_test.go
+++ b/service/controller/v14patch1/resource/namespace/delete_test.go
@@ -1,0 +1,124 @@
+package namespace
+
+import (
+	"context"
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/micrologger/microloggertest"
+	apiv1 "k8s.io/api/core/v1"
+	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func Test_Resource_Namespace_newDeleteChange(t *testing.T) {
+	testCases := []struct {
+		Obj               interface{}
+		Cur               interface{}
+		Des               interface{}
+		ExpectedNamespace *apiv1.Namespace
+	}{
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "foobar",
+					},
+				},
+			},
+			Cur: &apiv1.Namespace{
+				TypeMeta: apismetav1.TypeMeta{
+					Kind:       "Namespace",
+					APIVersion: "v1",
+				},
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name: "al9qy",
+					Labels: map[string]string{
+						"cluster":  "al9qy",
+						"customer": "test-customer",
+					},
+				},
+			},
+			Des: &apiv1.Namespace{
+				TypeMeta: apismetav1.TypeMeta{
+					Kind:       "Namespace",
+					APIVersion: "v1",
+				},
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name: "al9qy",
+					Labels: map[string]string{
+						"cluster":  "al9qy",
+						"customer": "test-customer",
+					},
+				},
+			},
+			ExpectedNamespace: &apiv1.Namespace{
+				TypeMeta: apismetav1.TypeMeta{
+					Kind:       "Namespace",
+					APIVersion: "v1",
+				},
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name: "al9qy",
+					Labels: map[string]string{
+						"cluster":  "al9qy",
+						"customer": "test-customer",
+					},
+				},
+			},
+		},
+
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "foobar",
+					},
+				},
+			},
+			Cur: nil,
+			Des: &apiv1.Namespace{
+				TypeMeta: apismetav1.TypeMeta{
+					Kind:       "Namespace",
+					APIVersion: "v1",
+				},
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name: "al9qy",
+					Labels: map[string]string{
+						"cluster":  "al9qy",
+						"customer": "test-customer",
+					},
+				},
+			},
+			ExpectedNamespace: nil,
+		},
+	}
+
+	var err error
+	var newResource *Resource
+	{
+		resourceConfig := DefaultConfig()
+		resourceConfig.K8sClient = fake.NewSimpleClientset()
+		resourceConfig.Logger = microloggertest.New()
+		newResource, err = New(resourceConfig)
+		if err != nil {
+			t.Fatal("expected", nil, "got", err)
+		}
+	}
+
+	for i, tc := range testCases {
+		result, err := newResource.newDeleteChange(context.TODO(), tc.Obj, tc.Cur, tc.Des)
+		if err != nil {
+			t.Fatal("case", i+1, "expected", nil, "got", err)
+		}
+		if tc.ExpectedNamespace == nil {
+			if tc.ExpectedNamespace != result {
+				t.Fatal("case", i+1, "expected", tc.ExpectedNamespace, "got", result)
+			}
+		} else {
+			name := result.(*apiv1.Namespace).Name
+			if tc.ExpectedNamespace.Name != name {
+				t.Fatal("case", i+1, "expected", tc.ExpectedNamespace.Name, "got", name)
+			}
+		}
+	}
+}

--- a/service/controller/v14patch1/resource/namespace/desired.go
+++ b/service/controller/v14patch1/resource/namespace/desired.go
@@ -1,0 +1,40 @@
+package namespace
+
+import (
+	"context"
+
+	"github.com/giantswarm/microerror"
+	apiv1 "k8s.io/api/core/v1"
+	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/giantswarm/kvm-operator/service/controller/v14/key"
+)
+
+func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interface{}, error) {
+	customObject, err := key.ToCustomObject(obj)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", "computing the desired namespace")
+
+	// Compute the desired state of the namespace to have a reference of data how
+	// it should be.
+	namespace := &apiv1.Namespace{
+		TypeMeta: apismetav1.TypeMeta{
+			Kind:       "Namespace",
+			APIVersion: "v1",
+		},
+		ObjectMeta: apismetav1.ObjectMeta{
+			Name: key.ClusterNamespace(customObject),
+			Labels: map[string]string{
+				"cluster":  key.ClusterID(customObject),
+				"customer": key.ClusterCustomer(customObject),
+			},
+		},
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", "computed the desired namespace")
+
+	return namespace, nil
+}

--- a/service/controller/v14patch1/resource/namespace/desired_test.go
+++ b/service/controller/v14patch1/resource/namespace/desired_test.go
@@ -1,0 +1,62 @@
+package namespace
+
+import (
+	"context"
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/micrologger/microloggertest"
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func Test_Resource_Namespace_GetDesiredState(t *testing.T) {
+	testCases := []struct {
+		Obj          interface{}
+		ExpectedName string
+	}{
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			ExpectedName: "al9qy",
+		},
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "foobar",
+					},
+				},
+			},
+			ExpectedName: "foobar",
+		},
+	}
+
+	var err error
+	var newResource *Resource
+	{
+		resourceConfig := DefaultConfig()
+		resourceConfig.K8sClient = fake.NewSimpleClientset()
+		resourceConfig.Logger = microloggertest.New()
+		newResource, err = New(resourceConfig)
+		if err != nil {
+			t.Fatal("expected", nil, "got", err)
+		}
+	}
+
+	for i, tc := range testCases {
+		result, err := newResource.GetDesiredState(context.TODO(), tc.Obj)
+		if err != nil {
+			t.Fatal("case", i+1, "expected", nil, "got", err)
+		}
+		name := result.(*apiv1.Namespace).Name
+		if tc.ExpectedName != name {
+			t.Fatalf("case %d expected %#v got %#v", i+1, tc.ExpectedName, name)
+		}
+	}
+}

--- a/service/controller/v14patch1/resource/namespace/error.go
+++ b/service/controller/v14patch1/resource/namespace/error.go
@@ -1,0 +1,21 @@
+package namespace
+
+import "github.com/giantswarm/microerror"
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var wrongTypeError = &microerror.Error{
+	Kind: "wrongTypeError",
+}
+
+// IsWrongTypeError asserts wrongTypeError.
+func IsWrongTypeError(err error) bool {
+	return microerror.Cause(err) == wrongTypeError
+}

--- a/service/controller/v14patch1/resource/namespace/resource.go
+++ b/service/controller/v14patch1/resource/namespace/resource.go
@@ -1,0 +1,73 @@
+package namespace
+
+import (
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	// Name is the identifier of the resource.
+	Name = "namespacev14"
+)
+
+// Config represents the configuration used to create a new cloud config resource.
+type Config struct {
+	// Dependencies.
+	K8sClient kubernetes.Interface
+	Logger    micrologger.Logger
+}
+
+// DefaultConfig provides a default configuration to create a new cloud config
+// resource by best effort.
+func DefaultConfig() Config {
+	return Config{
+		// Dependencies.
+		K8sClient: nil,
+		Logger:    nil,
+	}
+}
+
+// Resource implements the cloud config resource.
+type Resource struct {
+	// Dependencies.
+	k8sClient kubernetes.Interface
+	logger    micrologger.Logger
+}
+
+// New creates a new configured cloud config resource.
+func New(config Config) (*Resource, error) {
+	// Dependencies.
+	if config.K8sClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "config.K8sClient must not be empty")
+	}
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "config.Logger must not be empty")
+	}
+
+	newService := &Resource{
+		// Dependencies.
+		k8sClient: config.K8sClient,
+		logger:    config.Logger,
+	}
+
+	return newService, nil
+}
+
+func (r *Resource) Name() string {
+	return Name
+}
+
+func toNamespace(v interface{}) (*apiv1.Namespace, error) {
+	if v == nil {
+		return nil, nil
+	}
+
+	namespace, ok := v.(*apiv1.Namespace)
+	if !ok {
+		return nil, microerror.Maskf(wrongTypeError, "expected '%T', got '%T'", &apiv1.Namespace{}, v)
+	}
+
+	return namespace, nil
+}

--- a/service/controller/v14patch1/resource/namespace/update.go
+++ b/service/controller/v14patch1/resource/namespace/update.go
@@ -1,0 +1,34 @@
+package namespace
+
+import (
+	"context"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/operatorkit/controller"
+)
+
+func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateChange interface{}) error {
+	return nil
+}
+
+func (r *Resource) NewUpdatePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*controller.Patch, error) {
+	create, err := r.newCreateChange(ctx, obj, currentState, desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	update, err := r.newUpdateChange(ctx, obj, currentState, desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	patch := controller.NewPatch()
+	patch.SetCreateChange(create)
+	patch.SetUpdateChange(update)
+
+	return patch, nil
+}
+
+func (r *Resource) newUpdateChange(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, error) {
+	return nil, nil
+}

--- a/service/controller/v14patch1/resource/node/create.go
+++ b/service/controller/v14patch1/resource/node/create.go
@@ -1,0 +1,143 @@
+package node
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/giantswarm/errors/guest"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/operatorkit/client/k8srestconfig"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/kubernetes/pkg/api/v1/node"
+
+	"github.com/giantswarm/kvm-operator/service/controller/v14/key"
+)
+
+func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
+	customObject, err := key.ToCustomObject(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	// At first we need to create a Kubernetes client for the reconciled guest
+	// cluster.
+	var k8sClient kubernetes.Interface
+	{
+		r.logger.LogCtx(ctx, "level", "debug", "message", "creating K8s client for the guest cluster")
+
+		certs, err := r.certsSearcher.SearchCluster(key.ClusterID(customObject))
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		c := k8srestconfig.Config{
+			Logger: r.logger,
+
+			Address:   key.ClusterAPIEndpoint(customObject),
+			InCluster: false,
+			TLS: k8srestconfig.TLSClientConfig{
+				CAData:  certs.APIServer.CA,
+				CrtData: certs.APIServer.Crt,
+				KeyData: certs.APIServer.Key,
+			},
+		}
+		restConfig, err := k8srestconfig.New(c)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		k8sClient, err = kubernetes.NewForConfig(restConfig)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", "created K8s client for the guest cluster")
+	}
+
+	// We need to fetch the nodes being registered within the guest cluster's
+	// Kubernetes API. The list of nodes is used below to sort out which ones have
+	// to be deleted if there does no associated host cluster pod exist.
+	var nodes []corev1.Node
+	{
+		list, err := k8sClient.CoreV1().Nodes().List(metav1.ListOptions{})
+		if guest.IsAPINotAvailable(err) {
+			r.logger.LogCtx(ctx, "level", "debug", "message", "guest cluster is not available")
+			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+
+			return nil
+		} else if err != nil {
+			return microerror.Mask(err)
+		}
+		nodes = list.Items
+	}
+
+	// Fetch the list of pods running on the host cluster. These pods serve VMs
+	// which in turn run the guest cluster nodes. We use the pods to compare them
+	// against the guest cluster nodes below.
+	var pods []corev1.Pod
+	{
+		n := key.ClusterID(customObject)
+		list, err := r.k8sClient.CoreV1().Pods(n).List(metav1.ListOptions{})
+		if err != nil {
+			return microerror.Mask(err)
+		}
+		pods = list.Items
+	}
+
+	// Iterate through all nodes and compare them against the pods of the host
+	// cluster. Nodes being in a Ready state are fine. Nodes that belong to host
+	// cluster pods are also ok. If a guest cluster node does not have an
+	// associated host cluster pod, we delete it from the guest cluster's
+	// Kubernetes API.
+	for _, n := range nodes {
+		if node.IsNodeReady(&n) {
+			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("not deleting node '%s' because it is in state 'Ready'", n.GetName()))
+			continue
+		}
+
+		if doesNodeExistAsPod(pods, n) {
+			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("not deleting node '%s' because its host cluster pod does exist", n.GetName()))
+			continue
+		}
+
+		if isPodOfNodeRunning(pods, n) {
+			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("not deleting node '%s' because its host cluster pod is running", n.GetName()))
+			continue
+		}
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleting node '%s' in the guest cluster's Kubernetes API", n.GetName()))
+
+		err = k8sClient.CoreV1().Nodes().Delete(n.GetName(), nil)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("deleted node '%s' in the guest cluster's Kubernetes API", n.GetName()))
+	}
+
+	return nil
+}
+
+func doesNodeExistAsPod(pods []corev1.Pod, n corev1.Node) bool {
+	for _, p := range pods {
+		if p.GetName() == n.GetName() {
+			return true
+		}
+	}
+
+	return false
+}
+
+func isPodOfNodeRunning(pods []corev1.Pod, n corev1.Node) bool {
+	for _, p := range pods {
+		if p.GetName() == n.GetName() {
+			if p.Status.Phase == corev1.PodRunning {
+				return true
+			}
+		}
+	}
+
+	return false
+}

--- a/service/controller/v14patch1/resource/node/delete.go
+++ b/service/controller/v14patch1/resource/node/delete.go
@@ -1,0 +1,9 @@
+package node
+
+import (
+	"context"
+)
+
+func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
+	return nil
+}

--- a/service/controller/v14patch1/resource/node/error.go
+++ b/service/controller/v14patch1/resource/node/error.go
@@ -1,0 +1,14 @@
+package node
+
+import (
+	"github.com/giantswarm/microerror"
+)
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}

--- a/service/controller/v14patch1/resource/node/resource.go
+++ b/service/controller/v14patch1/resource/node/resource.go
@@ -1,0 +1,48 @@
+package node
+
+import (
+	"github.com/giantswarm/certs"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	Name = "nodev14"
+)
+
+type Config struct {
+	CertsSearcher certs.Interface
+	K8sClient     kubernetes.Interface
+	Logger        micrologger.Logger
+}
+
+type Resource struct {
+	certsSearcher certs.Interface
+	k8sClient     kubernetes.Interface
+	logger        micrologger.Logger
+}
+
+func New(config Config) (*Resource, error) {
+	if config.CertsSearcher == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.CertsSearcher must not be empty", config)
+	}
+	if config.K8sClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.K8sClient must not be empty", config)
+	}
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+
+	r := &Resource{
+		certsSearcher: config.CertsSearcher,
+		k8sClient:     config.K8sClient,
+		logger:        config.Logger,
+	}
+
+	return r, nil
+}
+
+func (r *Resource) Name() string {
+	return Name
+}

--- a/service/controller/v14patch1/resource/pod/create.go
+++ b/service/controller/v14patch1/resource/pod/create.go
@@ -1,0 +1,9 @@
+package pod
+
+import (
+	"context"
+)
+
+func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
+	return nil
+}

--- a/service/controller/v14patch1/resource/pod/delete.go
+++ b/service/controller/v14patch1/resource/pod/delete.go
@@ -1,0 +1,223 @@
+package pod
+
+import (
+	"context"
+
+	corev1alpha1 "github.com/giantswarm/apiextensions/pkg/apis/core/v1alpha1"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/operatorkit/controller/context/finalizerskeptcontext"
+	"github.com/giantswarm/operatorkit/controller/context/resourcecanceledcontext"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/giantswarm/kvm-operator/service/controller/v14/key"
+)
+
+func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
+	reconciledPod, err := key.ToPod(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	var currentPod *corev1.Pod
+	{
+		r.logger.LogCtx(ctx, "level", "debug", "message", "looking for the current version of the reconciled pod in the Kubernetes API")
+
+		currentPod, err = r.k8sClient.CoreV1().Pods(reconciledPod.GetNamespace()).Get(reconciledPod.Name, metav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			// In case we reconcile a pod we cannot find anymore this means the
+			// informer's watch event is outdated and the pod got already deleted in
+			// the Kubernetes API. This is a normal transition behaviour, so we just
+			// ignore it and assume we are done.
+			r.logger.LogCtx(ctx, "level", "debug", "message", "cannot find the current version of the reconciled pod in the Kubernetes API")
+			resourcecanceledcontext.SetCanceled(ctx)
+			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling reconciliation for pod")
+
+			return nil
+		} else if err != nil {
+			return microerror.Mask(err)
+		}
+		r.logger.LogCtx(ctx, "level", "debug", "message", "found the current version of the reconciled pod in the Kubernetes API")
+	}
+
+	{
+		isDrained, err := key.IsPodDraind(currentPod)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+		if isDrained {
+			r.logger.LogCtx(ctx, "level", "debug", "message", "pod is already drained")
+			resourcecanceledcontext.SetCanceled(ctx)
+			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+
+			return nil
+		}
+	}
+
+	{
+		r.logger.LogCtx(ctx, "level", "debug", "message", "looking for the drainer config for the guest cluster")
+
+		n := currentPod.GetNamespace()
+		p := currentPod.GetName()
+		o := metav1.GetOptions{}
+
+		drainerConfig, err := r.g8sClient.CoreV1alpha1().DrainerConfigs(n).Get(p, o)
+		if apierrors.IsNotFound(err) {
+			r.logger.LogCtx(ctx, "level", "debug", "message", "did not find drainer config for guest cluster node")
+
+			err := r.createDrainerConfig(ctx, currentPod)
+			if err != nil {
+				return microerror.Mask(err)
+			}
+
+			resourcecanceledcontext.SetCanceled(ctx)
+			finalizerskeptcontext.SetKept(ctx)
+			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling reconciliation for pod")
+			return nil
+
+		} else if err != nil {
+			return microerror.Mask(err)
+		} else {
+			r.logger.LogCtx(ctx, "level", "debug", "message", "found drainer config for the guest cluster")
+
+			r.logger.LogCtx(ctx, "level", "debug", "message", "waiting for inspection of the reconciled pod")
+		}
+
+		if drainerConfig.Status.HasDrainedCondition() {
+			r.logger.LogCtx(ctx, "level", "debug", "message", "drainer config of guest cluster has drained condition")
+
+			err := r.finishDraining(ctx, currentPod, drainerConfig)
+			if err != nil {
+				return microerror.Mask(err)
+			}
+		}
+
+		if drainerConfig.Status.HasTimeoutCondition() {
+			r.logger.LogCtx(ctx, "level", "debug", "message", "drainer config of guest cluster has timeout condition")
+
+			err := r.finishDraining(ctx, currentPod, drainerConfig)
+			if err != nil {
+				return microerror.Mask(err)
+			}
+		}
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", "drainer config of guest cluster has no drained condition")
+	resourcecanceledcontext.SetCanceled(ctx)
+	finalizerskeptcontext.SetKept(ctx)
+	r.logger.LogCtx(ctx, "level", "debug", "message", "canceling reconciliation")
+
+	return nil
+}
+
+func (r *Resource) createDrainerConfig(ctx context.Context, pod *corev1.Pod) error {
+	r.logger.LogCtx(ctx, "level", "debug", "message", "creating drainer config for guest cluster node")
+
+	apiEndpoint, err := key.ClusterAPIEndpointFromPod(pod)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	n := pod.GetNamespace()
+	c := &corev1alpha1.DrainerConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: pod.GetName(),
+		},
+		Spec: corev1alpha1.DrainerConfigSpec{
+			Guest: corev1alpha1.DrainerConfigSpecGuest{
+				Cluster: corev1alpha1.DrainerConfigSpecGuestCluster{
+					API: corev1alpha1.DrainerConfigSpecGuestClusterAPI{
+						Endpoint: apiEndpoint,
+					},
+					ID: pod.GetNamespace(),
+				},
+				Node: corev1alpha1.DrainerConfigSpecGuestNode{
+					Name: pod.GetName(),
+				},
+			},
+			VersionBundle: corev1alpha1.DrainerConfigSpecVersionBundle{
+				Version: "0.1.0",
+			},
+		},
+	}
+
+	_, err = r.g8sClient.CoreV1alpha1().DrainerConfigs(n).Create(c)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", "created drainer config for guest cluster node")
+
+	return nil
+}
+
+func (r *Resource) finishDraining(ctx context.Context, currentPod *corev1.Pod, drainerConfig *corev1alpha1.DrainerConfig) error {
+	var err error
+
+	{
+		r.logger.LogCtx(ctx, "level", "debug", "message", "deleting drainer config for guest cluster node")
+
+		n := currentPod.GetNamespace()
+		i := currentPod.GetName()
+		o := &metav1.DeleteOptions{}
+
+		err := r.g8sClient.CoreV1alpha1().DrainerConfigs(n).Delete(i, o)
+		if apierrors.IsNotFound(err) {
+			r.logger.LogCtx(ctx, "level", "debug", "message", "drainer config for guest cluster node already deleted")
+		} else if err != nil {
+			return microerror.Mask(err)
+		} else {
+			r.logger.LogCtx(ctx, "level", "debug", "message", "deleted drainer config for guest cluster node")
+		}
+	}
+
+	var podToDelete *corev1.Pod
+	{
+		podToDelete = currentPod
+
+		a := podToDelete.GetAnnotations()
+		a[key.AnnotationPodDrained] = "True"
+		podToDelete.SetAnnotations(a)
+	}
+
+	{
+		r.logger.LogCtx(ctx, "level", "debug", "message", "updating the pod in the Kubernetes API")
+
+		_, err := r.k8sClient.CoreV1().Pods(podToDelete.Namespace).Update(podToDelete)
+		if apierrors.IsConflict(err) {
+			// The reconciled pod may be updated by other processes or even humans
+			// meanwhile. In case the resource version we currently know does not
+			// match the latest existing one, we give up here and wait for the
+			// delete event to be replayed. Then we try again later until we
+			// succeed.
+			r.logger.LogCtx(ctx, "level", "debug", "message", "cannot update the pod in the Kubernetes API due to outdated resource version")
+			resourcecanceledcontext.SetCanceled(ctx)
+			finalizerskeptcontext.SetKept(ctx)
+			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling reconciliation")
+
+			return nil
+		} else if err != nil {
+			return microerror.Mask(err)
+		}
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", "updated the pod in the Kubernetes API")
+	}
+
+	{
+		r.logger.LogCtx(ctx, "level", "debug", "message", "deleting the pod in the Kubernetes API")
+
+		gracePeriodSeconds := int64(0)
+		options := &metav1.DeleteOptions{
+			GracePeriodSeconds: &gracePeriodSeconds,
+		}
+		err = r.k8sClient.CoreV1().Pods(podToDelete.Namespace).Delete(podToDelete.Name, options)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", "deleted the pod in the Kubernetes API")
+	}
+
+	return nil
+}

--- a/service/controller/v14patch1/resource/pod/error.go
+++ b/service/controller/v14patch1/resource/pod/error.go
@@ -1,0 +1,21 @@
+package pod
+
+import "github.com/giantswarm/microerror"
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var wrongTypeError = &microerror.Error{
+	Kind: "wrongTypeError",
+}
+
+// IsWrongTypeError asserts wrongTypeError.
+func IsWrongTypeError(err error) bool {
+	return microerror.Cause(err) == wrongTypeError
+}

--- a/service/controller/v14patch1/resource/pod/resource.go
+++ b/service/controller/v14patch1/resource/pod/resource.go
@@ -1,0 +1,48 @@
+package pod
+
+import (
+	"github.com/giantswarm/apiextensions/pkg/clientset/versioned"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	Name = "podv14"
+)
+
+type Config struct {
+	G8sClient versioned.Interface
+	K8sClient kubernetes.Interface
+	Logger    micrologger.Logger
+}
+
+type Resource struct {
+	g8sClient versioned.Interface
+	k8sClient kubernetes.Interface
+	logger    micrologger.Logger
+}
+
+func New(config Config) (*Resource, error) {
+	if config.G8sClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.G8sClient must not be empty", config)
+	}
+	if config.K8sClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.K8sClient must not be empty", config)
+	}
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+
+	r := &Resource{
+		g8sClient: config.G8sClient,
+		k8sClient: config.K8sClient,
+		logger:    config.Logger,
+	}
+
+	return r, nil
+}
+
+func (r *Resource) Name() string {
+	return Name
+}

--- a/service/controller/v14patch1/resource/pvc/create.go
+++ b/service/controller/v14patch1/resource/pvc/create.go
@@ -1,0 +1,68 @@
+package pvc
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/giantswarm/microerror"
+	apiv1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+
+	"github.com/giantswarm/kvm-operator/service/controller/v14/key"
+)
+
+func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange interface{}) error {
+	customObject, err := key.ToCustomObject(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	pvcsToCreate, err := toPVCs(createChange)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	if len(pvcsToCreate) != 0 {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "creating the PVCs in the Kubernetes API")
+
+		namespace := key.ClusterNamespace(customObject)
+		for _, PVC := range pvcsToCreate {
+			_, err := r.k8sClient.Core().PersistentVolumeClaims(namespace).Create(PVC)
+			if apierrors.IsAlreadyExists(err) {
+				// fall through
+			} else if err != nil {
+				return microerror.Mask(err)
+			}
+		}
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", "created the PVCs in the Kubernetes API")
+	} else {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "the PVCs do not need to be created in the Kubernetes API")
+	}
+
+	return nil
+}
+
+func (r *Resource) newCreateChange(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, error) {
+	currentPVCs, err := toPVCs(currentState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+	desiredPVCs, err := toPVCs(desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", "finding out which PVCs have to be created")
+
+	var pvcsToCreate []*apiv1.PersistentVolumeClaim
+
+	for _, desiredPVC := range desiredPVCs {
+		if !containsPVC(currentPVCs, desiredPVC) {
+			pvcsToCreate = append(pvcsToCreate, desiredPVC)
+		}
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("found %d PVCs that have to be created", len(pvcsToCreate)))
+
+	return pvcsToCreate, nil
+}

--- a/service/controller/v14patch1/resource/pvc/create_test.go
+++ b/service/controller/v14patch1/resource/pvc/create_test.go
@@ -1,0 +1,243 @@
+package pvc
+
+import (
+	"context"
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/micrologger/microloggertest"
+	apiv1 "k8s.io/api/core/v1"
+	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func Test_Resource_PVC_newCreateChange(t *testing.T) {
+	testCases := []struct {
+		Obj              interface{}
+		CurrentState     interface{}
+		DesiredState     interface{}
+		ExpectedPVCNames []string
+	}{
+		// Test 1, in case current state and desired state are empty the create
+		// state should be empty.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState:     []*apiv1.PersistentVolumeClaim{},
+			DesiredState:     []*apiv1.PersistentVolumeClaim{},
+			ExpectedPVCNames: []string{},
+		},
+
+		// Test 2, in case current state equals desired state the create state
+		// should be empty.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState: []*apiv1.PersistentVolumeClaim{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "pvc-1",
+					},
+				},
+			},
+			DesiredState: []*apiv1.PersistentVolumeClaim{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "pvc-1",
+					},
+				},
+			},
+			ExpectedPVCNames: []string{},
+		},
+
+		// Test 3, in case current state misses one item of desired state the create
+		// state should contain the missing item of the desired state.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState: []*apiv1.PersistentVolumeClaim{},
+			DesiredState: []*apiv1.PersistentVolumeClaim{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "pvc-1",
+					},
+				},
+			},
+			ExpectedPVCNames: []string{
+				"pvc-1",
+			},
+		},
+
+		// Test 4, in case current state misses items of desired state the create
+		// state should contain the missing items of the desired state.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState: []*apiv1.PersistentVolumeClaim{},
+			DesiredState: []*apiv1.PersistentVolumeClaim{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "pvc-1",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "pvc-2",
+					},
+				},
+			},
+			ExpectedPVCNames: []string{
+				"pvc-1",
+				"pvc-2",
+			},
+		},
+
+		// Test 5, in case current state contains one item not being in desired
+		// state the create state should not contain the missing item of the desired
+		// state.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState: []*apiv1.PersistentVolumeClaim{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "pvc-1",
+					},
+				},
+			},
+			DesiredState:     []*apiv1.PersistentVolumeClaim{},
+			ExpectedPVCNames: []string{},
+		},
+
+		// Test 6, in case current state contains items not being in desired state
+		// the create state should not contain the missing items of the desired
+		// state.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState: []*apiv1.PersistentVolumeClaim{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "pvc-1",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "pvc-2",
+					},
+				},
+			},
+			DesiredState:     []*apiv1.PersistentVolumeClaim{},
+			ExpectedPVCNames: []string{},
+		},
+
+		// Test 7, in case current state contains some items of desired state the
+		// create state should contain the items being in desired state which are
+		// not in create state.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState: []*apiv1.PersistentVolumeClaim{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "pvc-1",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "pvc-2",
+					},
+				},
+			},
+			DesiredState: []*apiv1.PersistentVolumeClaim{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "pvc-1",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "pvc-2",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "pvc-3",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "pvc-4",
+					},
+				},
+			},
+			ExpectedPVCNames: []string{
+				"pvc-3",
+				"pvc-4",
+			},
+		},
+	}
+
+	var err error
+	var newResource *Resource
+	{
+		resourceConfig := DefaultConfig()
+		resourceConfig.K8sClient = fake.NewSimpleClientset()
+		resourceConfig.Logger = microloggertest.New()
+		newResource, err = New(resourceConfig)
+		if err != nil {
+			t.Fatal("expected", nil, "got", err)
+		}
+	}
+
+	for i, tc := range testCases {
+		result, err := newResource.newCreateChange(context.TODO(), tc.Obj, tc.CurrentState, tc.DesiredState)
+		if err != nil {
+			t.Fatalf("case %d expected %#v got %#v", i+1, nil, err)
+		}
+
+		configMaps, ok := result.([]*apiv1.PersistentVolumeClaim)
+		if !ok {
+			t.Fatalf("case %d expected %T got %T", i+1, []*apiv1.PersistentVolumeClaim{}, result)
+		}
+
+		if len(configMaps) != len(tc.ExpectedPVCNames) {
+			t.Fatalf("case %d expected %d config maps got %d", i+1, len(tc.ExpectedPVCNames), len(configMaps))
+		}
+	}
+}

--- a/service/controller/v14patch1/resource/pvc/current.go
+++ b/service/controller/v14patch1/resource/pvc/current.go
@@ -1,0 +1,44 @@
+package pvc
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/giantswarm/microerror"
+	apiv1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/giantswarm/kvm-operator/service/controller/v14/key"
+)
+
+func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interface{}, error) {
+	customObject, err := key.ToCustomObject(obj)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", "looking for PVCs in the Kubernetes API")
+
+	var PVCs []*apiv1.PersistentVolumeClaim
+
+	namespace := key.ClusterNamespace(customObject)
+	pvcNames := key.PVCNames(customObject)
+
+	for _, name := range pvcNames {
+		manifest, err := r.k8sClient.Core().PersistentVolumeClaims(namespace).Get(name, apismetav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			r.logger.LogCtx(ctx, "level", "debug", "message", "did not find a PVC in the Kubernetes API")
+			// fall through
+		} else if err != nil {
+			return nil, microerror.Mask(err)
+		} else {
+			r.logger.LogCtx(ctx, "level", "debug", "message", "found a PVC in the Kubernetes API")
+			PVCs = append(PVCs, manifest)
+		}
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("found %d PVCs in the Kubernetes API", len(PVCs)))
+
+	return PVCs, nil
+}

--- a/service/controller/v14patch1/resource/pvc/delete.go
+++ b/service/controller/v14patch1/resource/pvc/delete.go
@@ -1,0 +1,82 @@
+package pvc
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/operatorkit/controller"
+	apiv1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/giantswarm/kvm-operator/service/controller/v14/key"
+)
+
+func (r *Resource) ApplyDeleteChange(ctx context.Context, obj, deleteChange interface{}) error {
+	customObject, err := key.ToCustomObject(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	pvcsToDelete, err := toPVCs(deleteChange)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	if len(pvcsToDelete) != 0 {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "deleting the PVCs in the Kubernetes API")
+
+		namespace := key.ClusterNamespace(customObject)
+		for _, PVC := range pvcsToDelete {
+			err := r.k8sClient.Core().PersistentVolumeClaims(namespace).Delete(PVC.Name, &apismetav1.DeleteOptions{})
+			if apierrors.IsNotFound(err) {
+				// fall through
+			} else if err != nil {
+				return microerror.Mask(err)
+			}
+		}
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", "deleted the PVCs in the Kubernetes API")
+	} else {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "the PVCs do not need to be deleted from the Kubernetes API")
+	}
+
+	return nil
+}
+
+func (r *Resource) NewDeletePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*controller.Patch, error) {
+	delete, err := r.newDeleteChange(ctx, obj, currentState, desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	patch := controller.NewPatch()
+	patch.SetDeleteChange(delete)
+
+	return patch, nil
+}
+
+func (r *Resource) newDeleteChange(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, error) {
+	currentPVCs, err := toPVCs(currentState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+	desiredPVCs, err := toPVCs(desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", "finding out which PVCs have to be deleted")
+
+	var pvcsToDelete []*apiv1.PersistentVolumeClaim
+
+	for _, currentPVC := range currentPVCs {
+		if containsPVC(desiredPVCs, currentPVC) {
+			pvcsToDelete = append(pvcsToDelete, currentPVC)
+		}
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("found %d PVCs that have to be deleted", len(pvcsToDelete)))
+
+	return pvcsToDelete, nil
+}

--- a/service/controller/v14patch1/resource/pvc/delete_test.go
+++ b/service/controller/v14patch1/resource/pvc/delete_test.go
@@ -1,0 +1,289 @@
+package pvc
+
+import (
+	"context"
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/micrologger/microloggertest"
+	apiv1 "k8s.io/api/core/v1"
+	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func Test_Resource_PVC_newDeleteChange(t *testing.T) {
+	testCases := []struct {
+		Obj              interface{}
+		CurrentState     interface{}
+		DesiredState     interface{}
+		ExpectedPVCNames []string
+	}{
+		// Test 1, in case current state and desired state are empty the delete
+		// state should be empty.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState:     []*apiv1.PersistentVolumeClaim{},
+			DesiredState:     []*apiv1.PersistentVolumeClaim{},
+			ExpectedPVCNames: []string{},
+		},
+
+		// Test 2, in case current state has one item and equals desired state the
+		// delete state should equal the current state.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState: []*apiv1.PersistentVolumeClaim{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "pvc-1",
+					},
+				},
+			},
+			DesiredState: []*apiv1.PersistentVolumeClaim{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "pvc-1",
+					},
+				},
+			},
+			ExpectedPVCNames: []string{
+				"pvc-1",
+			},
+		},
+
+		// Test 3, in case current state misses one item of desired state the delete
+		// state should not contain the missing item of the desired state.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState: []*apiv1.PersistentVolumeClaim{},
+			DesiredState: []*apiv1.PersistentVolumeClaim{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "pvc-1",
+					},
+				},
+			},
+			ExpectedPVCNames: []string{},
+		},
+
+		// Test 4, in case current state misses items of desired state the delete
+		// state should not contain the missing items of the desired state.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState: []*apiv1.PersistentVolumeClaim{},
+			DesiredState: []*apiv1.PersistentVolumeClaim{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "pvc-1",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "pvc-2",
+					},
+				},
+			},
+			ExpectedPVCNames: []string{},
+		},
+
+		// Test 5, in case current state contains one item and desired state is
+		// empty the delete state should be empty.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState: []*apiv1.PersistentVolumeClaim{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "pvc-1",
+					},
+				},
+			},
+			DesiredState:     []*apiv1.PersistentVolumeClaim{},
+			ExpectedPVCNames: []string{},
+		},
+
+		// Test 6, in case current state contains items and desired state is empty
+		// the delete state should be empty.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState: []*apiv1.PersistentVolumeClaim{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "pvc-1",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "pvc-2",
+					},
+				},
+			},
+			DesiredState:     []*apiv1.PersistentVolumeClaim{},
+			ExpectedPVCNames: []string{},
+		},
+
+		// Test 7, in case all items of current state are in desired state and
+		// desired state contains more items not being in current state the create
+		// state should contain all items being in current state.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState: []*apiv1.PersistentVolumeClaim{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "pvc-1",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "pvc-2",
+					},
+				},
+			},
+			DesiredState: []*apiv1.PersistentVolumeClaim{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "pvc-1",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "pvc-2",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "pvc-3",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "pvc-4",
+					},
+				},
+			},
+			ExpectedPVCNames: []string{
+				"pvc-1",
+				"pvc-2",
+			},
+		},
+
+		// Test 8, in case all items of desired state are in current state and
+		// current state contains more items not being in desired state the create
+		// state should contain all items being in desired state.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState: []*apiv1.PersistentVolumeClaim{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "pvc-1",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "pvc-2",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "pvc-3",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "pvc-4",
+					},
+				},
+			},
+			DesiredState: []*apiv1.PersistentVolumeClaim{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "pvc-1",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "pvc-2",
+					},
+				},
+			},
+			ExpectedPVCNames: []string{
+				"pvc-1",
+				"pvc-2",
+			},
+		},
+	}
+
+	var err error
+	var newResource *Resource
+	{
+		resourceConfig := DefaultConfig()
+		resourceConfig.K8sClient = fake.NewSimpleClientset()
+		resourceConfig.Logger = microloggertest.New()
+		newResource, err = New(resourceConfig)
+		if err != nil {
+			t.Fatal("expected", nil, "got", err)
+		}
+	}
+
+	for i, tc := range testCases {
+		result, err := newResource.newDeleteChange(context.TODO(), tc.Obj, tc.CurrentState, tc.DesiredState)
+		if err != nil {
+			t.Fatalf("case %d expected %#v got %#v", i+1, nil, err)
+		}
+
+		configMaps, ok := result.([]*apiv1.PersistentVolumeClaim)
+		if !ok {
+			t.Fatalf("case %d expected %T got %T", i+1, []*apiv1.PersistentVolumeClaim{}, result)
+		}
+
+		if len(configMaps) != len(tc.ExpectedPVCNames) {
+			t.Fatalf("case %d expected %d config maps got %d", i+1, len(tc.ExpectedPVCNames), len(configMaps))
+		}
+	}
+}

--- a/service/controller/v14patch1/resource/pvc/desired.go
+++ b/service/controller/v14patch1/resource/pvc/desired.go
@@ -1,0 +1,35 @@
+package pvc
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/giantswarm/microerror"
+	apiv1 "k8s.io/api/core/v1"
+
+	"github.com/giantswarm/kvm-operator/service/controller/v14/key"
+)
+
+func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interface{}, error) {
+	customObject, err := key.ToCustomObject(obj)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	var PVCs []*apiv1.PersistentVolumeClaim
+
+	if key.StorageType(customObject) == "persistentVolume" {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "computing the new PVCs")
+
+		PVCs, err = newEtcdPVCs(customObject)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("computed the %d new PVCs", len(PVCs)))
+	} else {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "not computing the new PVCs because storage type is not 'persistentVolume'")
+	}
+
+	return PVCs, nil
+}

--- a/service/controller/v14patch1/resource/pvc/desired_test.go
+++ b/service/controller/v14patch1/resource/pvc/desired_test.go
@@ -1,0 +1,221 @@
+package pvc
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/micrologger/microloggertest"
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func Test_Resource_PVC_GetDesiredState(t *testing.T) {
+	testCases := []struct {
+		Obj               interface{}
+		ExpectedEtcdCount int
+	}{
+		// Test 1 ensures there is one PVC for each master when there is one master
+		// and one worker node and storage type is 'persistentVolume' in the custom
+		// object.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+						Masters: []v1alpha1.ClusterNode{
+							{},
+						},
+						Workers: []v1alpha1.ClusterNode{
+							{},
+						},
+					},
+					KVM: v1alpha1.KVMConfigSpecKVM{
+						K8sKVM: v1alpha1.KVMConfigSpecKVMK8sKVM{
+							StorageType: "persistentVolume",
+						},
+					},
+				},
+			},
+			ExpectedEtcdCount: 1,
+		},
+
+		// Test 2 ensures there is one PVC for each master when there is one master
+		// and three worker nodes and storage type is 'persistentVolume' in the
+		// custom object.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+						Masters: []v1alpha1.ClusterNode{
+							{},
+						},
+						Workers: []v1alpha1.ClusterNode{
+							{},
+							{},
+							{},
+						},
+					},
+					KVM: v1alpha1.KVMConfigSpecKVM{
+						K8sKVM: v1alpha1.KVMConfigSpecKVMK8sKVM{
+							StorageType: "persistentVolume",
+						},
+					},
+				},
+			},
+			ExpectedEtcdCount: 1,
+		},
+
+		// Test 3 ensures there is one PVC for each master when there are three
+		// master and three worker nodes and storage type is 'persistentVolume' in
+		// the custom object.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+						Masters: []v1alpha1.ClusterNode{
+							{},
+							{},
+							{},
+						},
+						Workers: []v1alpha1.ClusterNode{
+							{},
+							{},
+							{},
+						},
+					},
+					KVM: v1alpha1.KVMConfigSpecKVM{
+						K8sKVM: v1alpha1.KVMConfigSpecKVMK8sKVM{
+							StorageType: "persistentVolume",
+						},
+					},
+				},
+			},
+			ExpectedEtcdCount: 3,
+		},
+
+		// Test 4 ensures there is no PVC for each master when there is one master
+		// and one worker node and storage type is 'hostPath' in the custom
+		// object.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+						Masters: []v1alpha1.ClusterNode{
+							{},
+						},
+						Workers: []v1alpha1.ClusterNode{
+							{},
+						},
+					},
+					KVM: v1alpha1.KVMConfigSpecKVM{
+						K8sKVM: v1alpha1.KVMConfigSpecKVMK8sKVM{
+							StorageType: "hostPath",
+						},
+					},
+				},
+			},
+			ExpectedEtcdCount: 0,
+		},
+
+		// Test 5 ensures there is no PVC for each master when there is one master
+		// and three worker nodes and storage type is 'hostPath' in the
+		// custom object.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+						Masters: []v1alpha1.ClusterNode{
+							{},
+						},
+						Workers: []v1alpha1.ClusterNode{
+							{},
+							{},
+							{},
+						},
+					},
+					KVM: v1alpha1.KVMConfigSpecKVM{
+						K8sKVM: v1alpha1.KVMConfigSpecKVMK8sKVM{
+							StorageType: "hostPath",
+						},
+					},
+				},
+			},
+			ExpectedEtcdCount: 0,
+		},
+
+		// Test 6 ensures there is no PVC for each master when there are three
+		// master and three worker nodes and storage type is 'hostPath' in
+		// the custom object.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+						Masters: []v1alpha1.ClusterNode{
+							{},
+							{},
+							{},
+						},
+						Workers: []v1alpha1.ClusterNode{
+							{},
+							{},
+							{},
+						},
+					},
+					KVM: v1alpha1.KVMConfigSpecKVM{
+						K8sKVM: v1alpha1.KVMConfigSpecKVMK8sKVM{
+							StorageType: "hostPath",
+						},
+					},
+				},
+			},
+			ExpectedEtcdCount: 0,
+		},
+	}
+
+	var err error
+	var newResource *Resource
+	{
+		resourceConfig := DefaultConfig()
+		resourceConfig.K8sClient = fake.NewSimpleClientset()
+		resourceConfig.Logger = microloggertest.New()
+		newResource, err = New(resourceConfig)
+		if err != nil {
+			t.Fatal("expected", nil, "got", err)
+		}
+	}
+
+	for i, tc := range testCases {
+		result, err := newResource.GetDesiredState(context.TODO(), tc.Obj)
+		if err != nil {
+			t.Fatalf("case %d expected %#v got %#v", i+1, nil, err)
+		}
+
+		PVCs, ok := result.([]*apiv1.PersistentVolumeClaim)
+		if !ok {
+			t.Fatalf("case %d expected %T got %T", i+1, []*apiv1.PersistentVolumeClaim{}, result)
+		}
+
+		if testGetEtcdCount(PVCs) != tc.ExpectedEtcdCount {
+			t.Fatalf("case %d expected %d worker nodes got %d", i+1, tc.ExpectedEtcdCount, testGetEtcdCount(PVCs))
+		}
+	}
+}
+
+func testGetEtcdCount(PVCs []*apiv1.PersistentVolumeClaim) int {
+	var count int
+
+	for _, i := range PVCs {
+		if strings.HasPrefix(i.Name, "pvc-master-etcd") {
+			count++
+		}
+	}
+
+	return count
+}

--- a/service/controller/v14patch1/resource/pvc/error.go
+++ b/service/controller/v14patch1/resource/pvc/error.go
@@ -1,0 +1,21 @@
+package pvc
+
+import "github.com/giantswarm/microerror"
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var wrongTypeError = &microerror.Error{
+	Kind: "wrongTypeError",
+}
+
+// IsWrongTypeError asserts wrongTypeError.
+func IsWrongTypeError(err error) bool {
+	return microerror.Cause(err) == wrongTypeError
+}

--- a/service/controller/v14patch1/resource/pvc/etcd_pvc.go
+++ b/service/controller/v14patch1/resource/pvc/etcd_pvc.go
@@ -1,0 +1,60 @@
+package pvc
+
+import (
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/microerror"
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/giantswarm/kvm-operator/service/controller/v14/key"
+)
+
+const (
+	// EtcdPVSize is the size the persistent volume for etcd is configured with.
+	EtcdPVSize = "15Gi"
+)
+
+func newEtcdPVCs(customObject v1alpha1.KVMConfig) ([]*apiv1.PersistentVolumeClaim, error) {
+	var persistentVolumeClaims []*apiv1.PersistentVolumeClaim
+
+	for i, masterNode := range customObject.Spec.Cluster.Masters {
+		quantity, err := resource.ParseQuantity(EtcdPVSize)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+
+		persistentVolumeClaim := &apiv1.PersistentVolumeClaim{
+			TypeMeta: apismetav1.TypeMeta{
+				Kind:       "PersistentVolumeClaim",
+				APIVersion: "v1",
+			},
+			ObjectMeta: apismetav1.ObjectMeta{
+				Name: key.EtcdPVCName(key.ClusterID(customObject), key.VMNumber(i)),
+				Labels: map[string]string{
+					"app":      key.MasterID,
+					"cluster":  key.ClusterID(customObject),
+					"customer": key.ClusterCustomer(customObject),
+					"node":     masterNode.ID,
+				},
+				Annotations: map[string]string{
+					"volume.beta.kubernetes.io/storage-class": StorageClass,
+				},
+			},
+			Spec: apiv1.PersistentVolumeClaimSpec{
+				AccessModes: []apiv1.PersistentVolumeAccessMode{
+					apiv1.ReadWriteOnce,
+				},
+				Resources: apiv1.ResourceRequirements{
+					Requests: map[apiv1.ResourceName]resource.Quantity{
+						apiv1.ResourceStorage: quantity,
+					},
+				},
+			},
+		}
+
+		persistentVolumeClaims = append(persistentVolumeClaims, persistentVolumeClaim)
+	}
+
+	return persistentVolumeClaims, nil
+}

--- a/service/controller/v14patch1/resource/pvc/resource.go
+++ b/service/controller/v14patch1/resource/pvc/resource.go
@@ -1,0 +1,86 @@
+package pvc
+
+import (
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	// Name is the identifier of the resource.
+	Name = "pvcv14"
+	// StorageClass is the storage class annotation persistent volume claims are
+	// configured with.
+	StorageClass = "g8s-storage"
+)
+
+// Config represents the configuration used to create a new PVC resource.
+type Config struct {
+	// Dependencies.
+	K8sClient kubernetes.Interface
+	Logger    micrologger.Logger
+}
+
+// DefaultConfig provides a default configuration to create a new PVC
+// resource by best effort.
+func DefaultConfig() Config {
+	return Config{
+		// Dependencies.
+		K8sClient: nil,
+		Logger:    nil,
+	}
+}
+
+// Resource implements the PVC resource.
+type Resource struct {
+	// Dependencies.
+	k8sClient kubernetes.Interface
+	logger    micrologger.Logger
+}
+
+// New creates a new configured PVC resource.
+func New(config Config) (*Resource, error) {
+	// Dependencies.
+	if config.K8sClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "config.K8sClient must not be empty")
+	}
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "config.Logger must not be empty")
+	}
+
+	newResource := &Resource{
+		// Dependencies.
+		k8sClient: config.K8sClient,
+		logger:    config.Logger,
+	}
+
+	return newResource, nil
+}
+
+func (r *Resource) Name() string {
+	return Name
+}
+
+func containsPVC(list []*apiv1.PersistentVolumeClaim, item *apiv1.PersistentVolumeClaim) bool {
+	for _, l := range list {
+		if l.Name == item.Name {
+			return true
+		}
+	}
+
+	return false
+}
+
+func toPVCs(v interface{}) ([]*apiv1.PersistentVolumeClaim, error) {
+	if v == nil {
+		return nil, nil
+	}
+
+	PVCs, ok := v.([]*apiv1.PersistentVolumeClaim)
+	if !ok {
+		return nil, microerror.Maskf(wrongTypeError, "expected '%T', got '%T'", []*apiv1.PersistentVolumeClaim{}, v)
+	}
+
+	return PVCs, nil
+}

--- a/service/controller/v14patch1/resource/pvc/update.go
+++ b/service/controller/v14patch1/resource/pvc/update.go
@@ -1,0 +1,34 @@
+package pvc
+
+import (
+	"context"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/operatorkit/controller"
+)
+
+func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateChange interface{}) error {
+	return nil
+}
+
+func (r *Resource) NewUpdatePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*controller.Patch, error) {
+	create, err := r.newCreateChange(ctx, obj, currentState, desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	update, err := r.newUpdateChange(ctx, obj, currentState, desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	patch := controller.NewPatch()
+	patch.SetCreateChange(create)
+	patch.SetUpdateChange(update)
+
+	return patch, nil
+}
+
+func (r *Resource) newUpdateChange(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, error) {
+	return nil, nil
+}

--- a/service/controller/v14patch1/resource/service/create.go
+++ b/service/controller/v14patch1/resource/service/create.go
@@ -1,0 +1,68 @@
+package service
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/giantswarm/microerror"
+	apiv1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+
+	"github.com/giantswarm/kvm-operator/service/controller/v14/key"
+)
+
+func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange interface{}) error {
+	customObject, err := key.ToCustomObject(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	servicesToCreate, err := toServices(createChange)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	if len(servicesToCreate) != 0 {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "creating the services in the Kubernetes API")
+
+		namespace := key.ClusterNamespace(customObject)
+		for _, service := range servicesToCreate {
+			_, err := r.k8sClient.CoreV1().Services(namespace).Create(service)
+			if apierrors.IsAlreadyExists(err) {
+				// fall through
+			} else if err != nil {
+				return microerror.Mask(err)
+			}
+		}
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", "created the services in the Kubernetes API")
+	} else {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "the services do not need to be created in the Kubernetes API")
+	}
+
+	return nil
+}
+
+func (r *Resource) newCreateChange(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, error) {
+	currentServices, err := toServices(currentState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+	desiredServices, err := toServices(desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", "finding out which services have to be created")
+
+	var servicesToCreate []*apiv1.Service
+
+	for _, desiredService := range desiredServices {
+		if !containsService(currentServices, desiredService) {
+			servicesToCreate = append(servicesToCreate, desiredService)
+		}
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("found %d services that have to be created", len(servicesToCreate)))
+
+	return servicesToCreate, nil
+}

--- a/service/controller/v14patch1/resource/service/create_test.go
+++ b/service/controller/v14patch1/resource/service/create_test.go
@@ -1,0 +1,243 @@
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/micrologger/microloggertest"
+	apiv1 "k8s.io/api/core/v1"
+	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func Test_Resource_Service_newCreateChange(t *testing.T) {
+	testCases := []struct {
+		Obj                  interface{}
+		CurrentState         interface{}
+		DesiredState         interface{}
+		ExpectedServiceNames []string
+	}{
+		// Test 1, in case current state and desired state are empty the create
+		// state should be empty.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState:         []*apiv1.Service{},
+			DesiredState:         []*apiv1.Service{},
+			ExpectedServiceNames: []string{},
+		},
+
+		// Test 2, in case current state equals desired state the create state
+		// should be empty.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState: []*apiv1.Service{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "service-1",
+					},
+				},
+			},
+			DesiredState: []*apiv1.Service{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "service-1",
+					},
+				},
+			},
+			ExpectedServiceNames: []string{},
+		},
+
+		// Test 3, in case current state misses one item of desired state the create
+		// state should contain the missing item of the desired state.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState: []*apiv1.Service{},
+			DesiredState: []*apiv1.Service{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "service-1",
+					},
+				},
+			},
+			ExpectedServiceNames: []string{
+				"service-1",
+			},
+		},
+
+		// Test 4, in case current state misses items of desired state the create
+		// state should contain the missing items of the desired state.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState: []*apiv1.Service{},
+			DesiredState: []*apiv1.Service{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "service-1",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "service-2",
+					},
+				},
+			},
+			ExpectedServiceNames: []string{
+				"service-1",
+				"service-2",
+			},
+		},
+
+		// Test 5, in case current state contains one item not being in desired
+		// state the create state should not contain the missing item of the desired
+		// state.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState: []*apiv1.Service{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "service-1",
+					},
+				},
+			},
+			DesiredState:         []*apiv1.Service{},
+			ExpectedServiceNames: []string{},
+		},
+
+		// Test 6, in case current state contains items not being in desired state
+		// the create state should not contain the missing items of the desired
+		// state.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState: []*apiv1.Service{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "service-1",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "service-2",
+					},
+				},
+			},
+			DesiredState:         []*apiv1.Service{},
+			ExpectedServiceNames: []string{},
+		},
+
+		// Test 7, in case current state contains some items of desired state the
+		// create state should contain the items being in desired state which are
+		// not in create state.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState: []*apiv1.Service{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "service-1",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "service-2",
+					},
+				},
+			},
+			DesiredState: []*apiv1.Service{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "service-1",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "service-2",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "service-3",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "service-4",
+					},
+				},
+			},
+			ExpectedServiceNames: []string{
+				"service-3",
+				"service-4",
+			},
+		},
+	}
+
+	var err error
+	var newResource *Resource
+	{
+		resourceConfig := DefaultConfig()
+		resourceConfig.K8sClient = fake.NewSimpleClientset()
+		resourceConfig.Logger = microloggertest.New()
+		newResource, err = New(resourceConfig)
+		if err != nil {
+			t.Fatal("expected", nil, "got", err)
+		}
+	}
+
+	for i, tc := range testCases {
+		result, err := newResource.newCreateChange(context.TODO(), tc.Obj, tc.CurrentState, tc.DesiredState)
+		if err != nil {
+			t.Fatalf("case %d expected %#v got %#v", i+1, nil, err)
+		}
+
+		configMaps, ok := result.([]*apiv1.Service)
+		if !ok {
+			t.Fatalf("case %d expected %T got %T", i+1, []*apiv1.Service{}, result)
+		}
+
+		if len(configMaps) != len(tc.ExpectedServiceNames) {
+			t.Fatalf("case %d expected %d config maps got %d", i+1, len(tc.ExpectedServiceNames), len(configMaps))
+		}
+	}
+}

--- a/service/controller/v14patch1/resource/service/current.go
+++ b/service/controller/v14patch1/resource/service/current.go
@@ -1,0 +1,72 @@
+package service
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/operatorkit/controller/context/finalizerskeptcontext"
+	"github.com/giantswarm/operatorkit/controller/context/resourcecanceledcontext"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/giantswarm/kvm-operator/service/controller/v14/key"
+)
+
+func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interface{}, error) {
+	customObject, err := key.ToCustomObject(obj)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", "looking for services in the Kubernetes API")
+
+	var services []*corev1.Service
+
+	namespace := key.ClusterNamespace(customObject)
+	serviceNames := []string{
+		key.MasterID,
+		key.WorkerID,
+	}
+
+	for _, name := range serviceNames {
+		manifest, err := r.k8sClient.CoreV1().Services(namespace).Get(name, metav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			r.logger.LogCtx(ctx, "level", "debug", "message", "did not find a service in the Kubernetes API")
+			// fall through
+		} else if err != nil {
+			return nil, microerror.Mask(err)
+		} else {
+			r.logger.LogCtx(ctx, "level", "debug", "message", "found a service in the Kubernetes API")
+			services = append(services, manifest)
+		}
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("found %d services in the Kubernetes API", len(services)))
+
+	// In case a cluster deletion happens, we want to delete the guest cluster
+	// services. We still need to use the services for ingress routing in order to
+	// drain nodes on KVM though. So as long as pods are there we delay the
+	// deletion of the services here in order to still be able to route traffic to
+	// the guest cluster API. As soon as the draining was done and the pods got
+	// removed we get an empty list here after the delete event got replayed. Then
+	// we just remove the services as usual.
+	if key.IsDeleted(customObject) {
+		n := key.ClusterNamespace(customObject)
+		list, err := r.k8sClient.CoreV1().Pods(n).List(metav1.ListOptions{})
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+		if len(list.Items) != 0 {
+			r.logger.LogCtx(ctx, "level", "debug", "message", "cannot finish deletion of services due to existing pods")
+			resourcecanceledcontext.SetCanceled(ctx)
+			finalizerskeptcontext.SetKept(ctx)
+			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+
+			return nil, nil
+		}
+	}
+
+	return services, nil
+}

--- a/service/controller/v14patch1/resource/service/delete.go
+++ b/service/controller/v14patch1/resource/service/delete.go
@@ -1,0 +1,82 @@
+package service
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/operatorkit/controller"
+	apiv1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/giantswarm/kvm-operator/service/controller/v14/key"
+)
+
+func (r *Resource) ApplyDeleteChange(ctx context.Context, obj, deleteChange interface{}) error {
+	customObject, err := key.ToCustomObject(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	servicesToDelete, err := toServices(deleteChange)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	if len(servicesToDelete) != 0 {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "deleting the services in the Kubernetes API")
+
+		namespace := key.ClusterNamespace(customObject)
+		for _, service := range servicesToDelete {
+			err := r.k8sClient.CoreV1().Services(namespace).Delete(service.Name, &apismetav1.DeleteOptions{})
+			if apierrors.IsNotFound(err) {
+				// fall through
+			} else if err != nil {
+				return microerror.Mask(err)
+			}
+		}
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", "deleted the services in the Kubernetes API")
+	} else {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "the services do not need to be deleted from the Kubernetes API")
+	}
+
+	return nil
+}
+
+func (r *Resource) NewDeletePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*controller.Patch, error) {
+	delete, err := r.newDeleteChange(ctx, obj, currentState, desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	patch := controller.NewPatch()
+	patch.SetDeleteChange(delete)
+
+	return patch, nil
+}
+
+func (r *Resource) newDeleteChange(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, error) {
+	currentServices, err := toServices(currentState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+	desiredServices, err := toServices(desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", "finding out which services have to be deleted")
+
+	var servicesToDelete []*apiv1.Service
+
+	for _, currentService := range currentServices {
+		if containsService(desiredServices, currentService) {
+			servicesToDelete = append(servicesToDelete, currentService)
+		}
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("found %d services that have to be deleted", len(servicesToDelete)))
+
+	return servicesToDelete, nil
+}

--- a/service/controller/v14patch1/resource/service/delete_test.go
+++ b/service/controller/v14patch1/resource/service/delete_test.go
@@ -1,0 +1,289 @@
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/micrologger/microloggertest"
+	apiv1 "k8s.io/api/core/v1"
+	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func Test_Resource_Service_newDeleteChange(t *testing.T) {
+	testCases := []struct {
+		Obj                  interface{}
+		CurrentState         interface{}
+		DesiredState         interface{}
+		ExpectedServiceNames []string
+	}{
+		// Test 1, in case current state and desired state are empty the delete
+		// state should be empty.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState:         []*apiv1.Service{},
+			DesiredState:         []*apiv1.Service{},
+			ExpectedServiceNames: []string{},
+		},
+
+		// Test 2, in case current state has one item and equals desired state the
+		// delete state should equal the current state.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState: []*apiv1.Service{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "service-1",
+					},
+				},
+			},
+			DesiredState: []*apiv1.Service{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "service-1",
+					},
+				},
+			},
+			ExpectedServiceNames: []string{
+				"service-1",
+			},
+		},
+
+		// Test 3, in case current state misses one item of desired state the delete
+		// state should not contain the missing item of the desired state.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState: []*apiv1.Service{},
+			DesiredState: []*apiv1.Service{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "service-1",
+					},
+				},
+			},
+			ExpectedServiceNames: []string{},
+		},
+
+		// Test 4, in case current state misses items of desired state the delete
+		// state should not contain the missing items of the desired state.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState: []*apiv1.Service{},
+			DesiredState: []*apiv1.Service{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "service-1",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "service-2",
+					},
+				},
+			},
+			ExpectedServiceNames: []string{},
+		},
+
+		// Test 5, in case current state contains one item and desired state is
+		// empty the delete state should be empty.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState: []*apiv1.Service{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "service-1",
+					},
+				},
+			},
+			DesiredState:         []*apiv1.Service{},
+			ExpectedServiceNames: []string{},
+		},
+
+		// Test 6, in case current state contains items and desired state is empty
+		// the delete state should be empty.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState: []*apiv1.Service{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "service-1",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "service-2",
+					},
+				},
+			},
+			DesiredState:         []*apiv1.Service{},
+			ExpectedServiceNames: []string{},
+		},
+
+		// Test 7, in case all items of current state are in desired state and
+		// desired state contains more items not being in current state the create
+		// state should contain all items being in current state.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState: []*apiv1.Service{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "service-1",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "service-2",
+					},
+				},
+			},
+			DesiredState: []*apiv1.Service{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "service-1",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "service-2",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "service-3",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "service-4",
+					},
+				},
+			},
+			ExpectedServiceNames: []string{
+				"service-1",
+				"service-2",
+			},
+		},
+
+		// Test 8, in case all items of desired state are in current state and
+		// current state contains more items not being in desired state the create
+		// state should contain all items being in desired state.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			CurrentState: []*apiv1.Service{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "service-1",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "service-2",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "service-3",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "service-4",
+					},
+				},
+			},
+			DesiredState: []*apiv1.Service{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "service-1",
+					},
+				},
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name: "service-2",
+					},
+				},
+			},
+			ExpectedServiceNames: []string{
+				"service-1",
+				"service-2",
+			},
+		},
+	}
+
+	var err error
+	var newResource *Resource
+	{
+		resourceConfig := DefaultConfig()
+		resourceConfig.K8sClient = fake.NewSimpleClientset()
+		resourceConfig.Logger = microloggertest.New()
+		newResource, err = New(resourceConfig)
+		if err != nil {
+			t.Fatal("expected", nil, "got", err)
+		}
+	}
+
+	for i, tc := range testCases {
+		result, err := newResource.newDeleteChange(context.TODO(), tc.Obj, tc.CurrentState, tc.DesiredState)
+		if err != nil {
+			t.Fatalf("case %d expected %#v got %#v", i+1, nil, err)
+		}
+
+		configMaps, ok := result.([]*apiv1.Service)
+		if !ok {
+			t.Fatalf("case %d expected %T got %T", i+1, []*apiv1.Service{}, result)
+		}
+
+		if len(configMaps) != len(tc.ExpectedServiceNames) {
+			t.Fatalf("case %d expected %d config maps got %d", i+1, len(tc.ExpectedServiceNames), len(configMaps))
+		}
+	}
+}

--- a/service/controller/v14patch1/resource/service/desired.go
+++ b/service/controller/v14patch1/resource/service/desired.go
@@ -1,0 +1,29 @@
+package service
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/giantswarm/microerror"
+	apiv1 "k8s.io/api/core/v1"
+
+	"github.com/giantswarm/kvm-operator/service/controller/v14/key"
+)
+
+func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interface{}, error) {
+	customObject, err := key.ToCustomObject(obj)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", "computing the new services")
+
+	var services []*apiv1.Service
+
+	services = append(services, newMasterService(customObject))
+	services = append(services, newWorkerService(customObject))
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("computed the %d new services", len(services)))
+
+	return services, nil
+}

--- a/service/controller/v14patch1/resource/service/desired_test.go
+++ b/service/controller/v14patch1/resource/service/desired_test.go
@@ -1,0 +1,145 @@
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/micrologger/microloggertest"
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func Test_Resource_Service_GetDesiredState(t *testing.T) {
+	testCases := []struct {
+		Obj                 interface{}
+		ExpectedMasterCount int
+		ExpectedWorkerCount int
+	}{
+		// Test 1 ensures there is one service for master and worker each when there
+		// is one master and one worker node in the custom object.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+						Masters: []v1alpha1.ClusterNode{
+							{},
+						},
+						Workers: []v1alpha1.ClusterNode{
+							{},
+						},
+					},
+				},
+			},
+			ExpectedMasterCount: 1,
+			ExpectedWorkerCount: 1,
+		},
+
+		// Test 2 ensures there is one service for master and worker each when there
+		// is one master and three worker nodes in the custom object.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+						Masters: []v1alpha1.ClusterNode{
+							{},
+						},
+						Workers: []v1alpha1.ClusterNode{
+							{},
+							{},
+							{},
+						},
+					},
+				},
+			},
+			ExpectedMasterCount: 1,
+			ExpectedWorkerCount: 1,
+		},
+
+		// Test 3 ensures there is one service for master and worker each when there
+		// are three master and three worker nodes in the custom object.
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+						Masters: []v1alpha1.ClusterNode{
+							{},
+							{},
+							{},
+						},
+						Workers: []v1alpha1.ClusterNode{
+							{},
+							{},
+							{},
+						},
+					},
+				},
+			},
+			ExpectedMasterCount: 1,
+			ExpectedWorkerCount: 1,
+		},
+	}
+
+	var err error
+	var newResource *Resource
+	{
+		resourceConfig := DefaultConfig()
+		resourceConfig.K8sClient = fake.NewSimpleClientset()
+		resourceConfig.Logger = microloggertest.New()
+		newResource, err = New(resourceConfig)
+		if err != nil {
+			t.Fatal("expected", nil, "got", err)
+		}
+	}
+
+	for i, tc := range testCases {
+		result, err := newResource.GetDesiredState(context.TODO(), tc.Obj)
+		if err != nil {
+			t.Fatalf("case %d expected %#v got %#v", i+1, nil, err)
+		}
+
+		services, ok := result.([]*apiv1.Service)
+		if !ok {
+			t.Fatalf("case %d expected %T got %T", i+1, []*apiv1.Service{}, result)
+		}
+
+		if testGetMasterCount(services) != tc.ExpectedMasterCount {
+			t.Fatalf("case %d expected %d master nodes got %d", i+1, tc.ExpectedMasterCount, testGetMasterCount(services))
+		}
+
+		if testGetWorkerCount(services) != tc.ExpectedWorkerCount {
+			t.Fatalf("case %d expected %d worker nodes got %d", i+1, tc.ExpectedWorkerCount, testGetWorkerCount(services))
+		}
+
+		if len(services) != tc.ExpectedMasterCount+tc.ExpectedWorkerCount {
+			t.Fatalf("case %d expected %d nodes got %d", i+1, tc.ExpectedMasterCount+tc.ExpectedWorkerCount, len(services))
+		}
+	}
+}
+
+func testGetMasterCount(services []*apiv1.Service) int {
+	var count int
+
+	for _, s := range services {
+		if s.Name == "master" {
+			count++
+		}
+	}
+
+	return count
+}
+
+func testGetWorkerCount(services []*apiv1.Service) int {
+	var count int
+
+	for _, s := range services {
+		if s.Name == "worker" {
+			count++
+		}
+	}
+
+	return count
+}

--- a/service/controller/v14patch1/resource/service/error.go
+++ b/service/controller/v14patch1/resource/service/error.go
@@ -1,0 +1,30 @@
+package service
+
+import "github.com/giantswarm/microerror"
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var notFoundError = &microerror.Error{
+	Kind: "notFoundError",
+}
+
+// IsNotFound asserts notFoundError.
+func IsNotFound(err error) bool {
+	return microerror.Cause(err) == notFoundError
+}
+
+var wrongTypeError = &microerror.Error{
+	Kind: "wrongTypeError",
+}
+
+// IsWrongTypeError asserts wrongTypeError.
+func IsWrongTypeError(err error) bool {
+	return microerror.Cause(err) == wrongTypeError
+}

--- a/service/controller/v14patch1/resource/service/master_service.go
+++ b/service/controller/v14patch1/resource/service/master_service.go
@@ -1,0 +1,57 @@
+package service
+
+import (
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	apiv1 "k8s.io/api/core/v1"
+	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/giantswarm/kvm-operator/service/controller/v14/key"
+)
+
+func newMasterService(customObject v1alpha1.KVMConfig) *apiv1.Service {
+	service := &apiv1.Service{
+		TypeMeta: apismetav1.TypeMeta{
+			Kind:       "service",
+			APIVersion: "v1",
+		},
+		ObjectMeta: apismetav1.ObjectMeta{
+			Name:      key.MasterID,
+			Namespace: key.ClusterID(customObject),
+			Labels: map[string]string{
+				key.LegacyLabelCluster: key.ClusterID(customObject),
+				key.LabelCustomer:      key.ClusterCustomer(customObject),
+				key.LabelApp:           key.MasterID,
+				key.LabelCluster:       key.ClusterID(customObject),
+				key.LabelOrganization:  key.ClusterCustomer(customObject),
+				key.LabelVersionBundle: key.VersionBundleVersion(customObject),
+			},
+			Annotations: map[string]string{
+				key.AnnotationEtcdDomain:        key.ClusterEtcdDomain(customObject),
+				key.AnnotationPrometheusCluster: key.ClusterID(customObject),
+				"prometheus.io/path":            "/healthz",
+				"prometheus.io/port":            "30010",
+				"prometheus.io/scheme":          "http",
+				"prometheus.io/scrape":          "true",
+			},
+		},
+		Spec: apiv1.ServiceSpec{
+			Type: apiv1.ServiceTypeClusterIP,
+			Ports: []apiv1.ServicePort{
+				{
+					Name:     "etcd",
+					Port:     int32(2379),
+					Protocol: "TCP",
+				},
+				{
+					Name:     "api",
+					Port:     int32(customObject.Spec.Cluster.Kubernetes.API.SecurePort),
+					Protocol: "TCP",
+				},
+			},
+			// Note that we do not use a selector definition on purpose to be able to
+			// manually set the IP address of the actual VM.
+		},
+	}
+
+	return service
+}

--- a/service/controller/v14patch1/resource/service/resource.go
+++ b/service/controller/v14patch1/resource/service/resource.go
@@ -1,0 +1,143 @@
+package service
+
+import (
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes"
+	"reflect"
+)
+
+const (
+	// Name is the identifier of the resource.
+	Name = "servicev14"
+)
+
+// Config represents the configuration used to create a new service resource.
+type Config struct {
+	// Dependencies.
+	K8sClient kubernetes.Interface
+	Logger    micrologger.Logger
+}
+
+// DefaultConfig provides a default configuration to create a new service
+// resource by best effort.
+func DefaultConfig() Config {
+	return Config{
+		// Dependencies.
+		K8sClient: nil,
+		Logger:    nil,
+	}
+}
+
+// Resource implements the service resource.
+type Resource struct {
+	// Dependencies.
+	k8sClient kubernetes.Interface
+	logger    micrologger.Logger
+}
+
+// New creates a new configured service resource.
+func New(config Config) (*Resource, error) {
+	// Dependencies.
+	if config.K8sClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "config.K8sClient must not be empty")
+	}
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "config.Logger must not be empty")
+	}
+
+	newService := &Resource{
+		// Dependencies.
+		k8sClient: config.K8sClient,
+		logger:    config.Logger,
+	}
+
+	return newService, nil
+}
+
+func (r *Resource) Name() string {
+	return Name
+}
+
+func containsService(list []*apiv1.Service, item *apiv1.Service) bool {
+	for _, l := range list {
+		if l.Name == item.Name {
+			return true
+		}
+	}
+
+	return false
+}
+
+func getServiceByName(list []*apiv1.Service, name string) (*apiv1.Service, error) {
+	for _, l := range list {
+		if l.Name == name {
+			return l, nil
+		}
+	}
+
+	return nil, microerror.Mask(notFoundError)
+}
+
+func isServiceModified(a, b *apiv1.Service) bool {
+	if a == nil || b == nil {
+		return true
+	}
+	if !portsEqual(a, b) {
+		return true
+	}
+
+	if !reflect.DeepEqual(a.Spec.Type, b.Spec.Type) {
+		return true
+	}
+
+	if !reflect.DeepEqual(a.Labels, b.Labels) {
+		return true
+	}
+
+	if !reflect.DeepEqual(a.Annotations, b.Annotations) {
+		return true
+	}
+
+	return false
+}
+
+func toServices(v interface{}) ([]*apiv1.Service, error) {
+	if v == nil {
+		return nil, nil
+	}
+
+	services, ok := v.([]*apiv1.Service)
+	if !ok {
+		return nil, microerror.Maskf(wrongTypeError, "expected '%T', got '%T'", []*apiv1.Service{}, v)
+	}
+
+	return services, nil
+}
+
+// portsEqual is a function that is checking if ports in the service have same important values.
+func portsEqual(a, b *apiv1.Service) bool {
+	if len(a.Spec.Ports) != len(b.Spec.Ports) {
+		return false
+	}
+
+	for i := 0; i < len(a.Spec.Ports); i++ {
+		portA := a.Spec.Ports[i]
+		portB := b.Spec.Ports[i]
+
+		if portA.Name != portB.Name {
+			return false
+		}
+		if !reflect.DeepEqual(portA.Port, portB.Port) {
+			return false
+		}
+		if !reflect.DeepEqual(portA.TargetPort, portB.TargetPort) {
+			return false
+		}
+		if !reflect.DeepEqual(portA.Protocol, portB.Protocol) {
+			return false
+		}
+	}
+	return true
+}

--- a/service/controller/v14patch1/resource/service/resource_test.go
+++ b/service/controller/v14patch1/resource/service/resource_test.go
@@ -1,0 +1,674 @@
+package service
+
+import (
+	"reflect"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+
+	"github.com/giantswarm/kvm-operator/service/controller/v14/key"
+)
+
+func Test_toService(t *testing.T) {
+	testCases := []struct {
+		name          string
+		input         interface{}
+		expectedState []*corev1.Service
+		errorMatcher  func(error) bool
+	}{
+		{
+			name: "case 0: basic match",
+			input: []*corev1.Service{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name:      "master",
+						Namespace: "xy123",
+						Labels: map[string]string{
+							key.LabelApp:           "master",
+							key.LegacyLabelCluster: "xy123",
+							key.LabelCustomer:      "customer1",
+							key.LabelCluster:       "xy123",
+							key.LabelOrganization:  "org1",
+							key.LabelVersionBundle: "1.2.3",
+						},
+						Annotations: map[string]string{
+							key.AnnotationPrometheusCluster: "xy123",
+							key.AnnotationEtcdDomain:        "etcd.cluster.mydomain:2379",
+						},
+					},
+					Spec: corev1.ServiceSpec{
+						Ports: []corev1.ServicePort{
+							{
+								Protocol:   corev1.ProtocolTCP,
+								Port:       443,
+								TargetPort: intstr.FromInt(443),
+							},
+						},
+					},
+				},
+			},
+			expectedState: []*corev1.Service{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name:      "master",
+						Namespace: "xy123",
+						Labels: map[string]string{
+							key.LabelApp:           "master",
+							key.LegacyLabelCluster: "xy123",
+							key.LabelCustomer:      "customer1",
+							key.LabelCluster:       "xy123",
+							key.LabelOrganization:  "org1",
+							key.LabelVersionBundle: "1.2.3",
+						},
+						Annotations: map[string]string{
+							key.AnnotationPrometheusCluster: "xy123",
+							key.AnnotationEtcdDomain:        "etcd.cluster.mydomain:2379",
+						},
+					},
+					Spec: corev1.ServiceSpec{
+						Ports: []corev1.ServicePort{
+							{
+								Protocol:   corev1.ProtocolTCP,
+								Port:       443,
+								TargetPort: intstr.FromInt(443),
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "case 1: wrong type (v1.Service instead of *v1.Service)",
+			input: []corev1.Service{
+				{
+					ObjectMeta: apismetav1.ObjectMeta{
+						Name:      "master",
+						Namespace: "xy123",
+						Labels: map[string]string{
+							key.LabelApp:           "master",
+							key.LegacyLabelCluster: "xy123",
+							key.LabelCustomer:      "customer1",
+							key.LabelCluster:       "xy123",
+							key.LabelOrganization:  "org1",
+							key.LabelVersionBundle: "1.2.3",
+						},
+						Annotations: map[string]string{
+							key.AnnotationPrometheusCluster: "xy123",
+							key.AnnotationEtcdDomain:        "etcd.cluster.mydomain:2379",
+						},
+					},
+					Spec: corev1.ServiceSpec{
+						Ports: []corev1.ServicePort{
+							{
+								Protocol:   corev1.ProtocolTCP,
+								Port:       443,
+								TargetPort: intstr.FromInt(443),
+							},
+						},
+					},
+				},
+			},
+			errorMatcher: IsWrongTypeError,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := toServices(tc.input)
+			switch {
+			case err != nil && tc.errorMatcher == nil:
+				t.Fatalf("error == %#v, want nil", err)
+			case err == nil && tc.errorMatcher != nil:
+				t.Fatalf("error == nil, want non-nil")
+			case err != nil && !tc.errorMatcher(err):
+				t.Fatalf("error == %#v, want matching", err)
+			}
+
+			if !reflect.DeepEqual(result, tc.expectedState) {
+				t.Fatalf("Service == %#v\n, want %#v", result, tc.expectedState)
+			}
+		})
+	}
+}
+
+func Test_isServiceModified(t *testing.T) {
+	testCases := []struct {
+		name           string
+		serviceA       *corev1.Service
+		serviceB       *corev1.Service
+		expectedResult bool
+	}{
+		{
+			name: "case 0: basic match",
+			serviceA: &corev1.Service{
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name:      "master",
+					Namespace: "xy123",
+					Labels: map[string]string{
+						key.LabelApp:           "master",
+						key.LegacyLabelCluster: "xy123",
+						key.LabelCustomer:      "customer1",
+						key.LabelCluster:       "xy123",
+						key.LabelOrganization:  "org1",
+						key.LabelVersionBundle: "1.2.3",
+					},
+					Annotations: map[string]string{
+						key.AnnotationPrometheusCluster: "xy123",
+						key.AnnotationEtcdDomain:        "etcd.cluster.mydomain:2379",
+					},
+				},
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{
+							Protocol:   corev1.ProtocolTCP,
+							Port:       443,
+							TargetPort: intstr.FromInt(443),
+						},
+					},
+				},
+			},
+			serviceB: &corev1.Service{
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name:      "master",
+					Namespace: "xy123",
+					Labels: map[string]string{
+						key.LabelApp:           "master",
+						key.LegacyLabelCluster: "xy123",
+						key.LabelCustomer:      "customer1",
+						key.LabelCluster:       "xy123",
+						key.LabelOrganization:  "org1",
+						key.LabelVersionBundle: "1.2.3",
+					},
+					Annotations: map[string]string{
+						key.AnnotationPrometheusCluster: "xy123",
+						key.AnnotationEtcdDomain:        "etcd.cluster.mydomain:2379",
+					},
+				},
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{
+							Protocol:   corev1.ProtocolTCP,
+							Port:       443,
+							TargetPort: intstr.FromInt(443),
+						},
+					},
+				},
+			},
+			expectedResult: false,
+		},
+		{
+			name: "case 1: label mismatch",
+			serviceA: &corev1.Service{
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name:      "master",
+					Namespace: "xy123",
+					Labels: map[string]string{
+						key.LabelApp:           "master",
+						key.LegacyLabelCluster: "xy123",
+						key.LabelCustomer:      "customer1",
+						key.LabelCluster:       "xy123",
+						key.LabelOrganization:  "org1",
+						key.LabelVersionBundle: "1.2.3",
+					},
+					Annotations: map[string]string{
+						key.AnnotationPrometheusCluster: "xy123",
+						key.AnnotationEtcdDomain:        "etcd.cluster.mydomain:2379",
+					},
+				},
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{
+							Protocol:   corev1.ProtocolTCP,
+							Port:       443,
+							TargetPort: intstr.FromInt(443),
+						},
+					},
+				},
+			},
+			serviceB: &corev1.Service{
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name:      "master",
+					Namespace: "xy123",
+					Labels: map[string]string{
+						key.LabelApp:           "master",
+						key.LegacyLabelCluster: "xy456",
+						key.LabelCustomer:      "customer2",
+						key.LabelCluster:       "xy456",
+						key.LabelOrganization:  "org2",
+						key.LabelVersionBundle: "1.2.4",
+					},
+					Annotations: map[string]string{
+						key.AnnotationPrometheusCluster: "xy123",
+						key.AnnotationEtcdDomain:        "etcd.cluster.mydomain:2379",
+					},
+				},
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{
+							Protocol:   corev1.ProtocolTCP,
+							Port:       443,
+							TargetPort: intstr.FromInt(443),
+						},
+					},
+				},
+			},
+			expectedResult: true,
+		},
+		{
+			name: "case 2: annotation mismatch",
+			serviceA: &corev1.Service{
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name:      "master",
+					Namespace: "xy123",
+					Labels: map[string]string{
+						key.LabelApp:           "master",
+						key.LegacyLabelCluster: "xy123",
+						key.LabelCustomer:      "customer1",
+						key.LabelCluster:       "xy123",
+						key.LabelOrganization:  "org1",
+						key.LabelVersionBundle: "1.2.3",
+					},
+					Annotations: map[string]string{
+						key.AnnotationPrometheusCluster: "xy123",
+						key.AnnotationEtcdDomain:        "etcd.cluster.mydomain:2379",
+					},
+				},
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{
+							Protocol:   corev1.ProtocolTCP,
+							Port:       443,
+							TargetPort: intstr.FromInt(443),
+						},
+					},
+				},
+			},
+			serviceB: &corev1.Service{
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name:      "master",
+					Namespace: "xy123",
+					Labels: map[string]string{
+						key.LabelApp:           "master",
+						key.LegacyLabelCluster: "xy123",
+						key.LabelCustomer:      "customer1",
+						key.LabelCluster:       "xy123",
+						key.LabelOrganization:  "org1",
+						key.LabelVersionBundle: "1.2.3",
+					},
+					Annotations: map[string]string{
+						key.AnnotationPrometheusCluster: "xy456",
+						key.AnnotationEtcdDomain:        "etcd2.cluster.NOTmydomain:433",
+					},
+				},
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{
+							Protocol:   corev1.ProtocolTCP,
+							Port:       443,
+							TargetPort: intstr.FromInt(443),
+						},
+					},
+				},
+			},
+			expectedResult: true,
+		},
+		{
+			name: "case 3: ports mismatch",
+			serviceA: &corev1.Service{
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name:      "master",
+					Namespace: "xy123",
+					Labels: map[string]string{
+						key.LabelApp:           "master",
+						key.LegacyLabelCluster: "xy123",
+						key.LabelCustomer:      "customer1",
+						key.LabelCluster:       "xy123",
+						key.LabelOrganization:  "org1",
+						key.LabelVersionBundle: "1.2.3",
+					},
+					Annotations: map[string]string{
+						key.AnnotationPrometheusCluster: "xy123",
+						key.AnnotationEtcdDomain:        "etcd.cluster.mydomain:2379",
+					},
+				},
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{
+							Protocol:   corev1.ProtocolTCP,
+							Port:       443,
+							TargetPort: intstr.FromInt(443),
+						},
+					},
+				},
+			},
+			serviceB: &corev1.Service{
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name:      "master",
+					Namespace: "xy123",
+					Labels: map[string]string{
+						key.LabelApp:           "master",
+						key.LegacyLabelCluster: "xy123",
+						key.LabelCustomer:      "customer1",
+						key.LabelCluster:       "xy123",
+						key.LabelOrganization:  "org1",
+						key.LabelVersionBundle: "1.2.3",
+					},
+					Annotations: map[string]string{
+						key.AnnotationPrometheusCluster: "xy123",
+						key.AnnotationEtcdDomain:        "etcd.cluster.mydomain:2379",
+					},
+				},
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{
+							Protocol:   corev1.ProtocolTCP,
+							Port:       443,
+							TargetPort: intstr.FromInt(443),
+						},
+						{
+							Protocol:   corev1.ProtocolTCP,
+							Port:       89,
+							TargetPort: intstr.FromInt(89),
+						},
+					},
+				},
+			},
+			expectedResult: true,
+		},
+		{
+			name: "case 4: service type mismatch",
+			serviceA: &corev1.Service{
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name:      "master",
+					Namespace: "xy123",
+					Labels: map[string]string{
+						key.LabelApp:           "master",
+						key.LegacyLabelCluster: "xy123",
+						key.LabelCustomer:      "customer1",
+						key.LabelCluster:       "xy123",
+						key.LabelOrganization:  "org1",
+						key.LabelVersionBundle: "1.2.3",
+					},
+					Annotations: map[string]string{
+						key.AnnotationPrometheusCluster: "xy123",
+						key.AnnotationEtcdDomain:        "etcd.cluster.mydomain:2379",
+					},
+				},
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{
+							Protocol:   corev1.ProtocolTCP,
+							Port:       443,
+							TargetPort: intstr.FromInt(443),
+						},
+					},
+					Type: corev1.ServiceTypeLoadBalancer,
+				},
+			},
+			serviceB: &corev1.Service{
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name:      "master",
+					Namespace: "xy123",
+					Labels: map[string]string{
+						key.LabelApp:           "master",
+						key.LegacyLabelCluster: "xy123",
+						key.LabelCustomer:      "customer1",
+						key.LabelCluster:       "xy123",
+						key.LabelOrganization:  "org1",
+						key.LabelVersionBundle: "1.2.3",
+					},
+					Annotations: map[string]string{
+						key.AnnotationPrometheusCluster: "xy123",
+						key.AnnotationEtcdDomain:        "etcd.cluster.mydomain:2379",
+					},
+				},
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{
+							Protocol:   corev1.ProtocolTCP,
+							Port:       443,
+							TargetPort: intstr.FromInt(443),
+						},
+					},
+					Type: corev1.ServiceTypeNodePort,
+				},
+			},
+			expectedResult: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := isServiceModified(tc.serviceA, tc.serviceB)
+
+			if result != tc.expectedResult {
+				t.Fatalf("isServiceModified '%s' failed, got %t, want %t", tc.name, result, tc.expectedResult)
+			}
+		})
+	}
+}
+
+func Test_portsEqual(t *testing.T) {
+	testCases := []struct {
+		name           string
+		serviceA       *corev1.Service
+		serviceB       *corev1.Service
+		expectedResult bool
+	}{
+		{
+			name: "case 0: basic match",
+			serviceA: &corev1.Service{
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name:      "service1",
+					Namespace: "xy123",
+				},
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{
+							Protocol:   corev1.ProtocolTCP,
+							Port:       443,
+							TargetPort: intstr.FromInt(443),
+						},
+					},
+				},
+			},
+			serviceB: &corev1.Service{
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name:      "service1",
+					Namespace: "xy123",
+				},
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{
+							Protocol:   corev1.ProtocolTCP,
+							Port:       443,
+							TargetPort: intstr.FromInt(443),
+						},
+					},
+				},
+			},
+			expectedResult: true,
+		},
+		{
+			name: "case 1: port count mismatch",
+			serviceA: &corev1.Service{
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name:      "service1",
+					Namespace: "xy123",
+				},
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{
+							Protocol:   corev1.ProtocolTCP,
+							Port:       443,
+							TargetPort: intstr.FromInt(443),
+						},
+					},
+				},
+			},
+			serviceB: &corev1.Service{
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name:      "service1",
+					Namespace: "xy123",
+				},
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{
+							Protocol:   corev1.ProtocolTCP,
+							Port:       443,
+							TargetPort: intstr.FromInt(443),
+						},
+						{
+							Protocol:   corev1.ProtocolTCP,
+							Port:       442,
+							TargetPort: intstr.FromInt(442),
+						},
+					},
+				},
+			},
+			expectedResult: false,
+		},
+		{
+			name: "case 2: port count mismatch 2",
+			serviceA: &corev1.Service{
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name:      "service1",
+					Namespace: "xy123",
+				},
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{},
+				},
+			},
+			serviceB: &corev1.Service{
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name:      "service1",
+					Namespace: "xy123",
+				},
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{
+							Protocol:   corev1.ProtocolTCP,
+							Port:       443,
+							TargetPort: intstr.FromInt(443),
+						},
+					},
+				},
+			},
+			expectedResult: false,
+		},
+		{
+			name: "case 3: protocol mismatch",
+			serviceA: &corev1.Service{
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name:      "service1",
+					Namespace: "xy123",
+				},
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{
+							Protocol:   corev1.ProtocolUDP,
+							Port:       443,
+							TargetPort: intstr.FromInt(443),
+						},
+					},
+				},
+			},
+			serviceB: &corev1.Service{
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name:      "service1",
+					Namespace: "xy123",
+				},
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{
+							Protocol:   corev1.ProtocolTCP,
+							Port:       443,
+							TargetPort: intstr.FromInt(443),
+						},
+					},
+				},
+			},
+			expectedResult: false,
+		},
+		{
+			name: "case 4: port number mismatch",
+			serviceA: &corev1.Service{
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name:      "service1",
+					Namespace: "xy123",
+				},
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{
+							Protocol:   corev1.ProtocolTCP,
+							Port:       443,
+							TargetPort: intstr.FromInt(443),
+						},
+					},
+				},
+			},
+			serviceB: &corev1.Service{
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name:      "service1",
+					Namespace: "xy123",
+				},
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{
+							Protocol:   corev1.ProtocolTCP,
+							Port:       445,
+							TargetPort: intstr.FromInt(443),
+						},
+					},
+				},
+			},
+			expectedResult: false,
+		},
+		{
+			name: "case 5: targetPort number mismatch",
+			serviceA: &corev1.Service{
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name:      "service1",
+					Namespace: "xy123",
+				},
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{
+							Protocol:   corev1.ProtocolTCP,
+							Port:       443,
+							TargetPort: intstr.FromInt(443),
+						},
+					},
+				},
+			},
+			serviceB: &corev1.Service{
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name:      "service1",
+					Namespace: "xy123",
+				},
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{
+							Protocol:   corev1.ProtocolTCP,
+							Port:       443,
+							TargetPort: intstr.FromInt(445),
+						},
+					},
+				},
+			},
+			expectedResult: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := portsEqual(tc.serviceA, tc.serviceB)
+
+			if result != tc.expectedResult {
+				t.Fatalf("portEqual '%s' failed, got %t, want %t", tc.name, result, tc.expectedResult)
+			}
+		})
+	}
+}

--- a/service/controller/v14patch1/resource/service/update.go
+++ b/service/controller/v14patch1/resource/service/update.go
@@ -1,0 +1,91 @@
+package service
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/operatorkit/controller"
+	apiv1 "k8s.io/api/core/v1"
+)
+
+func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateChange interface{}) error {
+	servicesToUpdate, err := toServices(updateChange)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	if len(servicesToUpdate) > 0 {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "updating services")
+
+		for _, serviceToUpdate := range servicesToUpdate {
+			_, err := r.k8sClient.CoreV1().Services(serviceToUpdate.Namespace).Update(serviceToUpdate)
+			if err != nil {
+				return microerror.Mask(err)
+			}
+		}
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", "updated services")
+	} else {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "no need to update services")
+	}
+	return nil
+}
+
+func (r *Resource) NewUpdatePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*controller.Patch, error) {
+	create, err := r.newCreateChange(ctx, obj, currentState, desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	update, err := r.newUpdateChange(ctx, obj, currentState, desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	patch := controller.NewPatch()
+	patch.SetCreateChange(create)
+	patch.SetUpdateChange(update)
+
+	return patch, nil
+}
+
+func (r *Resource) newUpdateChange(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, error) {
+	currentServices, err := toServices(currentState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+	desiredServices, err := toServices(desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", "finding out which services have to be updated")
+
+	servicesToUpdate := make([]*apiv1.Service, 0)
+
+	for _, currentService := range currentServices {
+		desiredService, err := getServiceByName(desiredServices, currentService.Name)
+		if IsNotFound(err) {
+			// Ignore here. These are handled by newDeleteChangeForUpdatePatch().
+			continue
+		} else if err != nil {
+			return nil, microerror.Mask(err)
+		}
+
+		if isServiceModified(desiredService, currentService) {
+			// Make a copy and set the resource version so the service can be updated.
+			serviceToUpdate := desiredService.DeepCopy()
+			serviceToUpdate.ObjectMeta.ResourceVersion = currentService.ObjectMeta.ResourceVersion
+			serviceToUpdate.Spec.ClusterIP = currentService.Spec.ClusterIP
+
+			servicesToUpdate = append(servicesToUpdate, serviceToUpdate)
+
+			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("found service '%s' that has to be updated", desiredService.GetName()))
+		}
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("found %d services which have to be updated", len(servicesToUpdate)))
+
+	return servicesToUpdate, nil
+}

--- a/service/controller/v14patch1/resource/service/worker_service.go
+++ b/service/controller/v14patch1/resource/service/worker_service.go
@@ -1,0 +1,44 @@
+package service
+
+import (
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	apiv1 "k8s.io/api/core/v1"
+	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/giantswarm/kvm-operator/service/controller/v14/key"
+)
+
+func newWorkerService(customObject v1alpha1.KVMConfig) *apiv1.Service {
+	service := &apiv1.Service{
+		TypeMeta: apismetav1.TypeMeta{
+			Kind:       "service",
+			APIVersion: "v1",
+		},
+		ObjectMeta: apismetav1.ObjectMeta{
+			Name:      key.WorkerID,
+			Namespace: key.ClusterID(customObject),
+			Labels: map[string]string{
+				key.LegacyLabelCluster: key.ClusterID(customObject),
+				key.LabelCustomer:      key.ClusterCustomer(customObject),
+				key.LabelApp:           key.MasterID,
+				key.LabelCluster:       key.ClusterID(customObject),
+				key.LabelOrganization:  key.ClusterCustomer(customObject),
+				key.LabelVersionBundle: key.VersionBundleVersion(customObject),
+			},
+			Annotations: map[string]string{
+				"prometheus.io/path":   "/healthz",
+				"prometheus.io/port":   "30010",
+				"prometheus.io/scheme": "http",
+				"prometheus.io/scrape": "true",
+			},
+		},
+		Spec: apiv1.ServiceSpec{
+			Type:  apiv1.ServiceTypeNodePort,
+			Ports: key.PortMappings(customObject),
+			// Note that we do not use a selector definition on purpose to be able to
+			// manually set the IP address of the actual VM.
+		},
+	}
+
+	return service
+}

--- a/service/controller/v14patch1/resource/serviceaccount/create.go
+++ b/service/controller/v14patch1/resource/serviceaccount/create.go
@@ -1,0 +1,63 @@
+package serviceaccount
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/giantswarm/microerror"
+	apiv1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+
+	"github.com/giantswarm/kvm-operator/service/controller/v14/key"
+)
+
+func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange interface{}) error {
+	customObject, err := key.ToCustomObject(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	serviceAccountToCreate, err := toServiceAccount(createChange)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	// Create the service account in the Kubernetes API.
+	if serviceAccountToCreate != nil {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "creating the service account in the Kubernetes API")
+
+		namespace := key.ClusterNamespace(customObject)
+		_, err := r.k8sClient.CoreV1().ServiceAccounts(namespace).Create(serviceAccountToCreate)
+		if apierrors.IsAlreadyExists(err) {
+		} else if err != nil {
+			return microerror.Mask(err)
+		}
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", "created the service account in the Kubernetes API")
+	} else {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "the service account does not need to be created in the Kubernetes API")
+	}
+
+	return nil
+}
+
+func (r *Resource) newCreateChange(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, error) {
+	currentServiceAccount, err := toServiceAccount(currentState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+	desiredServiceAccount, err := toServiceAccount(desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", "finding out which service account has to be created")
+
+	var serviceAccountToCreate *apiv1.ServiceAccount
+	if currentServiceAccount == nil {
+		serviceAccountToCreate = desiredServiceAccount
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("found out that service account that has to be created"))
+
+	return serviceAccountToCreate, nil
+}

--- a/service/controller/v14patch1/resource/serviceaccount/create_test.go
+++ b/service/controller/v14patch1/resource/serviceaccount/create_test.go
@@ -1,0 +1,124 @@
+package serviceaccount
+
+import (
+	"context"
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/micrologger/microloggertest"
+	apiv1 "k8s.io/api/core/v1"
+	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func Test_Resource_ServiceAccount_newCreateChange(t *testing.T) {
+	testCases := []struct {
+		Obj                    interface{}
+		Cur                    interface{}
+		Des                    interface{}
+		ExpectedServiceAccount *apiv1.ServiceAccount
+	}{
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "my-cluster",
+					},
+				},
+			},
+			Cur: &apiv1.ServiceAccount{
+				TypeMeta: apismetav1.TypeMeta{
+					Kind:       "ServiceAccount",
+					APIVersion: "v1",
+				},
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name: "al9qy",
+					Labels: map[string]string{
+						"cluster":  "al9qy",
+						"customer": "test-customer",
+					},
+				},
+			},
+			Des: &apiv1.ServiceAccount{
+				TypeMeta: apismetav1.TypeMeta{
+					Kind:       "ServiceAccount",
+					APIVersion: "v1",
+				},
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name: "al9qy",
+					Labels: map[string]string{
+						"cluster":  "al9qy",
+						"customer": "test-customer",
+					},
+				},
+			},
+			ExpectedServiceAccount: nil,
+		},
+
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "my-cluster",
+					},
+				},
+			},
+			Cur: nil,
+			Des: &apiv1.ServiceAccount{
+				TypeMeta: apismetav1.TypeMeta{
+					Kind:       "ServiceAccount",
+					APIVersion: "v1",
+				},
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name: "al9qy",
+					Labels: map[string]string{
+						"cluster":  "al9qy",
+						"customer": "test-customer",
+					},
+				},
+			},
+			ExpectedServiceAccount: &apiv1.ServiceAccount{
+				TypeMeta: apismetav1.TypeMeta{
+					Kind:       "ServiceAccount",
+					APIVersion: "v1",
+				},
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name: "al9qy",
+					Labels: map[string]string{
+						"cluster":  "al9qy",
+						"customer": "test-customer",
+					},
+				},
+			},
+		},
+	}
+
+	var err error
+	var newResource *Resource
+	{
+		resourceConfig := DefaultConfig()
+		resourceConfig.K8sClient = fake.NewSimpleClientset()
+		resourceConfig.Logger = microloggertest.New()
+		newResource, err = New(resourceConfig)
+		if err != nil {
+			t.Fatal("expected", nil, "got", err)
+		}
+	}
+
+	for i, tc := range testCases {
+		result, err := newResource.newCreateChange(context.TODO(), tc.Obj, tc.Cur, tc.Des)
+		if err != nil {
+			t.Fatal("case", i+1, "expected", nil, "got", err)
+		}
+		if tc.ExpectedServiceAccount == nil {
+			if tc.ExpectedServiceAccount != result {
+				t.Fatal("case", i+1, "expected", tc.ExpectedServiceAccount, "got", result)
+			}
+		} else {
+			name := result.(*apiv1.ServiceAccount).Name
+			if tc.ExpectedServiceAccount.Name != name {
+				t.Fatal("case", i+1, "expected", tc.ExpectedServiceAccount.Name, "got", name)
+			}
+		}
+	}
+}

--- a/service/controller/v14patch1/resource/serviceaccount/current.go
+++ b/service/controller/v14patch1/resource/serviceaccount/current.go
@@ -1,0 +1,38 @@
+package serviceaccount
+
+import (
+	"context"
+
+	"github.com/giantswarm/microerror"
+	apiv1 "k8s.io/api/core/v1"
+	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+
+	"github.com/giantswarm/kvm-operator/service/controller/v14/key"
+)
+
+func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interface{}, error) {
+	customObject, err := key.ToCustomObject(obj)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", "looking for a service account in the Kubernetes API")
+
+	namespace := key.ClusterNamespace(customObject)
+	var currentServiceAccount *apiv1.ServiceAccount
+	currentServiceAccount, err = r.k8sClient.CoreV1().ServiceAccounts(namespace).Get(key.ServiceAccountName(customObject), apismetav1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "did not find the service account in the Kubernetes API")
+		//When service account is not found api still returning non nil value so it can break create/update/delete
+		// and is why force the return value to nil
+		return nil, nil
+	} else if err != nil {
+		return nil, microerror.Mask(err)
+	} else {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "found a service account in the Kubernetes API")
+	}
+
+	return currentServiceAccount, nil
+}

--- a/service/controller/v14patch1/resource/serviceaccount/delete.go
+++ b/service/controller/v14patch1/resource/serviceaccount/delete.go
@@ -1,0 +1,76 @@
+package serviceaccount
+
+import (
+	"context"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/operatorkit/controller"
+	apiv1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/giantswarm/kvm-operator/service/controller/v14/key"
+)
+
+func (r *Resource) ApplyDeleteChange(ctx context.Context, obj, deleteChange interface{}) error {
+	customObject, err := key.ToCustomObject(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	serviceAccountToDelete, err := toServiceAccount(deleteChange)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	if serviceAccountToDelete != nil {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "deleting the service account in the Kubernetes API")
+
+		// Delete service account in the Kubernetes API.
+		namespace := key.ClusterNamespace(customObject)
+		err := r.k8sClient.CoreV1().ServiceAccounts(namespace).Delete(serviceAccountToDelete.Name, &apismetav1.DeleteOptions{})
+		if apierrors.IsNotFound(err) {
+		} else if err != nil {
+			return microerror.Mask(err)
+		}
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", "deleted the service account in the Kubernetes API")
+	} else {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "the service account does not need to be deleted from the Kubernetes API")
+	}
+
+	return nil
+}
+
+func (r *Resource) NewDeletePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*controller.Patch, error) {
+	deleteChange, err := r.newDeleteChange(ctx, obj, currentState, desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	patch := controller.NewPatch()
+	patch.SetDeleteChange(deleteChange)
+
+	return patch, nil
+}
+
+func (r *Resource) newDeleteChange(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, error) {
+	currentServiceAccount, err := toServiceAccount(currentState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+	desiredServiceAccount, err := toServiceAccount(desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", "finding out which service account has to be deleted")
+
+	var serviceAccountToDelete *apiv1.ServiceAccount
+	if currentServiceAccount != nil {
+		serviceAccountToDelete = desiredServiceAccount
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", "found out service account that has to be deleted")
+
+	return serviceAccountToDelete, nil
+}

--- a/service/controller/v14patch1/resource/serviceaccount/delete_test.go
+++ b/service/controller/v14patch1/resource/serviceaccount/delete_test.go
@@ -1,0 +1,124 @@
+package serviceaccount
+
+import (
+	"context"
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/micrologger/microloggertest"
+	apiv1 "k8s.io/api/core/v1"
+	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func Test_Resource_ServiceAccount_newDeleteChange(t *testing.T) {
+	testCases := []struct {
+		Obj                    interface{}
+		Cur                    interface{}
+		Des                    interface{}
+		ExpectedServiceAccount *apiv1.ServiceAccount
+	}{
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "my-cluster",
+					},
+				},
+			},
+			Cur: &apiv1.ServiceAccount{
+				TypeMeta: apismetav1.TypeMeta{
+					Kind:       "ServiceAccount",
+					APIVersion: "v1",
+				},
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name: "al9qy",
+					Labels: map[string]string{
+						"cluster":  "al9qy",
+						"customer": "test-customer",
+					},
+				},
+			},
+			Des: &apiv1.ServiceAccount{
+				TypeMeta: apismetav1.TypeMeta{
+					Kind:       "ServiceAccount",
+					APIVersion: "v1",
+				},
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name: "al9qy",
+					Labels: map[string]string{
+						"cluster":  "al9qy",
+						"customer": "test-customer",
+					},
+				},
+			},
+			ExpectedServiceAccount: &apiv1.ServiceAccount{
+				TypeMeta: apismetav1.TypeMeta{
+					Kind:       "ServiceAccount",
+					APIVersion: "v1",
+				},
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name: "al9qy",
+					Labels: map[string]string{
+						"cluster":  "al9qy",
+						"customer": "test-customer",
+					},
+				},
+			},
+		},
+
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "my-cluster",
+					},
+				},
+			},
+			Cur: nil,
+			Des: &apiv1.ServiceAccount{
+				TypeMeta: apismetav1.TypeMeta{
+					Kind:       "ServiceAccount",
+					APIVersion: "v1",
+				},
+				ObjectMeta: apismetav1.ObjectMeta{
+					Name: "al9qy",
+					Labels: map[string]string{
+						"cluster":  "al9qy",
+						"customer": "test-customer",
+					},
+				},
+			},
+			ExpectedServiceAccount: nil,
+		},
+	}
+
+	var err error
+	var newResource *Resource
+	{
+		resourceConfig := DefaultConfig()
+		resourceConfig.K8sClient = fake.NewSimpleClientset()
+		resourceConfig.Logger = microloggertest.New()
+		newResource, err = New(resourceConfig)
+		if err != nil {
+			t.Fatal("expected", nil, "got", err)
+		}
+	}
+
+	for i, tc := range testCases {
+		result, err := newResource.newDeleteChange(context.TODO(), tc.Obj, tc.Cur, tc.Des)
+		if err != nil {
+			t.Fatal("case", i+1, "expected", nil, "got", err)
+		}
+		if tc.ExpectedServiceAccount == nil {
+			if tc.ExpectedServiceAccount != result {
+				t.Fatal("case", i+1, "expected", tc.ExpectedServiceAccount, "got", result)
+			}
+		} else {
+			name := result.(*apiv1.ServiceAccount).Name
+			if tc.ExpectedServiceAccount.Name != name {
+				t.Fatal("case", i+1, "expected", tc.ExpectedServiceAccount.Name, "got", name)
+			}
+		}
+	}
+}

--- a/service/controller/v14patch1/resource/serviceaccount/desired.go
+++ b/service/controller/v14patch1/resource/serviceaccount/desired.go
@@ -1,0 +1,39 @@
+package serviceaccount
+
+import (
+	"context"
+
+	"github.com/giantswarm/microerror"
+	apiv1 "k8s.io/api/core/v1"
+	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/giantswarm/kvm-operator/service/controller/v14/key"
+)
+
+func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interface{}, error) {
+	customObject, err := key.ToCustomObject(obj)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", "computing the new service account")
+
+	serviceAccount := &apiv1.ServiceAccount{
+		TypeMeta: apismetav1.TypeMeta{
+			Kind:       "ServiceAccount",
+			APIVersion: "v1",
+		},
+		ObjectMeta: apismetav1.ObjectMeta{
+			Name:      key.ServiceAccountName(customObject),
+			Namespace: key.ClusterID(customObject),
+			Labels: map[string]string{
+				"cluster-id":  key.ClusterID(customObject),
+				"customer-id": key.ClusterCustomer(customObject),
+			},
+		},
+	}
+
+	r.logger.LogCtx(ctx, "level", "debug", "message", "computed the new service account")
+
+	return serviceAccount, nil
+}

--- a/service/controller/v14patch1/resource/serviceaccount/desired_test.go
+++ b/service/controller/v14patch1/resource/serviceaccount/desired_test.go
@@ -1,0 +1,62 @@
+package serviceaccount
+
+import (
+	"context"
+	"testing"
+
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/micrologger/microloggertest"
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func Test_Resource_ServiceAccount_GetDesiredState(t *testing.T) {
+	testCases := []struct {
+		Obj          interface{}
+		ExpectedName string
+	}{
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "al9qy",
+					},
+				},
+			},
+			ExpectedName: "al9qy",
+		},
+		{
+			Obj: &v1alpha1.KVMConfig{
+				Spec: v1alpha1.KVMConfigSpec{
+					Cluster: v1alpha1.Cluster{
+						ID: "my-cluster",
+					},
+				},
+			},
+			ExpectedName: "my-cluster",
+		},
+	}
+
+	var err error
+	var newResource *Resource
+	{
+		resourceConfig := DefaultConfig()
+		resourceConfig.K8sClient = fake.NewSimpleClientset()
+		resourceConfig.Logger = microloggertest.New()
+		newResource, err = New(resourceConfig)
+		if err != nil {
+			t.Fatal("expected", nil, "got", err)
+		}
+	}
+
+	for i, tc := range testCases {
+		result, err := newResource.GetDesiredState(context.TODO(), tc.Obj)
+		if err != nil {
+			t.Fatal("case", i+1, "expected", nil, "got", err)
+		}
+		name := result.(*apiv1.ServiceAccount).Name
+		if tc.ExpectedName != name {
+			t.Fatalf("case %d expected %#v got %#v", i+1, tc.ExpectedName, name)
+		}
+	}
+}

--- a/service/controller/v14patch1/resource/serviceaccount/error.go
+++ b/service/controller/v14patch1/resource/serviceaccount/error.go
@@ -1,0 +1,30 @@
+package serviceaccount
+
+import "github.com/giantswarm/microerror"
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var notFoundError = &microerror.Error{
+	Kind: "notFoundError",
+}
+
+// IsNotFound asserts notFoundError.
+func IsNotFound(err error) bool {
+	return microerror.Cause(err) == notFoundError
+}
+
+var wrongTypeError = &microerror.Error{
+	Kind: "wrongTypeError",
+}
+
+// IsWrongTypeError asserts wrongTypeError.
+func IsWrongTypeError(err error) bool {
+	return microerror.Cause(err) == wrongTypeError
+}

--- a/service/controller/v14patch1/resource/serviceaccount/resource.go
+++ b/service/controller/v14patch1/resource/serviceaccount/resource.go
@@ -1,0 +1,70 @@
+package serviceaccount
+
+import (
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	// Name is the identifier of the resource.
+	Name = "serviceaccountv14"
+)
+
+// Config represents the configuration used to create a new cloud config resource.
+type Config struct {
+	// Dependencies.
+	K8sClient kubernetes.Interface
+	Logger    micrologger.Logger
+}
+
+// DefaultConfig provides a default configuration to create a new config map
+// resource by best effort.
+func DefaultConfig() Config {
+	return Config{
+		K8sClient: nil,
+		Logger:    nil,
+	}
+}
+
+// Resource implements the config map resource.
+type Resource struct {
+	// Dependencies.
+	k8sClient kubernetes.Interface
+	logger    micrologger.Logger
+}
+
+// New creates a new configured config map resource.
+func New(config Config) (*Resource, error) {
+	if config.K8sClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "config.K8sClient must not be empty")
+	}
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "config.Logger must not be empty")
+	}
+
+	newService := &Resource{
+		k8sClient: config.K8sClient,
+		logger:    config.Logger,
+	}
+
+	return newService, nil
+}
+
+func (r *Resource) Name() string {
+	return Name
+}
+
+func toServiceAccount(v interface{}) (*apiv1.ServiceAccount, error) {
+	if v == nil {
+		return nil, nil
+	}
+
+	serviceAccount, ok := v.(*apiv1.ServiceAccount)
+	if !ok {
+		return nil, microerror.Maskf(wrongTypeError, "expected '%T', got '%T'", apiv1.ServiceAccount{}, v)
+	}
+
+	return serviceAccount, nil
+}

--- a/service/controller/v14patch1/resource/serviceaccount/update.go
+++ b/service/controller/v14patch1/resource/serviceaccount/update.go
@@ -1,0 +1,34 @@
+package serviceaccount
+
+import (
+	"context"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/operatorkit/controller"
+)
+
+func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateChange interface{}) error {
+	return nil
+}
+
+func (r *Resource) NewUpdatePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*controller.Patch, error) {
+	create, err := r.newCreateChange(ctx, obj, currentState, desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	update, err := r.newUpdateChange(ctx, obj, currentState, desiredState)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	patch := controller.NewPatch()
+	patch.SetCreateChange(create)
+	patch.SetUpdateChange(update)
+
+	return patch, nil
+}
+
+func (r *Resource) newUpdateChange(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, error) {
+	return nil, nil
+}

--- a/service/controller/v14patch1/version_bundle.go
+++ b/service/controller/v14patch1/version_bundle.go
@@ -1,0 +1,59 @@
+package v14
+
+import (
+	"github.com/giantswarm/versionbundle"
+)
+
+func VersionBundle() versionbundle.Bundle {
+	return versionbundle.Bundle{
+		Changelogs: []versionbundle.Changelog{
+			{
+				Component:   "kvm-operator",
+				Description: "Added support for etcd monitoring.",
+				Kind:        versionbundle.KindAdded,
+			},
+			{
+				Component:   "kvm-operator",
+				Description: "Changed service types.",
+				Kind:        versionbundle.KindChanged,
+			},
+			{
+				Component:   "kvm-operator",
+				Description: "Expose guest ingress via nodePort.",
+				Kind:        versionbundle.KindAdded,
+			},
+		},
+		Components: []versionbundle.Component{
+			{
+				Name:    "calico",
+				Version: "3.0.5",
+			},
+			{
+				Name:    "containerlinux",
+				Version: "1688.5.3",
+			},
+			{
+				Name:    "docker",
+				Version: "17.12.1",
+			},
+			{
+				Name:    "etcd",
+				Version: "3.3.3",
+			},
+			{
+				Name:    "coredns",
+				Version: "1.1.1",
+			},
+			{
+				Name:    "kubernetes",
+				Version: "1.10.4",
+			},
+			{
+				Name:    "nginx-ingress-controller",
+				Version: "0.12.0",
+			},
+		},
+		Name:    "kvm-operator",
+		Version: "2.5.0",
+	}
+}


### PR DESCRIPTION
Copy PR for v14patch1. This is needed for updating k8s 1.10 clusters to use cluster-operator 0.6.0 and chart-operator for ingress controler.