### PR TITLE
Add shutdown-deferrer sidecar container to PODs

### DIFF
--- a/service/controller/v15/key/key.go
+++ b/service/controller/v15/key/key.go
@@ -43,7 +43,7 @@ const (
 	K8SEndpointUpdaterDocker = "quay.io/giantswarm/k8s-endpoint-updater:df982fc73b71e60fc70a7444c068b52441ddb30e"
 	K8SKVMDockerImage        = "quay.io/giantswarm/k8s-kvm:db5f9c0ad08fd99a7e775e31fba99e5c7f87ab59"
 	K8SKVMHealthDocker       = "quay.io/giantswarm/k8s-kvm-health:ddf211dfed52086ade32ab8c45e44eb0273319ef"
-	ShutdownDeferrerDocker   = "quay.io/giantswarm/shutdown-deferrer:latest"
+	ShutdownDeferrerDocker   = "quay.io/giantswarm/shutdown-deferrer:bbbdf26500fd7d8e46c626914eeae9cc6323c442"
 
 	// constants for calculation qemu memory overhead.
 	baseMasterMemoryOverhead     = "1G"

--- a/service/controller/v15/key/key.go
+++ b/service/controller/v15/key/key.go
@@ -43,7 +43,7 @@ const (
 	K8SEndpointUpdaterDocker = "quay.io/giantswarm/k8s-endpoint-updater:df982fc73b71e60fc70a7444c068b52441ddb30e"
 	K8SKVMDockerImage        = "quay.io/giantswarm/k8s-kvm:db5f9c0ad08fd99a7e775e31fba99e5c7f87ab59"
 	K8SKVMHealthDocker       = "quay.io/giantswarm/k8s-kvm-health:ddf211dfed52086ade32ab8c45e44eb0273319ef"
-	ShutdownDeferrerDocker   = "quay.io/giantswarm/shutdown-deferrer:bbbdf26500fd7d8e46c626914eeae9cc6323c442"
+	ShutdownDeferrerDocker   = "quay.io/giantswarm/shutdown-deferrer:dd07d71449651b2e9c8bd5d7834100451984b722"
 
 	// constants for calculation qemu memory overhead.
 	baseMasterMemoryOverhead     = "1G"

--- a/service/controller/v15/key/key.go
+++ b/service/controller/v15/key/key.go
@@ -43,6 +43,7 @@ const (
 	K8SEndpointUpdaterDocker = "quay.io/giantswarm/k8s-endpoint-updater:df982fc73b71e60fc70a7444c068b52441ddb30e"
 	K8SKVMDockerImage        = "quay.io/giantswarm/k8s-kvm:db5f9c0ad08fd99a7e775e31fba99e5c7f87ab59"
 	K8SKVMHealthDocker       = "quay.io/giantswarm/k8s-kvm-health:ddf211dfed52086ade32ab8c45e44eb0273319ef"
+	ShutdownDeferrerDocker   = "quay.io/giantswarm/shutdown-deferrer:latest"
 
 	// constants for calculation qemu memory overhead.
 	baseMasterMemoryOverhead     = "1G"

--- a/service/controller/v15/resource/deployment/master_deployment.go
+++ b/service/controller/v15/resource/deployment/master_deployment.go
@@ -321,6 +321,11 @@ func newMasterDeployments(customObject v1alpha1.KVMConfig) ([]*extensionsv1.Depl
 									},
 								},
 							},
+							{
+								Name:            "shutdown-deferrer",
+								Image:           key.ShutdownDeferrerDocker,
+								ImagePullPolicy: apiv1.PullAlways,
+							},
 						},
 					},
 				},

--- a/service/controller/v15/resource/deployment/worker_deployment.go
+++ b/service/controller/v15/resource/deployment/worker_deployment.go
@@ -285,6 +285,11 @@ func newWorkerDeployments(customObject v1alpha1.KVMConfig) ([]*extensionsv1.Depl
 									},
 								},
 							},
+							{
+								Name:            "shutdown-deferrer",
+								Image:           key.ShutdownDeferrerDocker,
+								ImagePullPolicy: apiv1.PullAlways,
+							},
 						},
 					},
 				},

