### PR TITLE
customize-var-lib-kubelet

### DIFF
--- a/service/controller/deleter.go
+++ b/service/controller/deleter.go
@@ -18,6 +18,7 @@ import (
 	"github.com/giantswarm/kvm-operator/service/controller/v14patch2"
 	"github.com/giantswarm/kvm-operator/service/controller/v15"
 	"github.com/giantswarm/kvm-operator/service/controller/v16"
+	"github.com/giantswarm/kvm-operator/service/controller/v17"
 )
 
 type DeleterConfig struct {
@@ -198,6 +199,22 @@ func newDeleterResourceSets(config DeleterConfig) ([]*controller.ResourceSet, er
 		}
 	}
 
+	var resourceSetV17 *controller.ResourceSet
+	{
+		c := v17.DeleterResourceSetConfig{
+			CertsSearcher: config.CertsSearcher,
+			K8sClient:     config.K8sClient,
+			Logger:        config.Logger,
+
+			ProjectName: config.ProjectName,
+		}
+
+		resourceSetV17, err = v17.NewDeleterResourceSet(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
 	resourceSets := []*controller.ResourceSet{
 		resourceSetV13,
 		resourceSetV14,
@@ -205,6 +222,7 @@ func newDeleterResourceSets(config DeleterConfig) ([]*controller.ResourceSet, er
 		resourceSetV14Patch2,
 		resourceSetV15,
 		resourceSetV16,
+		resourceSetV17,
 	}
 
 	return resourceSets, nil

--- a/service/controller/drainer.go
+++ b/service/controller/drainer.go
@@ -21,6 +21,7 @@ import (
 	"github.com/giantswarm/kvm-operator/service/controller/v15"
 	"github.com/giantswarm/kvm-operator/service/controller/v16"
 	"github.com/giantswarm/kvm-operator/service/controller/v16/key"
+	"github.com/giantswarm/kvm-operator/service/controller/v17"
 )
 
 type DrainerConfig struct {
@@ -236,6 +237,22 @@ func newDrainerResourceSets(config DrainerConfig) ([]*controller.ResourceSet, er
 		}
 	}
 
+	var resourceSetV17 *controller.ResourceSet
+	{
+		c := v17.DrainerResourceSetConfig{
+			G8sClient: config.G8sClient,
+			K8sClient: config.K8sClient,
+			Logger:    config.Logger,
+
+			ProjectName: config.ProjectName,
+		}
+
+		resourceSetV17, err = v17.NewDrainerResourceSet(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
 	resourceSets := []*controller.ResourceSet{
 		resourceSetV11,
 		resourceSetV12,
@@ -245,6 +262,7 @@ func newDrainerResourceSets(config DrainerConfig) ([]*controller.ResourceSet, er
 		resourceSetV14Patch2,
 		resourceSetV15,
 		resourceSetV16,
+		resourceSetV17,
 	}
 
 	return resourceSets, nil

--- a/service/controller/v17/cloudconfig/master_template.go
+++ b/service/controller/v17/cloudconfig/master_template.go
@@ -134,6 +134,21 @@ WantedBy=multi-user.target
 			Command: "start",
 		},
 		{
+			AssetContent: `[Unit]
+Before=docker.service
+Description=Mount for kubelet volume
+[Mount]
+What=/dev/disk/by-id/virtio-kubeletfs
+Where=/var/lib/kubelet
+Type=xfs
+[Install]
+WantedBy=multi-user.target
+`,
+			Name:    "var-lib-kubelet.mount",
+			Enable:  true,
+			Command: "start",
+		},
+		{
 			Name:    "iscsid.service",
 			Enable:  true,
 			Command: "start",

--- a/service/controller/v17/cloudconfig/worker_template.go
+++ b/service/controller/v17/cloudconfig/worker_template.go
@@ -96,6 +96,21 @@ WantedBy=multi-user.target
 			Command: "start",
 		},
 		{
+			AssetContent: `[Unit]
+Before=docker.service
+Description=Mount for kubelet volume
+[Mount]
+What=/dev/disk/by-id/virtio-kubeletfs
+Where=/var/lib/kubelet
+Type=xfs
+[Install]
+WantedBy=multi-user.target
+`,
+			Name:    "var-lib-kubelet.mount",
+			Enable:  true,
+			Command: "start",
+		},
+		{
 			Name:    "iscsid.service",
 			Enable:  true,
 			Command: "start",

--- a/service/controller/v17/key/key.go
+++ b/service/controller/v17/key/key.go
@@ -63,6 +63,10 @@ const (
 	// within k8s-kvm. Note we use this only for masters, since the value for the
 	// workers can be configured at runtime by the user.
 	DefaultDockerDiskSize = "50G"
+	// DefaultKubeletDiskSize defines the space used to partition the kubelet FS
+	// within k8s-kvm. Note we use this only for masters, since the value for the
+	// workers can be configured at runtime by the user.
+	DefaultKubeletDiskSize = "5G"
 	// DefaultOSDiskSize defines the space used to partition the root FS within
 	// k8s-kvm.
 	DefaultOSDiskSize = "5G"
@@ -221,6 +225,21 @@ func IsPodDrained(pod *corev1.Pod) (bool, error) {
 	}
 
 	return b, nil
+}
+
+func KubeletVolumeSizeFromNode(node v1alpha1.KVMConfigSpecKVMNode) string {
+	// TODO: calvix
+	// TODO: for now we use same value as for DockerVolumeSizeFromNode, when we have kubelet size in spec we should use that.
+
+	if node.DockerVolumeSizeGB != 0 {
+		return fmt.Sprintf("%dG", node.DockerVolumeSizeGB)
+	}
+
+	if node.Disk != 0 {
+		return fmt.Sprintf("%sG", strconv.FormatFloat(node.Disk, 'f', 0, 64))
+	}
+
+	return DefaultKubeletDiskSize
 }
 
 // ArePodContainersTerminated checks ContainerState for all containers present

--- a/service/controller/v17/key/key.go
+++ b/service/controller/v17/key/key.go
@@ -228,7 +228,7 @@ func IsPodDrained(pod *corev1.Pod) (bool, error) {
 }
 
 func KubeletVolumeSizeFromNode(node v1alpha1.KVMConfigSpecKVMNode) string {
-	// TODO: calvix
+	// TODO: https://github.com/giantswarm/giantswarm/issues/4105#issuecomment-421772917
 	// TODO: for now we use same value as for DockerVolumeSizeFromNode, when we have kubelet size in spec we should use that.
 
 	if node.DockerVolumeSizeGB != 0 {

--- a/service/controller/v17/key/key.go
+++ b/service/controller/v17/key/key.go
@@ -48,7 +48,7 @@ const (
 	CoreosVersion        = "1855.5.0"
 
 	K8SEndpointUpdaterDocker = "quay.io/giantswarm/k8s-endpoint-updater:590479a6228c2c143695a268bda5382b52f7ffe1"
-	K8SKVMDockerImage        = "quay.io/giantswarm/k8s-kvm:f33392c3eff8adac6eb17339d31047deb60a8162"
+	K8SKVMDockerImage        = "quay.io/giantswarm/k8s-kvm:75994050b92498ef3a8fa3bac22e17f5e6c62956"
 	K8SKVMHealthDocker       = "quay.io/giantswarm/k8s-kvm-health:6e345a9250097f83f42bae5a002c04f772cd3c2f"
 	ShutdownDeferrerDocker   = "quay.io/giantswarm/shutdown-deferrer:b2ffdb2c4ec93fe6bf2d4af8e55c8a4b11253611"
 

--- a/service/controller/v17/resource/deployment/master_deployment.go
+++ b/service/controller/v17/resource/deployment/master_deployment.go
@@ -211,6 +211,10 @@ func newMasterDeployments(customResource v1alpha1.KVMConfig) ([]*extensionsv1.De
 										Value: key.DefaultDockerDiskSize,
 									},
 									{
+										Name:  "DISK_KUBELET",
+										Value: key.DefaultKubeletDiskSize,
+									},
+									{
 										Name:  "DISK_OS",
 										Value: key.DefaultOSDiskSize,
 									},

--- a/service/controller/v17/resource/deployment/worker_deployment.go
+++ b/service/controller/v17/resource/deployment/worker_deployment.go
@@ -179,6 +179,10 @@ func newWorkerDeployments(customResource v1alpha1.KVMConfig) ([]*extensionsv1.De
 										Value: key.DockerVolumeSizeFromNode(capabilities),
 									},
 									{
+										Name:  "DISK_KUBELET",
+										Value: key.KubeletVolumeSizeFromNode(capabilities),
+									},
+									{
 										Name:  "DISK_OS",
 										Value: key.DefaultOSDiskSize,
 									},


### PR DESCRIPTION
add separate partition for `/var/lib/kubelet` and allow customizing its size
as api/crd and other specs are still not done, for now, we will use the same size for `/var/lib/kubelet` as for `/var/lib/docker` (workers only)

for master we use default size of `5G` as nothing big should run on master anyway



towards https://github.com/giantswarm/giantswarm/issues/4105

changes for k8s-kvm https://github.com/giantswarm/k8s-kvm/pull/25