### PR TITLE
improve-memory-overhead-formulat-with-new-qemu

### DIFF
--- a/service/controller/v22/key/key.go
+++ b/service/controller/v22/key/key.go
@@ -60,7 +60,7 @@ const (
 
 	// constants for calculation qemu memory overhead.
 	baseMasterMemoryOverhead     = "1024M"
-	baseWorkerMemoryOverheadMB   = 512
+	baseWorkerMemoryOverheadMB   = 768
 	baseWorkerOverheadMultiplier = 2
 	baseWorkerOverheadModulator  = 12
 	qemuMemoryIOOverhead         = "512M"
@@ -345,11 +345,20 @@ func MemoryQuantityWorker(n v1alpha1.KVMConfigSpecKVMNode) (resource.Quantity, e
 	q.Add(ioOverhead)
 
 	// memory overhead is more complex as it increases with the size of the memory
-	// basic calculation is (2 + (memory / 12))*512M
+	// basic calculation is (2 + (memory / 12))*768M
 	// examples:
-	// Memory under 15G >> overhead 1024M
-	// memory between 15 - 30G >> overhead 1536M
-	// memory between 30 - 45G >> overhead 2048M
+	// Memory under 12G >> overhead 1536M
+	// memory between 12 - 24G >> overhead 2048M
+	// memory between 24 - 36G >> overhead 2816M
+	// memory between 24 - 36G >> overhead 3584M
+	// memory between 36 - 48G >> overhead 4352M
+	// memory between 48 - 60G >> overhead 5120M
+	// memory between 60 - 72G >> overhead 5888M
+	// memory between 72 - 84G >> overhead 6656M
+	// memory between 84 - 96G >> overhead 7424M
+	// memory between 96 - 108G >> overhead 8192M
+	// memory between 108 - 120G >> overhead 8960M
+
 	overheadMultiplier := int(baseWorkerOverheadMultiplier + mQuantity.ScaledValue(resource.Giga)/baseWorkerOverheadModulator)
 	workerMemoryOverhead := strconv.Itoa(baseWorkerMemoryOverheadMB*overheadMultiplier) + "M"
 

--- a/service/controller/v22/resource/deployment/desired_test.go
+++ b/service/controller/v22/resource/deployment/desired_test.go
@@ -66,11 +66,11 @@ func Test_Resource_Deployment_GetDesiredState(t *testing.T) {
 				{
 					Requests: apiv1.ResourceList{
 						apiv1.ResourceCPU:    resource.MustParse("4"),
-						apiv1.ResourceMemory: resource.MustParse("9728M"),
+						apiv1.ResourceMemory: resource.MustParse("10240M"),
 					},
 					Limits: apiv1.ResourceList{
 						apiv1.ResourceCPU:    resource.MustParse("4"),
-						apiv1.ResourceMemory: resource.MustParse("9728M"),
+						apiv1.ResourceMemory: resource.MustParse("10240M"),
 					},
 				},
 			},
@@ -125,31 +125,31 @@ func Test_Resource_Deployment_GetDesiredState(t *testing.T) {
 				{
 					Requests: apiv1.ResourceList{
 						apiv1.ResourceCPU:    resource.MustParse("4"),
-						apiv1.ResourceMemory: resource.MustParse("9728M"),
+						apiv1.ResourceMemory: resource.MustParse("10240M"),
 					},
 					Limits: apiv1.ResourceList{
 						apiv1.ResourceCPU:    resource.MustParse("4"),
-						apiv1.ResourceMemory: resource.MustParse("9728M"),
+						apiv1.ResourceMemory: resource.MustParse("10240M"),
 					},
 				},
 				{
 					Requests: apiv1.ResourceList{
 						apiv1.ResourceCPU:    resource.MustParse("4"),
-						apiv1.ResourceMemory: resource.MustParse("9728M"),
+						apiv1.ResourceMemory: resource.MustParse("10240M"),
 					},
 					Limits: apiv1.ResourceList{
 						apiv1.ResourceCPU:    resource.MustParse("4"),
-						apiv1.ResourceMemory: resource.MustParse("9728M"),
+						apiv1.ResourceMemory: resource.MustParse("10240M"),
 					},
 				},
 				{
 					Requests: apiv1.ResourceList{
 						apiv1.ResourceCPU:    resource.MustParse("4"),
-						apiv1.ResourceMemory: resource.MustParse("9728M"),
+						apiv1.ResourceMemory: resource.MustParse("10240M"),
 					},
 					Limits: apiv1.ResourceList{
 						apiv1.ResourceCPU:    resource.MustParse("4"),
-						apiv1.ResourceMemory: resource.MustParse("9728M"),
+						apiv1.ResourceMemory: resource.MustParse("10240M"),
 					},
 				},
 			},
@@ -228,31 +228,31 @@ func Test_Resource_Deployment_GetDesiredState(t *testing.T) {
 				{
 					Requests: apiv1.ResourceList{
 						apiv1.ResourceCPU:    resource.MustParse("4"),
-						apiv1.ResourceMemory: resource.MustParse("9728M"),
+						apiv1.ResourceMemory: resource.MustParse("10240M"),
 					},
 					Limits: apiv1.ResourceList{
 						apiv1.ResourceCPU:    resource.MustParse("4"),
-						apiv1.ResourceMemory: resource.MustParse("9728M"),
+						apiv1.ResourceMemory: resource.MustParse("10240M"),
 					},
 				},
 				{
 					Requests: apiv1.ResourceList{
 						apiv1.ResourceCPU:    resource.MustParse("4"),
-						apiv1.ResourceMemory: resource.MustParse("9728M"),
+						apiv1.ResourceMemory: resource.MustParse("10240M"),
 					},
 					Limits: apiv1.ResourceList{
 						apiv1.ResourceCPU:    resource.MustParse("4"),
-						apiv1.ResourceMemory: resource.MustParse("9728M"),
+						apiv1.ResourceMemory: resource.MustParse("10240M"),
 					},
 				},
 				{
 					Requests: apiv1.ResourceList{
 						apiv1.ResourceCPU:    resource.MustParse("4"),
-						apiv1.ResourceMemory: resource.MustParse("9728M"),
+						apiv1.ResourceMemory: resource.MustParse("10240M"),
 					},
 					Limits: apiv1.ResourceList{
 						apiv1.ResourceCPU:    resource.MustParse("4"),
-						apiv1.ResourceMemory: resource.MustParse("9728M"),
+						apiv1.ResourceMemory: resource.MustParse("10240M"),
 					},
 				},
 			},

--- a/service/controller/v22/version_bundle.go
+++ b/service/controller/v22/version_bundle.go
@@ -8,8 +8,8 @@ func VersionBundle() versionbundle.Bundle {
 	return versionbundle.Bundle{
 		Changelogs: []versionbundle.Changelog{
 			{
-				Component:   "TODO",
-				Description: "TODO",
+				Component:   "kvm-operator",
+				Description: "Improved memory overhead formula with new qemu version.",
 				Kind:        versionbundle.KindChanged,
 			},
 		},


### PR DESCRIPTION
improve memory overhead formula to  work with new qemu version

 after checking anubis cluster, it looks like all clusters are experiencing the same issue so its across whole range of memory usage

for https://github.com/giantswarm/giantswarm/issues/6120