### PR TITLE
Disable CoreDNS k8scloudconfig templates

### DIFF
--- a/service/controller/v16/cloudconfig/master_template.go
+++ b/service/controller/v16/cloudconfig/master_template.go
@@ -17,6 +17,7 @@ func (c *CloudConfig) NewMasterTemplate(customObject v1alpha1.KVMConfig, certs c
 	{
 		params.APIServerEncryptionKey = string(randomKeys.APIServerEncryptionKey)
 		params.Cluster = customObject.Spec.Cluster
+		params.DisableCoreDNS = true
 		params.DisableIngressController = true
 		// Ingress controller service remains in k8scloudconfig and will be
 		// removed in a later migration.

--- a/service/controller/v16/version_bundle.go
+++ b/service/controller/v16/version_bundle.go
@@ -8,11 +8,6 @@ func VersionBundle() versionbundle.Bundle {
 	return versionbundle.Bundle{
 		Changelogs: []versionbundle.Changelog{
 			{
-				Component:   "cloudconfig",
-				Description: "Removed CoreDNS related components (now managed by chart-operator).",
-				Kind:        versionbundle.KindRemoved,
-			},
-			{
 				Component:   "kubernetes",
 				Description: "Updated Kubernetes to 1.12.2. More info here: https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.12.md",
 				Kind:        versionbundle.KindChanged,

--- a/service/controller/v16/version_bundle.go
+++ b/service/controller/v16/version_bundle.go
@@ -8,6 +8,11 @@ func VersionBundle() versionbundle.Bundle {
 	return versionbundle.Bundle{
 		Changelogs: []versionbundle.Changelog{
 			{
+				Component:   "cloudconfig",
+				Description: "Removed CoreDNS related components (now managed by chart-operator).",
+				Kind:        versionbundle.KindRemoved,
+			},
+			{
 				Component:   "kubernetes",
 				Description: "Updated Kubernetes to 1.12.2. More info here: https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.12.md",
 				Kind:        versionbundle.KindChanged,
@@ -59,10 +64,6 @@ func VersionBundle() versionbundle.Bundle {
 			{
 				Name:    "etcd",
 				Version: "3.3.9",
-			},
-			{
-				Name:    "coredns",
-				Version: "1.1.1",
 			},
 			{
 				Name:    "kubernetes",


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/1902

Disable management of CoreDNS component via k8scloudconfig as it is now managed by cluster-operator.