--- a/service/controller/v16/key/key.go
+++ b/service/controller/v16/key/key.go
@@ -43,7 +43,7 @@ const (
 	K8SEndpointUpdaterDocker = "quay.io/giantswarm/k8s-endpoint-updater:df982fc73b71e60fc70a7444c068b52441ddb30e"
 	K8SKVMDockerImage        = "quay.io/giantswarm/k8s-kvm:db5f9c0ad08fd99a7e775e31fba99e5c7f87ab59"
 	K8SKVMHealthDocker       = "quay.io/giantswarm/k8s-kvm-health:ddf211dfed52086ade32ab8c45e44eb0273319ef"
-	ShutdownDeferrerDocker   = "quay.io/giantswarm/shutdown-deferrer:latest"
+	ShutdownDeferrerDocker   = "quay.io/giantswarm/shutdown-deferrer:bbbdf26500fd7d8e46c626914eeae9cc6323c442"
 
 	// constants for calculation qemu memory overhead.
 	baseMasterMemoryOverhead     = "1G"

--- a/service/controller/v16/key/key.go
+++ b/service/controller/v16/key/key.go
@@ -43,7 +43,7 @@ const (
 	K8SEndpointUpdaterDocker = "quay.io/giantswarm/k8s-endpoint-updater:df982fc73b71e60fc70a7444c068b52441ddb30e"
 	K8SKVMDockerImage        = "quay.io/giantswarm/k8s-kvm:db5f9c0ad08fd99a7e775e31fba99e5c7f87ab59"
 	K8SKVMHealthDocker       = "quay.io/giantswarm/k8s-kvm-health:ddf211dfed52086ade32ab8c45e44eb0273319ef"
-	ShutdownDeferrerDocker   = "quay.io/giantswarm/shutdown-deferrer:bbbdf26500fd7d8e46c626914eeae9cc6323c442"
+	ShutdownDeferrerDocker   = "quay.io/giantswarm/shutdown-deferrer:dd07d71449651b2e9c8bd5d7834100451984b722"
 
 	// constants for calculation qemu memory overhead.
 	baseMasterMemoryOverhead     = "1G"

--- a/service/controller/v16/key/key.go
+++ b/service/controller/v16/key/key.go
@@ -43,6 +43,7 @@ const (
 	K8SEndpointUpdaterDocker = "quay.io/giantswarm/k8s-endpoint-updater:df982fc73b71e60fc70a7444c068b52441ddb30e"
 	K8SKVMDockerImage        = "quay.io/giantswarm/k8s-kvm:db5f9c0ad08fd99a7e775e31fba99e5c7f87ab59"
 	K8SKVMHealthDocker       = "quay.io/giantswarm/k8s-kvm-health:ddf211dfed52086ade32ab8c45e44eb0273319ef"
+	ShutdownDeferrerDocker   = "quay.io/giantswarm/shutdown-deferrer:latest"
 
 	// constants for calculation qemu memory overhead.
 	baseMasterMemoryOverhead     = "1G"

--- a/service/controller/v16/resource/deployment/master_deployment.go
+++ b/service/controller/v16/resource/deployment/master_deployment.go
@@ -321,6 +321,11 @@ func newMasterDeployments(customObject v1alpha1.KVMConfig) ([]*extensionsv1.Depl
 									},
 								},
 							},
+							{
+								Name:            "shutdown-deferrer",
+								Image:           key.ShutdownDeferrerDocker,
+								ImagePullPolicy: apiv1.PullAlways,
+							},
 						},
 					},
 				},

--- a/service/controller/v16/resource/deployment/worker_deployment.go
+++ b/service/controller/v16/resource/deployment/worker_deployment.go
@@ -285,6 +285,11 @@ func newWorkerDeployments(customObject v1alpha1.KVMConfig) ([]*extensionsv1.Depl
 									},
 								},
 							},
+							{
+								Name:            "shutdown-deferrer",
+								Image:           key.ShutdownDeferrerDocker,
+								ImagePullPolicy: apiv1.PullAlways,
+							},
 						},
 					},
 				},


### PR DESCRIPTION
Shutdown deferrer is a service that will monitor DrainerConfig object
for specific POD it's running in and prevents POD / container
termination before corresponding node is properly drained (by
node-operator).

Towards https://github.com/giantswarm/giantswarm/issues/2993

FYI: @giantswarm/sig-infrastructure 