### PR TITLE
Add configurable psp name

### DIFF
--- a/helm/kvm-operator-chart/templates/psp.yaml
+++ b/helm/kvm-operator-chart/templates/psp.yaml
@@ -1,7 +1,7 @@
 apiVersion: extensions/v1beta1
 kind: PodSecurityPolicy
 metadata:
-  name: kvm-operator-psp
+  name: {{ .Values.pspName }}
 spec:
   privileged: false
   fsGroup:

--- a/helm/kvm-operator-chart/values.yaml
+++ b/helm/kvm-operator-chart/values.yaml
@@ -3,3 +3,4 @@ clusterRoleBindingNamePSP: kvm-operator-psp
 clusterRoleName: kvm-operator
 clusterRoleNamePSP: kvm-operator-psp
 namespace: giantswarm
+pspName: kvm-operator-psp


### PR DESCRIPTION
towards https://github.com/giantswarm/giantswarm/issues/4388

I will check this manually. E2E will likely fail right now because this is missing.