### PR TITLE
Update microkit dep & enable debug server

### DIFF
--- a/helm/kvm-operator-chart/templates/configmap.yaml
+++ b/helm/kvm-operator-chart/templates/configmap.yaml
@@ -6,6 +6,9 @@ metadata:
 data:
   config.yml: |
     server:
+      enable:
+        debug:
+          server: true
       listen:
         address: 'http://0.0.0.0:8000'
     service:


### PR DESCRIPTION
Added debug server exposes net/http/pprof interface in
http://127.0.0.1:6060/debug.

This helps with profiling running service e.g. when it's OOMing.

Towards https://github.com/giantswarm/giantswarm/issues/4088