### PR TITLE
Wrap crdstorage with retrystorage in e2e tests

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -338,11 +338,14 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:ddd43139c09097ebf88f8748425ae83d37770763aae32f6a855782847161e587"
+  digest = "1:dcce0e2a37e13265ab8ae53d5403ad511dbad131adefc7b5452d41b1687428f6"
   name = "github.com/giantswarm/microstorage"
-  packages = ["."]
+  packages = [
+    ".",
+    "retrystorage",
+  ]
   pruneopts = "UT"
-  revision = "4411a6307c6b844b7f9e68aaba37407b41b1c4d7"
+  revision = "e7d619b8ec166cd68eb4d026b68b9193bb645d8f"
 
 [[projects]]
   branch = "master"
@@ -1526,6 +1529,7 @@
     "github.com/giantswarm/micrologger",
     "github.com/giantswarm/micrologger/microloggertest",
     "github.com/giantswarm/microstorage",
+    "github.com/giantswarm/microstorage/retrystorage",
     "github.com/giantswarm/operatorkit/client/k8scrdclient",
     "github.com/giantswarm/operatorkit/client/k8srestconfig",
     "github.com/giantswarm/operatorkit/controller",

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1495,6 +1495,7 @@
   analyzer-name = "dep"
   analyzer-version = 1
   input-imports = [
+    "github.com/cenkalti/backoff",
     "github.com/docker/distribution/reference",
     "github.com/giantswarm/apiextensions/pkg/apis/core/v1alpha1",
     "github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -69,6 +69,10 @@ required = [
 
 [[constraint]]
   branch = "master"
+  name = "github.com/giantswarm/microstorage"
+
+[[constraint]]
+  branch = "master"
   name = "github.com/giantswarm/micrologger"
 
 [[constraint]]

--- a/integration/setup/setup.go
+++ b/integration/setup/setup.go
@@ -17,6 +17,7 @@ import (
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
 	"github.com/giantswarm/microstorage"
+	"github.com/giantswarm/microstorage/retrystorage"
 
 	"github.com/giantswarm/kvm-operator/integration/env"
 	"github.com/giantswarm/kvm-operator/integration/ipam"
@@ -131,9 +132,21 @@ func installKVMResource(h *framework.Host) error {
 		}
 	}
 
-	var crdStorage microstorage.Storage
+	var retryingCRDStorage microstorage.Storage
 	{
-		crdStorage, err = storage.InitCRDStorage(ctx, h, l)
+		crdStorage, err := storage.InitCRDStorage(ctx, h, l)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		b := backoff.NewExponential(framework.ShortMaxWait, framework.ShortMaxInterval)
+		c := retrystorage.Config{
+			Logger:         l,
+			Underlying:     crdstorage,
+			NewBackoffFunc: b,
+		}
+
+		retryingCRDStorage, err = retrystorage.New(c)
 		if err != nil {
 			return microerror.Mask(err)
 		}
@@ -143,7 +156,7 @@ func installKVMResource(h *framework.Host) error {
 	{
 		kvmResourceChartValues.ClusterID = env.ClusterID()
 
-		rangePool, err := rangepool.InitRangePool(crdStorage, l)
+		rangePool, err := rangepool.InitRangePool(retryingCRDStorage, l)
 		if err != nil {
 			return microerror.Mask(err)
 		}

--- a/vendor/github.com/giantswarm/microstorage/Gopkg.lock
+++ b/vendor/github.com/giantswarm/microstorage/Gopkg.lock
@@ -3,134 +3,179 @@
 
 [[projects]]
   branch = "master"
+  digest = "1:0c5485088ce274fac2e931c1b979f2619345097b39d91af3239977114adf0320"
   name = "github.com/beorn7/perks"
   packages = ["quantile"]
+  pruneopts = ""
   revision = "4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9"
 
 [[projects]]
+  digest = "1:f619cb9b07aebe5416262cdd8b86082e8d5bdc5264cb3b615ff858df0b645f97"
   name = "github.com/cenkalti/backoff"
   packages = ["."]
-  revision = "61153c768f31ee5f130071d08fc82b85208528de"
-  version = "v1.1.0"
+  pruneopts = ""
+  revision = "2ea60e5f094469f9e65adb9cd103795b73ae743e"
+  version = "v2.0.0"
 
 [[projects]]
+  digest = "1:56c130d885a4aacae1dd9c7b71cfe39912c7ebc1ff7d2b46083c8812996dc43b"
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
+  pruneopts = ""
   revision = "346938d642f2ec3594ed81d874461961cd0faa76"
   version = "v1.1.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:17a0bc4efb06b5d45fb5fe0200e3d81c29782ee471a1ba0bf237a80b81ef9cdd"
   name = "github.com/giantswarm/microerror"
   packages = ["."]
+  pruneopts = ""
   revision = "325932fa68e70dd4464598f11e2f710ac1aaec46"
 
 [[projects]]
   branch = "master"
+  digest = "1:693dc99c348122ffd1087467934015dc862466e954f0b859b7b100a5d596097d"
   name = "github.com/giantswarm/micrologger"
   packages = [
     ".",
-    "loggermeta"
+    "loggermeta",
   ]
+  pruneopts = ""
   revision = "216e9191d90f55723bfc0e93801af96e6b80eb12"
 
 [[projects]]
+  digest = "1:44ec1082ba97d89ce860abcc6ee3f0cf24e658d3efb8531b0f0a52f0781e4243"
   name = "github.com/go-kit/kit"
   packages = ["log"]
+  pruneopts = ""
   revision = "4dc7be5d2d12881735283bcab7352178e190fc71"
   version = "v0.6.0"
 
 [[projects]]
+  digest = "1:6a4a01d58b227c4b6b11111b9f172ec5c17682b82724e58e6daf3f19f4faccd8"
   name = "github.com/go-logfmt/logfmt"
   packages = ["."]
+  pruneopts = ""
   revision = "390ab7935ee28ec6b286364bba9b4dd6410cb3d5"
   version = "v0.3.0"
 
 [[projects]]
+  digest = "1:9ca737b471693542351e112c9e86be9bf7385e42256893a09ecb2a98e2036f74"
   name = "github.com/go-stack/stack"
   packages = ["."]
+  pruneopts = ""
   revision = "259ab82a6cad3992b4e21ff5cac294ccb06474bc"
   version = "v1.7.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:3b760d3b93f994df8eb1d9ebfad17d3e9e37edcb7f7efaa15b427c0d7a64f4e4"
   name = "github.com/golang/protobuf"
   packages = ["proto"]
+  pruneopts = ""
   revision = "1e59b77b52bf8e4b449a57e6f79f21226d571845"
 
 [[projects]]
   branch = "master"
+  digest = "1:6a3c12156fd310ad95e3fe38070b1bf74e123552e374f1a57a188682a96d168e"
   name = "github.com/juju/errgo"
   packages = ["."]
+  pruneopts = ""
   revision = "08cceb5d0b5331634b9826762a8fd53b29b86ad8"
 
 [[projects]]
   branch = "master"
+  digest = "1:1ed9eeebdf24aadfbca57eb50e6455bd1d2474525e0f0d4454de8c8e9bc7ee9a"
   name = "github.com/kr/logfmt"
   packages = ["."]
+  pruneopts = ""
   revision = "b84e30acd515aadc4b783ad4ff83aff3299bdfe0"
 
 [[projects]]
+  digest = "1:4c23ced97a470b17d9ffd788310502a077b9c1f60221a85563e49696276b4147"
   name = "github.com/matttproud/golang_protobuf_extensions"
   packages = ["pbutil"]
+  pruneopts = ""
   revision = "3247c84500bff8d9fb6d579d800f20b3e091582c"
   version = "v1.0.0"
 
 [[projects]]
+  digest = "1:256484dbbcd271f9ecebc6795b2df8cad4c458dd0f5fd82a8c2fa0c29f233411"
   name = "github.com/pmezard/go-difflib"
   packages = ["difflib"]
+  pruneopts = ""
   revision = "792786c7400a136282c1664665ae0a8db921c6c2"
   version = "v1.0.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:5e9a29677a616360bd6b9852dabff374e5f1bed83853de18d14ff051d54ad191"
   name = "github.com/prometheus/client_golang"
   packages = ["prometheus"]
+  pruneopts = ""
   revision = "f02bfc3484a6b03d1fc00d72d86add103ef9567b"
 
 [[projects]]
   branch = "master"
+  digest = "1:60aca47f4eeeb972f1b9da7e7db51dee15ff6c59f7b401c1588b8e6771ba15ef"
   name = "github.com/prometheus/client_model"
   packages = ["go"]
+  pruneopts = ""
   revision = "99fa1f4be8e564e8a6b613da7fa6f46c9edafc6c"
 
 [[projects]]
   branch = "master"
+  digest = "1:acf9415ef3a5f298495b0e1aa4d0e18f571a3c845872944e6c52777496819b21"
   name = "github.com/prometheus/common"
   packages = [
     "expfmt",
     "internal/bitbucket.org/ww/goautoneg",
-    "model"
+    "model",
   ]
+  pruneopts = ""
   revision = "89604d197083d4781071d3c65855d24ecfb0a563"
 
 [[projects]]
   branch = "master"
+  digest = "1:f0857d075687b4ddebb10c8403d5fec9f093f7208b34ed5b6f3101ee2e77cec5"
   name = "github.com/prometheus/procfs"
   packages = [
     ".",
-    "xfs"
+    "xfs",
   ]
+  pruneopts = ""
   revision = "b15cd069a83443be3154b719d0cc9fe8117f09fb"
 
 [[projects]]
+  digest = "1:2d0dc026c4aef5e2f3a0e06a4dabe268b840d8f63190cf6894e02134a03f52c5"
   name = "github.com/stretchr/testify"
   packages = [
     "assert",
-    "require"
+    "require",
   ]
+  pruneopts = ""
   revision = "b91bfb9ebec76498946beb6af7c0230c7cc7ba6c"
   version = "v1.2.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:f3ee2a699dd02cac37fbca1d028f1121ce0e48143a0f9abd293d3141dcfe6b92"
   name = "golang.org/x/net"
   packages = ["context"]
+  pruneopts = ""
   revision = "5ccada7d0a7ba9aeb5d3aca8d3501b4c2a509fec"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "5fb281229bbcad3d2fd51775ee290c238c5dcb4b68c3064f4ead57eb9309501a"
+  input-imports = [
+    "github.com/cenkalti/backoff",
+    "github.com/giantswarm/microerror",
+    "github.com/giantswarm/micrologger",
+    "github.com/prometheus/client_golang/prometheus",
+    "github.com/stretchr/testify/assert",
+    "github.com/stretchr/testify/require",
+  ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/vendor/github.com/giantswarm/microstorage/Gopkg.toml
+++ b/vendor/github.com/giantswarm/microstorage/Gopkg.toml
@@ -22,7 +22,7 @@
 
 [[constraint]]
   name = "github.com/cenkalti/backoff"
-  version = "1.1.0"
+  version = "=2.0.0"
 
 [[constraint]]
   branch = "master"
@@ -38,4 +38,4 @@
 
 [[constraint]]
   name = "github.com/stretchr/testify"
-  version = "1.2.0"
+  version = "=1.2.0"

--- a/vendor/github.com/giantswarm/microstorage/retrystorage/error.go
+++ b/vendor/github.com/giantswarm/microstorage/retrystorage/error.go
@@ -1,0 +1,10 @@
+package retrystorage
+
+import "github.com/giantswarm/microerror"
+
+var invalidConfigError = microerror.New("invalid config")
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}

--- a/vendor/github.com/giantswarm/microstorage/retrystorage/storage.go
+++ b/vendor/github.com/giantswarm/microstorage/retrystorage/storage.go
@@ -1,0 +1,178 @@
+package retrystorage
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/cenkalti/backoff"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/giantswarm/microstorage"
+)
+
+const (
+	// defaultMaxAttempts is the default number of attempts of each storate
+	// operations before it finally fails.
+	defaultMaxAttempts = 3
+)
+
+type stoppingBackOff struct {
+	attempts    int
+	MaxAttempts int
+	Underlying  backoff.BackOff
+}
+
+func (s *stoppingBackOff) NextBackOff() time.Duration {
+	if s.attempts >= s.MaxAttempts {
+		return backoff.Stop
+	}
+	s.attempts++
+	return s.Underlying.NextBackOff()
+}
+
+func (s *stoppingBackOff) Reset() {
+	s.attempts = 0
+	s.Underlying.Reset()
+}
+
+type Config struct {
+	// Dependencies.
+
+	Logger     micrologger.Logger
+	Underlying microstorage.Storage
+
+	// Settings.
+
+	NewBackOffFunc func() backoff.BackOff
+}
+
+func DefaultConfig() Config {
+	return Config{
+		// Dependencies.
+
+		Logger:     nil, // Required.
+		Underlying: nil, // Required.
+
+		// Settings.
+
+		NewBackOffFunc: func() backoff.BackOff {
+			return &stoppingBackOff{
+				MaxAttempts: defaultMaxAttempts,
+				Underlying:  backoff.NewExponentialBackOff(),
+			}
+		},
+	}
+}
+
+type Storage struct {
+	logger         micrologger.Logger
+	underlying     microstorage.Storage
+	newBackOffFunc func() backoff.BackOff
+}
+
+func New(config Config) (*Storage, error) {
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "config.Logger is empty")
+	}
+	if config.Underlying == nil {
+		return nil, microerror.Maskf(invalidConfigError, "config.Underlying is empty")
+	}
+	if config.NewBackOffFunc == nil {
+		return nil, microerror.Maskf(invalidConfigError, "config.NewBackOffFunc is empty")
+	}
+
+	s := &Storage{
+		logger:         config.Logger,
+		underlying:     config.Underlying,
+		newBackOffFunc: config.NewBackOffFunc,
+	}
+
+	return s, nil
+}
+
+func (s *Storage) Put(ctx context.Context, kv microstorage.KV) error {
+	b := s.newBackOffFunc()
+	op := func() error {
+		err := s.underlying.Put(ctx, kv)
+		if microstorage.IsInvalidKey(err) || microstorage.IsNotFound(err) {
+			return backoff.Permanent(err)
+		}
+		return err
+	}
+	notify := func(err error, delay time.Duration) {
+		s.logger.Log("warning", "retrying", "op", "put", "key", kv.Key, "delay", delay, "err", fmt.Sprintf("%#v", err))
+	}
+	err := backoff.RetryNotify(op, b, notify)
+	return microerror.Mask(err)
+}
+
+func (s *Storage) Delete(ctx context.Context, key microstorage.K) error {
+	b := s.newBackOffFunc()
+	op := func() error {
+		err := s.underlying.Delete(ctx, key)
+		if microstorage.IsInvalidKey(err) || microstorage.IsNotFound(err) {
+			return backoff.Permanent(err)
+		}
+		return err
+	}
+	notify := func(err error, delay time.Duration) {
+		s.logger.Log("warning", "retrying", "op", "delete", "key", key, "delay", delay, "err", fmt.Sprintf("%#v", err))
+	}
+	err := backoff.RetryNotify(op, b, notify)
+	return microerror.Mask(err)
+}
+
+func (s *Storage) Exists(ctx context.Context, key microstorage.K) (bool, error) {
+	b := s.newBackOffFunc()
+	var exists bool
+	op := func() error {
+		var err error
+		exists, err = s.underlying.Exists(ctx, key)
+		if microstorage.IsInvalidKey(err) || microstorage.IsNotFound(err) {
+			return backoff.Permanent(err)
+		}
+		return err
+	}
+	notify := func(err error, delay time.Duration) {
+		s.logger.Log("warning", "retrying", "op", "exists", "key", key, "delay", delay, "err", fmt.Sprintf("%#v", err))
+	}
+	err := backoff.RetryNotify(op, b, notify)
+	return exists, microerror.Mask(err)
+}
+
+func (s *Storage) List(ctx context.Context, key microstorage.K) ([]microstorage.KV, error) {
+	b := s.newBackOffFunc()
+	var list []microstorage.KV
+	op := func() error {
+		var err error
+		list, err = s.underlying.List(ctx, key)
+		if microstorage.IsInvalidKey(err) || microstorage.IsNotFound(err) {
+			return backoff.Permanent(err)
+		}
+		return err
+	}
+	notify := func(err error, delay time.Duration) {
+		s.logger.Log("warning", "retrying", "op", "list", "key", key, "delay", delay, "err", fmt.Sprintf("%#v", err))
+	}
+	err := backoff.RetryNotify(op, b, notify)
+	return list, microerror.Mask(err)
+}
+
+func (s *Storage) Search(ctx context.Context, key microstorage.K) (microstorage.KV, error) {
+	b := s.newBackOffFunc()
+	var value microstorage.KV
+	op := func() error {
+		var err error
+		value, err = s.underlying.Search(ctx, key)
+		if microstorage.IsInvalidKey(err) || microstorage.IsNotFound(err) {
+			return backoff.Permanent(err)
+		}
+		return err
+	}
+	notify := func(err error, delay time.Duration) {
+		s.logger.Log("warning", "retrying", "op", "search", "key", key, "delay", delay, "err", fmt.Sprintf("%#v", err))
+	}
+	err := backoff.RetryNotify(op, b, notify)
+	return value, microerror.Mask(err)
+}


### PR DESCRIPTION
On KVM e2e tests run on same control plane and in order to coordinate
Flannel VNI, Ingress node port and Flannel network allocations, all e2e
tests must use same crdstorage instance. This introduces race condition
where two e2e tests are running concurrently and modify the shared CR
object. To work with this, operations that involve crdstorage
modifications must retry on error.

Towards https://github.com/giantswarm/giantswarm/issues/4214