### PR TITLE
add-static-initiator-name-for-vms

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2016-2017 Giant Swarm GmbH
+   Copyright 2016 - 2019 Giant Swarm GmbH
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/service/controller/v18/cloudconfig/cloud_config.go
+++ b/service/controller/v18/cloudconfig/cloud_config.go
@@ -14,6 +14,13 @@ const (
 
 	IscsiInitiatorNameFilePath    = "/etc/iscsi/initiatorname.iscsi"
 	IscsiInitiatorFilePermissions = 0644
+
+	IscsiConfigFilePath        = "/etc/iscsi/iscsid.conf"
+	IscsiConfigFilePermissions = 0644
+	IscsiConfigFileContent     = `
+# Check for active mounts on devices reachable through a session
+# and refuse to logout if there are any.  Defaults to "No".
+iscsid.safe_logout = Yes`
 )
 
 // Config represents the configuration used to create a cloud config service.

--- a/service/controller/v18/cloudconfig/cloud_config.go
+++ b/service/controller/v18/cloudconfig/cloud_config.go
@@ -11,6 +11,8 @@ const (
 	FileOwnerUser  = "root"
 	FileOwnerGroup = "root"
 	FilePermission = 0700
+
+	IscsiInitiatorNameFilePath = "/etc/iscsi/initiatorname.iscsi"
 )
 
 // Config represents the configuration used to create a cloud config service.

--- a/service/controller/v18/cloudconfig/cloud_config.go
+++ b/service/controller/v18/cloudconfig/cloud_config.go
@@ -12,7 +12,8 @@ const (
 	FileOwnerGroup = "root"
 	FilePermission = 0700
 
-	IscsiInitiatorNameFilePath = "/etc/iscsi/initiatorname.iscsi"
+	IscsiInitiatorNameFilePath    = "/etc/iscsi/initiatorname.iscsi"
+	IscsiInitiatorFilePermissions = 0644
 )
 
 // Config represents the configuration used to create a cloud config service.

--- a/service/controller/v18/cloudconfig/master_template.go
+++ b/service/controller/v18/cloudconfig/master_template.go
@@ -94,6 +94,17 @@ func (e *masterExtension) Files() ([]k8scloudconfig.FileAsset, error) {
 	}
 	filesMeta = append(filesMeta, iscsiInitiatorFile)
 
