### PR TITLE
Backport iSCSI initiator name fix from v19

### DIFF
--- a/service/controller/v18patch1/cloudconfig/master_template.go
+++ b/service/controller/v18patch1/cloudconfig/master_template.go
@@ -12,7 +12,7 @@ import (
 
 // NewMasterTemplate generates a new worker cloud config template and returns it
 // as a base64 encoded string.
-func (c *CloudConfig) NewMasterTemplate(customObject v1alpha1.KVMConfig, certs certs.Cluster, node v1alpha1.ClusterNode, randomKeys randomkeys.Cluster) (string, error) {
+func (c *CloudConfig) NewMasterTemplate(customObject v1alpha1.KVMConfig, certs certs.Cluster, node v1alpha1.ClusterNode, randomKeys randomkeys.Cluster, nodeIndex int) (string, error) {
 	var err error
 
 	var params k8scloudconfig.Params
@@ -28,7 +28,7 @@ func (c *CloudConfig) NewMasterTemplate(customObject v1alpha1.KVMConfig, certs c
 		params.Extension = &masterExtension{
 			certs:        certs,
 			customObject: customObject,
-			node:         node,
+			nodeIndex:    nodeIndex,
 		}
 		params.Node = node
 		params.Hyperkube.Apiserver.Pod.CommandExtraArgs = c.k8sAPIExtraArgs
@@ -64,7 +64,7 @@ func (c *CloudConfig) NewMasterTemplate(customObject v1alpha1.KVMConfig, certs c
 type masterExtension struct {
 	certs        certs.Cluster
 	customObject v1alpha1.KVMConfig
-	node         v1alpha1.ClusterNode
+	nodeIndex    int
 }
 
 func (e *masterExtension) Files() ([]k8scloudconfig.FileAsset, error) {
@@ -84,7 +84,7 @@ func (e *masterExtension) Files() ([]k8scloudconfig.FileAsset, error) {
 	}
 
 	iscsiInitiatorFile := k8scloudconfig.FileMetadata{
-		AssetContent: fmt.Sprintf("InitiatorName=%s", key.IscsiInitiatorName(e.customObject, e.node, key.MasterID)),
+		AssetContent: fmt.Sprintf("InitiatorName=%s", key.IscsiInitiatorName(e.customObject, e.nodeIndex, key.MasterID)),
 		Path:         IscsiInitiatorNameFilePath,
 		Owner: k8scloudconfig.Owner{
 			User:  FileOwnerUser,

--- a/service/controller/v18patch1/cloudconfig/worker_template.go
+++ b/service/controller/v18patch1/cloudconfig/worker_template.go
@@ -11,7 +11,7 @@ import (
 
 // NewWorkerTemplate generates a new worker cloud config template and returns it
 // as a base64 encoded string.
-func (c *CloudConfig) NewWorkerTemplate(customObject v1alpha1.KVMConfig, certs certs.Cluster, node v1alpha1.ClusterNode) (string, error) {
+func (c *CloudConfig) NewWorkerTemplate(customObject v1alpha1.KVMConfig, certs certs.Cluster, node v1alpha1.ClusterNode, nodeIndex int) (string, error) {
 	var err error
 
 	var params k8scloudconfig.Params
@@ -23,7 +23,7 @@ func (c *CloudConfig) NewWorkerTemplate(customObject v1alpha1.KVMConfig, certs c
 		params.Extension = &workerExtension{
 			certs:        certs,
 			customObject: customObject,
-			node:         node,
+			nodeIndex:    nodeIndex,
 		}
 		params.Node = node
 		params.SSOPublicKey = c.ssoPublicKey
@@ -58,7 +58,7 @@ func (c *CloudConfig) NewWorkerTemplate(customObject v1alpha1.KVMConfig, certs c
 type workerExtension struct {
 	certs        certs.Cluster
 	customObject v1alpha1.KVMConfig
-	node         v1alpha1.ClusterNode
+	nodeIndex    int
 }
 
 func (e *workerExtension) Files() ([]k8scloudconfig.FileAsset, error) {
@@ -78,7 +78,7 @@ func (e *workerExtension) Files() ([]k8scloudconfig.FileAsset, error) {
 	}
 
 	iscsiInitiatorFile := k8scloudconfig.FileMetadata{
-		AssetContent: fmt.Sprintf("InitiatorName=%s", key.IscsiInitiatorName(e.customObject, e.node, key.WorkerID)),
+		AssetContent: fmt.Sprintf("InitiatorName=%s", key.IscsiInitiatorName(e.customObject, e.nodeIndex, key.WorkerID)),
 		Path:         IscsiInitiatorNameFilePath,
 		Owner: k8scloudconfig.Owner{
 			User:  FileOwnerUser,

--- a/service/controller/v18patch1/key/key.go
+++ b/service/controller/v18patch1/key/key.go
@@ -233,8 +233,8 @@ func HealthListenAddress(customObject v1alpha1.KVMConfig) string {
 	return "http://" + ProbeHost + ":" + strconv.Itoa(int(LivenessPort(customObject)))
 }
 
-func IscsiInitiatorName(customObject v1alpha1.KVMConfig, node v1alpha1.ClusterNode, nodeRole string) string {
-	return fmt.Sprintf("iqn.2016-04.com.coreos.iscsi:giantswarm-%s-%s-%s", ClusterID(customObject), nodeRole, node.ID)
+func IscsiInitiatorName(customObject v1alpha1.KVMConfig, nodeIndex int, nodeRole string) string {
+	return fmt.Sprintf("iqn.2016-04.com.coreos.iscsi:giantswarm-%s-%s-%d", ClusterID(customObject), nodeRole, nodeIndex)
 }
 
 func IsDeleted(customObject v1alpha1.KVMConfig) bool {

--- a/service/controller/v18patch1/resource/configmap/desired.go
+++ b/service/controller/v18patch1/resource/configmap/desired.go
@@ -44,7 +44,12 @@ func (r *Resource) newConfigMaps(customResource v1alpha1.KVMConfig) ([]*apiv1.Co
 	}
 
 	for _, node := range customResource.Spec.Cluster.Masters {
-		template, err := r.cloudConfig.NewMasterTemplate(customResource, certs, node, keys)
+		nodeIdx, exists := key.NodeIndex(customResource, node.ID)
+		if !exists {
+			return nil, microerror.Maskf(notFoundError, fmt.Sprintf("node index for master (%q) is not available", node.ID))
+		}
+
+		template, err := r.cloudConfig.NewMasterTemplate(customResource, certs, node, keys, nodeIdx)
 		if err != nil {
 			return nil, microerror.Mask(err)
 		}
@@ -58,7 +63,12 @@ func (r *Resource) newConfigMaps(customResource v1alpha1.KVMConfig) ([]*apiv1.Co
 	}
 
 	for _, node := range customResource.Spec.Cluster.Workers {
-		template, err := r.cloudConfig.NewWorkerTemplate(customResource, certs, node)
+		nodeIdx, exists := key.NodeIndex(customResource, node.ID)
+		if !exists {
+			return nil, microerror.Maskf(notFoundError, fmt.Sprintf("node index for worker (%q) is not available", node.ID))
+		}
+
+		template, err := r.cloudConfig.NewWorkerTemplate(customResource, certs, node, nodeIdx)
 		if err != nil {
 			return nil, microerror.Mask(err)
 		}


### PR DESCRIPTION
This change backports a fix for iSCSI initiator name that makes it use assigned
node index instead of node ID in order to be predictable and unique among
running nodes.

Original PR: https://github.com/giantswarm/kvm-operator/pull/652