### PR TITLE
fix e2e-cluster-id

### DIFF
--- a/integration/template/kvm_config_e2e_values.go
+++ b/integration/template/kvm_config_e2e_values.go
@@ -9,7 +9,8 @@ type KVMConfigE2eChartValues struct {
 }
 
 const ApiextensionsKVMConfigE2EChartValues = `
-clusterName: "{{.ClusterID}}"
+cluster:
+  id:  "{{.ClusterID}}"
 baseDomain: "k8s.gastropod.gridscale.kvm.gigantic.io"
 sshUser: "test-user"
 sshPublicKey: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAAAYQCurvzg5Ia54kb3NZapA6yP00//+Jt6XJNeC7Seq3TeCqMR9x7Snalj19r0lWok1PkRgDo1PXj+3y53zo/wqBrPqN4cQqp00R06kNfnhAgesaRMvYhuyVRQQbfXV5gQg8M= dummy-key"


### PR DESCRIPTION
fix broken cluster name
see https://github.com/giantswarm/apiextensions/blob/master/helm/apiextensions-kvm-config-e2e-chart/values.yaml -> https://github.com/giantswarm/apiextensions/pull/135