+	iscsiConfigFile := k8scloudconfig.FileMetadata{
+		AssetContent: IscsiConfigFileContent,
+		Path:         IscsiConfigFilePath,
+		Owner: k8scloudconfig.Owner{
+			User:  FileOwnerUser,
+			Group: FileOwnerGroup,
+		},
+		Permissions: IscsiConfigFilePermissions,
+	}
+	filesMeta = append(filesMeta, iscsiConfigFile)
+
 	var newFiles []k8scloudconfig.FileAsset
 
 	for _, fm := range filesMeta {

--- a/service/controller/v18/cloudconfig/master_template.go
+++ b/service/controller/v18/cloudconfig/master_template.go
@@ -94,6 +94,7 @@ func (e *masterExtension) Files() ([]k8scloudconfig.FileAsset, error) {
 	}
 	filesMeta = append(filesMeta, iscsiInitiatorFile)
 
+	// iscsi config as workaround for this bug https://github.com/kubernetes/kubernetes/issues/73181
 	iscsiConfigFile := k8scloudconfig.FileMetadata{
 		AssetContent: IscsiConfigFileContent,
 		Path:         IscsiConfigFilePath,

--- a/service/controller/v18/cloudconfig/master_template.go
+++ b/service/controller/v18/cloudconfig/master_template.go
@@ -1,6 +1,7 @@
 package cloudconfig
 
 import (
+	"fmt"
 	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
 	"github.com/giantswarm/certs"
 	k8scloudconfig "github.com/giantswarm/k8scloudconfig/v_4_0_0"
@@ -25,7 +26,9 @@ func (c *CloudConfig) NewMasterTemplate(customObject v1alpha1.KVMConfig, certs c
 		// removed in a later migration.
 		params.DisableIngressControllerService = false
 		params.Extension = &masterExtension{
-			certs: certs,
+			certs:        certs,
+			customObject: customObject,
+			node:         node,
 		}
 		params.Node = node
 		params.Hyperkube.Apiserver.Pod.CommandExtraArgs = c.k8sAPIExtraArgs
@@ -59,7 +62,9 @@ func (c *CloudConfig) NewMasterTemplate(customObject v1alpha1.KVMConfig, certs c
 }
 
 type masterExtension struct {
-	certs certs.Cluster
+	certs        certs.Cluster
+	customObject v1alpha1.KVMConfig
+	node         v1alpha1.ClusterNode
 }
 
 func (e *masterExtension) Files() ([]k8scloudconfig.FileAsset, error) {
@@ -77,6 +82,17 @@ func (e *masterExtension) Files() ([]k8scloudconfig.FileAsset, error) {
 		}
 		filesMeta = append(filesMeta, m)
 	}
+
+	iscsiInitiatorFile := k8scloudconfig.FileMetadata{
+		AssetContent: fmt.Sprintf("InitiatorName=%s", key.IscsiInitiatorName(e.customObject, e.node, key.MasterID)),
+		Path:         IscsiInitiatorNameFilePath,
+		Owner: k8scloudconfig.Owner{
+			User:  FileOwnerUser,
+			Group: FileOwnerGroup,
+		},
+		Permissions: FilePermission,
+	}
+	filesMeta = append(filesMeta, iscsiInitiatorFile)
 
 	var newFiles []k8scloudconfig.FileAsset
 

--- a/service/controller/v18/cloudconfig/master_template.go
+++ b/service/controller/v18/cloudconfig/master_template.go
@@ -90,7 +90,7 @@ func (e *masterExtension) Files() ([]k8scloudconfig.FileAsset, error) {
 			User:  FileOwnerUser,
 			Group: FileOwnerGroup,
 		},
-		Permissions: FilePermission,
+		Permissions: IscsiInitiatorFilePermissions,
 	}
 	filesMeta = append(filesMeta, iscsiInitiatorFile)
 

--- a/service/controller/v18/cloudconfig/worker_template.go
+++ b/service/controller/v18/cloudconfig/worker_template.go
@@ -84,7 +84,7 @@ func (e *workerExtension) Files() ([]k8scloudconfig.FileAsset, error) {
 			User:  FileOwnerUser,
 			Group: FileOwnerGroup,
 		},
-		Permissions: FilePermission,
+		Permissions: IscsiInitiatorFilePermissions,
 	}
 	filesMeta = append(filesMeta, iscsiInitiatorFile)
 

--- a/service/controller/v18/cloudconfig/worker_template.go
+++ b/service/controller/v18/cloudconfig/worker_template.go
@@ -88,6 +88,7 @@ func (e *workerExtension) Files() ([]k8scloudconfig.FileAsset, error) {
 	}
 	filesMeta = append(filesMeta, iscsiInitiatorFile)
 
+	// iscsi config as workaround for this bug https://github.com/kubernetes/kubernetes/issues/73181
 	iscsiConfigFile := k8scloudconfig.FileMetadata{
 		AssetContent: IscsiConfigFileContent,
 		Path:         IscsiConfigFilePath,

--- a/service/controller/v18/cloudconfig/worker_template.go
+++ b/service/controller/v18/cloudconfig/worker_template.go
@@ -1,6 +1,7 @@
 package cloudconfig
 
 import (
+	"fmt"
 	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
 	"github.com/giantswarm/certs"
 	k8scloudconfig "github.com/giantswarm/k8scloudconfig/v_4_0_0"
@@ -20,7 +21,9 @@ func (c *CloudConfig) NewWorkerTemplate(customObject v1alpha1.KVMConfig, certs c
 		params.BaseDomain = key.BaseDomain(customObject)
 		params.Cluster = customObject.Spec.Cluster
 		params.Extension = &workerExtension{
-			certs: certs,
+			certs:        certs,
+			customObject: customObject,
+			node:         node,
 		}
 		params.Node = node
 		params.SSOPublicKey = c.ssoPublicKey
@@ -53,7 +56,9 @@ func (c *CloudConfig) NewWorkerTemplate(customObject v1alpha1.KVMConfig, certs c
 }
 
 type workerExtension struct {
-	certs certs.Cluster
+	certs        certs.Cluster
+	customObject v1alpha1.KVMConfig
+	node         v1alpha1.ClusterNode
 }
 
 func (e *workerExtension) Files() ([]k8scloudconfig.FileAsset, error) {
@@ -71,6 +76,17 @@ func (e *workerExtension) Files() ([]k8scloudconfig.FileAsset, error) {
 		}
 		filesMeta = append(filesMeta, m)
 	}
+
+	iscsiInitiatorFile := k8scloudconfig.FileMetadata{
+		AssetContent: fmt.Sprintf("InitiatorName=%s", key.IscsiInitiatorName(e.customObject, e.node, key.WorkerID)),
+		Path:         IscsiInitiatorNameFilePath,
+		Owner: k8scloudconfig.Owner{
+			User:  FileOwnerUser,
+			Group: FileOwnerGroup,
+		},
+		Permissions: FilePermission,
+	}
+	filesMeta = append(filesMeta, iscsiInitiatorFile)
 
 	var newFiles []k8scloudconfig.FileAsset
 

--- a/service/controller/v18/cloudconfig/worker_template.go
+++ b/service/controller/v18/cloudconfig/worker_template.go
@@ -88,6 +88,17 @@ func (e *workerExtension) Files() ([]k8scloudconfig.FileAsset, error) {
 	}
 	filesMeta = append(filesMeta, iscsiInitiatorFile)
 
+	iscsiConfigFile := k8scloudconfig.FileMetadata{
+		AssetContent: IscsiConfigFileContent,
+		Path:         IscsiConfigFilePath,
+		Owner: k8scloudconfig.Owner{
+			User:  FileOwnerUser,
+			Group: FileOwnerGroup,
+		},
+		Permissions: IscsiConfigFilePermissions,
+	}
+	filesMeta = append(filesMeta, iscsiConfigFile)
+
 	var newFiles []k8scloudconfig.FileAsset
 
 	for _, fm := range filesMeta {

--- a/service/controller/v18/key/key.go
+++ b/service/controller/v18/key/key.go
@@ -204,6 +204,10 @@ func HealthListenAddress(customObject v1alpha1.KVMConfig) string {
 	return "http://" + ProbeHost + ":" + strconv.Itoa(int(LivenessPort(customObject)))
 }
 
+func IscsiInitiatorName(customObject v1alpha1.KVMConfig, node v1alpha1.ClusterNode, nodeRole string) string {
+	return fmt.Sprintf("iqn.2016-04.com.coreos.iscsi:giantswarm-%s-%s-%s", ClusterID(customObject), nodeRole, node.ID)
+}
+
 func IsDeleted(customObject v1alpha1.KVMConfig) bool {
 	return customObject.GetDeletionTimestamp() != nil
 }

--- a/service/controller/v18/version_bundle.go
+++ b/service/controller/v18/version_bundle.go
@@ -27,6 +27,11 @@ func VersionBundle() versionbundle.Bundle {
 				Description: "Improved node draining during updates and scaling.",
 				Kind:        versionbundle.KindChanged,
 			},
+			{
+				Component:   "cloudconfig",
+				Description: "Add static initiator name for each vm.",
+				Kind:        versionbundle.KindAdded,
+			},
 		},
 		Components: []versionbundle.Component{
 			{

--- a/service/controller/v18/version_bundle.go
+++ b/service/controller/v18/version_bundle.go
@@ -29,7 +29,7 @@ func VersionBundle() versionbundle.Bundle {
 			},
 			{
 				Component:   "cloudconfig",
-				Description: "Add static initiator name for each vm.",
+				Description: "Add static iSCSI initiator name for each vm.",
 				Kind:        versionbundle.KindAdded,
 			},
 		},


### PR DESCRIPTION
the initiator name is built from  cluster-id, node id and node role ie: 
```
iqn.2016-04.com.coreos.iscsi:giantswarm-${CLUSTER_ID}-${NODE_ROLE}-${NODE_ID}
iqn.2016-04.com.coreos.iscsi:giantswarm-xsd4e-master-w23kl
```

this solution should help a customer with using iscsi on KVM clusters as the initiators will be always the same for the same node and easily deterministic

The primary source for this change is the current centaur situation and their need to somehow resolve the story and if more customer wants to try iscsi this will help us in the future. 

There should be no drawback.