### PR TITLE
fix-endpoint-update-race

### DIFF
--- a/service/controller/v17patch1/resource/endpoint/desired.go
+++ b/service/controller/v17patch1/resource/endpoint/desired.go
@@ -2,6 +2,7 @@ package endpoint
 
 import (
 	"context"
+	"github.com/giantswarm/kvm-operator/service/controller/v17patch1/key"
 
 	"github.com/giantswarm/microerror"
 	corev1 "k8s.io/api/core/v1"
@@ -34,7 +35,7 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interf
 	}
 
 	// If the pod is not ready we should not add the ip to the endpoint list.
-	if !podIsReady {
+	if !podIsReady && serviceName == key.WorkerID {
 		desiredEndpoint.IPs = []string{}
 	}
 

--- a/service/controller/v18/resource/endpoint/desired.go
+++ b/service/controller/v18/resource/endpoint/desired.go
@@ -2,6 +2,7 @@ package endpoint
 
 import (
 	"context"
+	"github.com/giantswarm/kvm-operator/service/controller/v18/key"
 
 	"github.com/giantswarm/microerror"
 	corev1 "k8s.io/api/core/v1"
@@ -34,7 +35,7 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interf
 	}
 
 	// If the pod is not ready so we should not add the ip to the endpoint list.
-	if !podIsReady {
+	if !podIsReady && serviceName == key.WorkerID {
 		desiredEndpoint.IPs = []string{}
 	}
 


### PR DESCRIPTION
looks like I introduced a small bug that could cause master IP not being removed from endpoint list

 We  need just worker ips to be removed/not added after  deletion

