### PR TITLE
Add flannel-operator crd label selector for e2e tests

### DIFF
--- a/integration/template/flannel_config_e2e_values.go
+++ b/integration/template/flannel_config_e2e_values.go
@@ -22,4 +22,7 @@ Installation:
       Registry:
         PullSecret:
           DockerConfigJSON: "{\"auths\":{\"quay.io\":{\"auth\":\"$REGISTRY_PULL_SECRET\"}}}"
+service:
+  crd:
+    labelSelector: ${CLUSTER_NAME}
 `


### PR DESCRIPTION
In KVM e2e tests there are multiple instances of same operator running.
In order to prevent race conditions, an informer label selector can be
specified for operator so that it only processes CR objects for its own
e2e run.

Towards https://github.com/giantswarm/giantswarm/issues/4196#issuecomment-421297710