### PR TITLE
Retry operations that involve crdstorage in e2e tests

### DIFF
--- a/integration/storage/storage.go
+++ b/integration/storage/storage.go
@@ -44,10 +44,15 @@ func InitCRDStorage(ctx context.Context, h *framework.Host, l micrologger.Logger
 	c.K8sClient = h.K8sClient()
 	c.Logger = l
 
+	targetNamespace := h.TargetNamespace()
+	if targetNamespace == "" {
+		targetNamespace = giantswarmNamespace
+	}
+
 	c.Name = "kvm-e2e"
 	c.Namespace = &v1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: giantswarmNamespace,
+			Name: targetNamespace,
 		},
 	}
 

--- a/integration/storage/storage.go
+++ b/integration/storage/storage.go
@@ -44,15 +44,10 @@ func InitCRDStorage(ctx context.Context, h *framework.Host, l micrologger.Logger
 	c.K8sClient = h.K8sClient()
 	c.Logger = l
 
-	targetNamespace := h.TargetNamespace()
-	if targetNamespace == "" {
-		targetNamespace = giantswarmNamespace
-	}
-
 	c.Name = "kvm-e2e"
 	c.Namespace = &v1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: targetNamespace,
+			Name: giantswarmNamespace,
 		},
 	}
 


### PR DESCRIPTION
On KVM e2e tests run on same control plane and in order to coordinate
Flannel VNI, Ingress node port and Flannel network allocations, all e2e
tests must use same crdstorage instance. This introduces race condition
where two e2e tests are running concurrently and modify the shared CR
object. To work with this, operations that involve crdstorage
modifications must retry on error.

Towards https://github.com/giantswarm/giantswarm/issues/4214