### PR TITLE
increase-master-mem-overhead

### DIFF
--- a/service/controller/v20/key/key.go
+++ b/service/controller/v20/key/key.go
@@ -63,7 +63,7 @@ const (
 	baseWorkerMemoryOverheadMB   = 512
 	baseWorkerOverheadMultiplier = 2
 	baseWorkerOverheadModulator  = 12
-	workerIOOverhead             = "512M"
+	qemuMemoryIOOverhead         = "512M"
 
 	// DefaultDockerDiskSize defines the space used to partition the docker FS
 	// within k8s-kvm. Note we use this only for masters, since the value for the
@@ -318,10 +318,11 @@ func MemoryQuantityMaster(n v1alpha1.KVMConfigSpecKVMNode) (resource.Quantity, e
 		return resource.Quantity{}, microerror.Maskf(err, "creating Memory quantity from node definition")
 	}
 	additionalMemory := resource.MustParse(baseMasterMemoryOverhead)
-	if err != nil {
-		return resource.Quantity{}, microerror.Maskf(err, "creating Memory quantity from addtional memory")
-	}
 	q.Add(additionalMemory)
+
+	// IO overhead for qemu is around 512M memory
+	ioOverhead := resource.MustParse(qemuMemoryIOOverhead)
+	q.Add(ioOverhead)
 
 	return q, nil
 }
@@ -340,7 +341,7 @@ func MemoryQuantityWorker(n v1alpha1.KVMConfigSpecKVMNode) (resource.Quantity, e
 		return resource.Quantity{}, microerror.Maskf(err, "creating Memory quantity from node definition")
 	}
 	// IO overhead for qemu is around 512M memory
-	ioOverhead := resource.MustParse(workerIOOverhead)
+	ioOverhead := resource.MustParse(qemuMemoryIOOverhead)
 	q.Add(ioOverhead)
 
 	// memory overhead is more complex as it increases with the size of the memory

--- a/service/controller/v20/key/key.go
+++ b/service/controller/v20/key/key.go
@@ -59,7 +59,7 @@ const (
 	ShutdownDeferrerDocker   = "quay.io/giantswarm/shutdown-deferrer:4e7d2b73859ea7dac1a2138e04e07fa5870d109b"
 
 	// constants for calculation qemu memory overhead.
-	baseMasterMemoryOverhead     = "1G"
+	baseMasterMemoryOverhead     = "1024M"
 	baseWorkerMemoryOverheadMB   = 512
 	baseWorkerOverheadMultiplier = 2
 	baseWorkerOverheadModulator  = 12

--- a/service/controller/v20/resource/deployment/desired_test.go
+++ b/service/controller/v20/resource/deployment/desired_test.go
@@ -54,11 +54,11 @@ func Test_Resource_Deployment_GetDesiredState(t *testing.T) {
 				{
 					Requests: apiv1.ResourceList{
 						apiv1.ResourceCPU:    resource.MustParse("1"),
-						apiv1.ResourceMemory: resource.MustParse("2G"),
+						apiv1.ResourceMemory: resource.MustParse("2536M"),
 					},
 					Limits: apiv1.ResourceList{
 						apiv1.ResourceCPU:    resource.MustParse("1"),
-						apiv1.ResourceMemory: resource.MustParse("2G"),
+						apiv1.ResourceMemory: resource.MustParse("2536M"),
 					},
 				},
 			},
@@ -113,11 +113,11 @@ func Test_Resource_Deployment_GetDesiredState(t *testing.T) {
 				{
 					Requests: apiv1.ResourceList{
 						apiv1.ResourceCPU:    resource.MustParse("1"),
-						apiv1.ResourceMemory: resource.MustParse("2G"),
+						apiv1.ResourceMemory: resource.MustParse("2536M"),
 					},
 					Limits: apiv1.ResourceList{
 						apiv1.ResourceCPU:    resource.MustParse("1"),
-						apiv1.ResourceMemory: resource.MustParse("2G"),
+						apiv1.ResourceMemory: resource.MustParse("2536M"),
 					},
 				},
 			},
@@ -196,31 +196,31 @@ func Test_Resource_Deployment_GetDesiredState(t *testing.T) {
 				{
 					Requests: apiv1.ResourceList{
 						apiv1.ResourceCPU:    resource.MustParse("1"),
-						apiv1.ResourceMemory: resource.MustParse("2G"),
+						apiv1.ResourceMemory: resource.MustParse("2536M"),
 					},
 					Limits: apiv1.ResourceList{
 						apiv1.ResourceCPU:    resource.MustParse("1"),
-						apiv1.ResourceMemory: resource.MustParse("2G"),
+						apiv1.ResourceMemory: resource.MustParse("2536M"),
 					},
 				},
 				{
 					Requests: apiv1.ResourceList{
 						apiv1.ResourceCPU:    resource.MustParse("1"),
-						apiv1.ResourceMemory: resource.MustParse("2G"),
+						apiv1.ResourceMemory: resource.MustParse("2536M"),
 					},
 					Limits: apiv1.ResourceList{
 						apiv1.ResourceCPU:    resource.MustParse("1"),
-						apiv1.ResourceMemory: resource.MustParse("2G"),
+						apiv1.ResourceMemory: resource.MustParse("2536M"),
 					},
 				},
 				{
 					Requests: apiv1.ResourceList{
 						apiv1.ResourceCPU:    resource.MustParse("1"),
-						apiv1.ResourceMemory: resource.MustParse("2G"),
+						apiv1.ResourceMemory: resource.MustParse("2536M"),
 					},
 					Limits: apiv1.ResourceList{
 						apiv1.ResourceCPU:    resource.MustParse("1"),
-						apiv1.ResourceMemory: resource.MustParse("2G"),
+						apiv1.ResourceMemory: resource.MustParse("2536M"),
 					},
 				},
 			},

--- a/service/controller/v20/version_bundle.go
+++ b/service/controller/v20/version_bundle.go
@@ -8,8 +8,8 @@ func VersionBundle() versionbundle.Bundle {
 	return versionbundle.Bundle{
 		Changelogs: []versionbundle.Changelog{
 			{
-				Component:   "TODO",
-				Description: "todo",
+				Component:   "kvm-operator",
+				Description: "Adjust master memory limit.",
 				Kind:        versionbundle.KindChanged,
 			},
 		},


### PR DESCRIPTION
towards https://github.com/giantswarm/giantswarm/issues/5547

on  big KVM clusters, master gets more IO and more load which cause reaching the memory limit, so adjusting here to also include memory  overhead for IO