### PR TITLE
Configure NTP servers on tenant nodes

### DIFF
--- a/flag/service/installation/installation.go
+++ b/flag/service/installation/installation.go
@@ -2,11 +2,13 @@ package installation
 
 import (
 	"github.com/giantswarm/kvm-operator/flag/service/installation/dns"
+	"github.com/giantswarm/kvm-operator/flag/service/installation/ntp"
 	"github.com/giantswarm/kvm-operator/flag/service/installation/tenant"
 )
 
 type Installation struct {
 	DNS    dns.DNS
 	Name   string
+	NTP    ntp.NTP
 	Tenant tenant.Tenant
 }

--- a/flag/service/installation/ntp/ntp.go
+++ b/flag/service/installation/ntp/ntp.go
@@ -1,0 +1,5 @@
+package ntp
+
+type NTP struct {
+	Servers string
+}

--- a/helm/kvm-operator-chart/templates/configmap.yaml
+++ b/helm/kvm-operator-chart/templates/configmap.yaml
@@ -24,6 +24,8 @@ data:
       installation:
         dns:
           servers: {{ .Values.Installation.V1.Provider.KVM.DNS.Servers }}
+        ntp:
+          servers: {{ .Values.Installation.V1.Provider.KVM.NTP.Servers }}
         {{- if .Values.Installation.V1.Guest }}
         tenant:
           kubernetes:

--- a/main.go
+++ b/main.go
@@ -109,6 +109,7 @@ func mainError() error {
 	daemonCommand := newCommand.DaemonCommand().CobraCommand()
 
 	daemonCommand.PersistentFlags().String(f.Service.Installation.DNS.Servers, "", "Comma separated list of DNS servers.")
+	daemonCommand.PersistentFlags().String(f.Service.Installation.NTP.Servers, "", "Comma separated list of NTPservers.")
 
 	daemonCommand.PersistentFlags().String(f.Service.Installation.Tenant.Kubernetes.API.Auth.Provider.OIDC.ClientID, "", "OIDC authorization provider ClientID.")
 	daemonCommand.PersistentFlags().String(f.Service.Installation.Tenant.Kubernetes.API.Auth.Provider.OIDC.IssuerURL, "", "OIDC authorization provider IssuerURL.")

--- a/service/controller/cluster.go
+++ b/service/controller/cluster.go
@@ -15,17 +15,17 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 
-	"github.com/giantswarm/kvm-operator/service/controller/v20"
+	v20 "github.com/giantswarm/kvm-operator/service/controller/v20"
 	v20cloudconfig "github.com/giantswarm/kvm-operator/service/controller/v20/cloudconfig"
-	"github.com/giantswarm/kvm-operator/service/controller/v21"
+	v21 "github.com/giantswarm/kvm-operator/service/controller/v21"
 	v21cloudconfig "github.com/giantswarm/kvm-operator/service/controller/v21/cloudconfig"
-	"github.com/giantswarm/kvm-operator/service/controller/v22"
+	v22 "github.com/giantswarm/kvm-operator/service/controller/v22"
 	v22cloudconfig "github.com/giantswarm/kvm-operator/service/controller/v22/cloudconfig"
-	"github.com/giantswarm/kvm-operator/service/controller/v23"
+	v23 "github.com/giantswarm/kvm-operator/service/controller/v23"
 	v23cloudconfig "github.com/giantswarm/kvm-operator/service/controller/v23/cloudconfig"
 	"github.com/giantswarm/kvm-operator/service/controller/v23patch1"
 	v23patch1cloudconfig "github.com/giantswarm/kvm-operator/service/controller/v23patch1/cloudconfig"
-	"github.com/giantswarm/kvm-operator/service/controller/v24"
+	v24 "github.com/giantswarm/kvm-operator/service/controller/v24"
 	v24cloudconfig "github.com/giantswarm/kvm-operator/service/controller/v24/cloudconfig"
 )
 
@@ -41,6 +41,7 @@ type ClusterConfig struct {
 	DNSServers         string
 	GuestUpdateEnabled bool
 	IgnitionPath       string
+	NTPServers         string
 	OIDC               ClusterConfigOIDC
 	ProjectName        string
 	SSOPublicKey       string
@@ -275,6 +276,7 @@ func NewCluster(config ClusterConfig) (*Cluster, error) {
 			DNSServers:         config.DNSServers,
 			GuestUpdateEnabled: config.GuestUpdateEnabled,
 			IgnitionPath:       config.IgnitionPath,
+			NTPServers:         config.NTPServers,
 			ProjectName:        config.ProjectName,
 			OIDC: v24cloudconfig.OIDCConfig{
 				ClientID:      config.OIDC.ClientID,

--- a/service/controller/v24/cluster_resource_set.go
+++ b/service/controller/v24/cluster_resource_set.go
@@ -38,9 +38,10 @@ type ClusterResourceSetConfig struct {
 	TenantCluster      tenantcluster.Interface
 
 	DNSServers         string
-	IgnitionPath       string
-	OIDC               cloudconfig.OIDCConfig
 	GuestUpdateEnabled bool
+	IgnitionPath       string
+	NTPServers         string
+	OIDC               cloudconfig.OIDCConfig
 	ProjectName        string
 	SSOPublicKey       string
 }
@@ -141,11 +142,12 @@ func NewClusterResourceSet(config ClusterResourceSetConfig) (*controller.Resourc
 
 	var deploymentResource controller.Resource
 	{
-		c := deployment.DefaultConfig()
-
-		c.DNSServers = config.DNSServers
-		c.K8sClient = config.K8sClient
-		c.Logger = config.Logger
+		c := deployment.Config{
+			DNSServers: config.DNSServers,
+			K8sClient:  config.K8sClient,
+			Logger:     config.Logger,
+			NTPServers: config.NTPServers,
+		}
 
 		ops, err := deployment.New(c)
 		if err != nil {

--- a/service/controller/v24/key/key.go
+++ b/service/controller/v24/key/key.go
@@ -54,7 +54,7 @@ const (
 	CoreosVersion        = "2135.4.0"
 
 	K8SEndpointUpdaterDocker = "quay.io/giantswarm/k8s-endpoint-updater:590479a6228c2c143695a268bda5382b52f7ffe1"
-	K8SKVMDockerImage        = "quay.io/giantswarm/k8s-kvm:34e40049f80ce8ea0f774e56c1b10c7f24921eca"
+	K8SKVMDockerImage        = "quay.io/giantswarm/k8s-kvm:f3feaa5ba3e8905fc5c1ad9911fc08a0fd1fb66d"
 	K8SKVMHealthDocker       = "quay.io/giantswarm/k8s-kvm-health:20517098a762a0d7ca2b0902316ddff487dbc7f5"
 	ShutdownDeferrerDocker   = "quay.io/giantswarm/shutdown-deferrer:4e7d2b73859ea7dac1a2138e04e07fa5870d109b"
 

--- a/service/controller/v24/key/key.go
+++ b/service/controller/v24/key/key.go
@@ -54,7 +54,7 @@ const (
 	CoreosVersion        = "2135.4.0"
 
 	K8SEndpointUpdaterDocker = "quay.io/giantswarm/k8s-endpoint-updater:590479a6228c2c143695a268bda5382b52f7ffe1"
-	K8SKVMDockerImage        = "quay.io/giantswarm/k8s-kvm:f3feaa5ba3e8905fc5c1ad9911fc08a0fd1fb66d"
+	K8SKVMDockerImage        = "quay.io/giantswarm/k8s-kvm:e9989b8667070b8a10a030e2f1f6078d2ffb803e"
 	K8SKVMHealthDocker       = "quay.io/giantswarm/k8s-kvm-health:20517098a762a0d7ca2b0902316ddff487dbc7f5"
 	ShutdownDeferrerDocker   = "quay.io/giantswarm/shutdown-deferrer:4e7d2b73859ea7dac1a2138e04e07fa5870d109b"
 

--- a/service/controller/v24/resource/deployment/create_test.go
+++ b/service/controller/v24/resource/deployment/create_test.go
@@ -216,10 +216,11 @@ func Test_Resource_Deployment_newCreateChange(t *testing.T) {
 	var err error
 	var newResource *Resource
 	{
-		resourceConfig := DefaultConfig()
-		resourceConfig.DNSServers = "dnsserver1,dnsserver2"
-		resourceConfig.K8sClient = fake.NewSimpleClientset()
-		resourceConfig.Logger = microloggertest.New()
+		resourceConfig := Config{
+			DNSServers: "dnsserver1,dnsserver2",
+			K8sClient:  fake.NewSimpleClientset(),
+			Logger:     microloggertest.New(),
+		}
 		newResource, err = New(resourceConfig)
 		if err != nil {
 			t.Fatal("expected", nil, "got", err)

--- a/service/controller/v24/resource/deployment/delete_test.go
+++ b/service/controller/v24/resource/deployment/delete_test.go
@@ -262,10 +262,11 @@ func Test_Resource_Deployment_newDeleteChange(t *testing.T) {
 	var err error
 	var newResource *Resource
 	{
-		resourceConfig := DefaultConfig()
-		resourceConfig.DNSServers = "dnsserver1,dnsserver2"
-		resourceConfig.K8sClient = fake.NewSimpleClientset()
-		resourceConfig.Logger = microloggertest.New()
+		resourceConfig := Config{
+			DNSServers: "dnsserver1,dnsserver2",
+			K8sClient:  fake.NewSimpleClientset(),
+			Logger:     microloggertest.New(),
+		}
 		newResource, err = New(resourceConfig)
 		if err != nil {
 			t.Fatal("expected", nil, "got", err)

--- a/service/controller/v24/resource/deployment/desired.go
+++ b/service/controller/v24/resource/deployment/desired.go
@@ -21,13 +21,13 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interf
 	var deployments []*v1beta1.Deployment
 
 	{
-		masterDeployments, err := newMasterDeployments(customResource, r.dnsServers)
+		masterDeployments, err := newMasterDeployments(customResource, r.dnsServers, r.ntpServers)
 		if err != nil {
 			return nil, microerror.Mask(err)
 		}
 		deployments = append(deployments, masterDeployments...)
 
-		workerDeployments, err := newWorkerDeployments(customResource, r.dnsServers)
+		workerDeployments, err := newWorkerDeployments(customResource, r.dnsServers, r.ntpServers)
 		if err != nil {
 			return nil, microerror.Mask(err)
 		}

--- a/service/controller/v24/resource/deployment/desired_test.go
+++ b/service/controller/v24/resource/deployment/desired_test.go
@@ -262,10 +262,11 @@ func Test_Resource_Deployment_GetDesiredState(t *testing.T) {
 	var err error
 	var newResource *Resource
 	{
-		resourceConfig := DefaultConfig()
-		resourceConfig.DNSServers = "dnsserver1,dnsserver2"
-		resourceConfig.K8sClient = fake.NewSimpleClientset()
-		resourceConfig.Logger = microloggertest.New()
+		resourceConfig := Config{
+			DNSServers: "dnsserver1,dnsserver2",
+			K8sClient:  fake.NewSimpleClientset(),
+			Logger:     microloggertest.New(),
+		}
 		newResource, err = New(resourceConfig)
 		if err != nil {
 			t.Fatal("expected", nil, "got", err)

--- a/service/controller/v24/resource/deployment/master_deployment.go
+++ b/service/controller/v24/resource/deployment/master_deployment.go
@@ -13,7 +13,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
-func newMasterDeployments(customResource v1alpha1.KVMConfig, dnsServers string) ([]*extensionsv1.Deployment, error) {
+func newMasterDeployments(customResource v1alpha1.KVMConfig, dnsServers, ntpServers string) ([]*extensionsv1.Deployment, error) {
 	var deployments []*extensionsv1.Deployment
 
 	privileged := true
@@ -232,6 +232,11 @@ func newMasterDeployments(customResource v1alpha1.KVMConfig, dnsServers string) 
 										},
 									},
 									{
+										Name: "MEMORY",
+										// TODO provide memory like disk as float64 and format here.
+										Value: capabilities.Memory,
+									},
+									{
 										Name:  "NETWORK_BRIDGE_NAME",
 										Value: key.NetworkBridgeName(customResource),
 									},
@@ -240,9 +245,8 @@ func newMasterDeployments(customResource v1alpha1.KVMConfig, dnsServers string) 
 										Value: key.NetworkTapName(customResource),
 									},
 									{
-										Name: "MEMORY",
-										// TODO provide memory like disk as float64 and format here.
-										Value: capabilities.Memory,
+										Name:  "NTP_SERVERS",
+										Value: ntpServers,
 									},
 									{
 										Name:  "ROLE",

--- a/service/controller/v24/resource/deployment/resource.go
+++ b/service/controller/v24/resource/deployment/resource.go
@@ -41,9 +41,6 @@ func New(config Config) (*Resource, error) {
 	if config.Logger == nil {
 		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
 	}
-	if config.NTPServers == "" {
-		return nil, microerror.Maskf(invalidConfigError, "%T.NTPServers must not be empty", config)
-	}
 
 	newResource := &Resource{
 		dnsServers: config.DNSServers,

--- a/service/controller/v24/resource/deployment/resource.go
+++ b/service/controller/v24/resource/deployment/resource.go
@@ -16,49 +16,40 @@ const (
 
 // Config represents the configuration used to create a new deployment resource.
 type Config struct {
-	// Dependencies.
 	DNSServers string
 	K8sClient  kubernetes.Interface
 	Logger     micrologger.Logger
-}
-
-// DefaultConfig provides a default configuration to create a new deployment
-// resource by best effort.
-func DefaultConfig() Config {
-	return Config{
-		// Dependencies.
-		DNSServers: "",
-		K8sClient:  nil,
-		Logger:     nil,
-	}
+	NTPServers string
 }
 
 // Resource implements the deployment resource.
 type Resource struct {
-	// Dependencies.
 	dnsServers string
 	k8sClient  kubernetes.Interface
 	logger     micrologger.Logger
+	ntpServers string
 }
 
 // New creates a new configured deployment resource.
 func New(config Config) (*Resource, error) {
-	// Dependencies.
 	if config.DNSServers == "" {
-		return nil, microerror.Maskf(invalidConfigError, "config.DNSServers must not be empty")
+		return nil, microerror.Maskf(invalidConfigError, "%T.DNSServers must not be empty", config)
 	}
 	if config.K8sClient == nil {
-		return nil, microerror.Maskf(invalidConfigError, "config.K8sClient must not be empty")
+		return nil, microerror.Maskf(invalidConfigError, "%T.K8sClient must not be empty", config)
 	}
 	if config.Logger == nil {
-		return nil, microerror.Maskf(invalidConfigError, "config.Logger must not be empty")
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+	if config.NTPServers == "" {
+		return nil, microerror.Maskf(invalidConfigError, "%T.NTPServers must not be empty", config)
 	}
 
 	newResource := &Resource{
-		// Dependencies.
 		dnsServers: config.DNSServers,
 		k8sClient:  config.K8sClient,
 		logger:     config.Logger,
+		ntpServers: config.NTPServers,
 	}
 
 	return newResource, nil

--- a/service/controller/v24/resource/deployment/update_test.go
+++ b/service/controller/v24/resource/deployment/update_test.go
@@ -1208,10 +1208,11 @@ func Test_Resource_Deployment_newUpdateChange(t *testing.T) {
 	var err error
 	var newResource *Resource
 	{
-		resourceConfig := DefaultConfig()
-		resourceConfig.DNSServers = "dnsserver1,dnsserver2"
-		resourceConfig.K8sClient = fake.NewSimpleClientset()
-		resourceConfig.Logger = microloggertest.New()
+		resourceConfig := Config{
+			DNSServers: "dnsserver1,dnsserver2",
+			K8sClient:  fake.NewSimpleClientset(),
+			Logger:     microloggertest.New(),
+		}
 		newResource, err = New(resourceConfig)
 		if err != nil {
 			t.Fatal("expected", nil, "got", err)

--- a/service/controller/v24/resource/deployment/worker_deployment.go
+++ b/service/controller/v24/resource/deployment/worker_deployment.go
@@ -13,7 +13,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
-func newWorkerDeployments(customResource v1alpha1.KVMConfig, dnsServers string) ([]*extensionsv1.Deployment, error) {
+func newWorkerDeployments(customResource v1alpha1.KVMConfig, dnsServers, ntpServers string) ([]*extensionsv1.Deployment, error) {
 	var deployments []*extensionsv1.Deployment
 
 	privileged := true
@@ -200,6 +200,11 @@ func newWorkerDeployments(customResource v1alpha1.KVMConfig, dnsServers string) 
 										},
 									},
 									{
+										Name: "MEMORY",
+										// TODO provide memory like disk as float64 and format here.
+										Value: capabilities.Memory,
+									},
+									{
 										Name:  "NETWORK_BRIDGE_NAME",
 										Value: key.NetworkBridgeName(customResource),
 									},
@@ -208,9 +213,8 @@ func newWorkerDeployments(customResource v1alpha1.KVMConfig, dnsServers string) 
 										Value: key.NetworkTapName(customResource),
 									},
 									{
-										Name: "MEMORY",
-										// TODO provide memory like disk as float64 and format here.
-										Value: capabilities.Memory,
+										Name:  "NTP_SERVERS",
+										Value: ntpServers,
 									},
 									{
 										Name:  "ROLE",

--- a/service/controller/v24/version_bundle.go
+++ b/service/controller/v24/version_bundle.go
@@ -22,6 +22,11 @@ func VersionBundle() versionbundle.Bundle {
 				Description: "Introduce explicit resource reservation for OS resources and container runtime.",
 				Kind:        versionbundle.KindAdded,
 			},
+			{
+				Component:   "kvm-operator",
+				Description: "Fix NTP server configuration on tenant nodes.",
+				Kind:        versionbundle.KindFixed,
+			},
 		},
 		Components: []versionbundle.Component{
 			{

--- a/service/service.go
+++ b/service/service.go
@@ -136,6 +136,7 @@ func New(config Config) (*Service, error) {
 
 			DNSServers:   config.Viper.GetString(config.Flag.Service.Installation.DNS.Servers),
 			IgnitionPath: config.Viper.GetString(config.Flag.Service.Tenant.Ignition.Path),
+			NTPServers:   config.Viper.GetString(config.Flag.Service.Installation.NTP.Servers),
 			OIDC: controller.ClusterConfigOIDC{
 				ClientID:      config.Viper.GetString(config.Flag.Service.Installation.Tenant.Kubernetes.API.Auth.Provider.OIDC.ClientID),
 				IssuerURL:     config.Viper.GetString(config.Flag.Service.Installation.Tenant.Kubernetes.API.Auth.Provider.OIDC.IssuerURL),


### PR DESCRIPTION
On-prem installations often have internal NTP servers present and sometimes
access to public ones is prevented. In order to keep node time in sync, pull
installation specific NTP servers from configuration and pass the information
into k8s-kvm container which then configures these NTP servers into node's
network configuration.

While here, I sorted few fields alphabetically & zapped one legacy
DefaultConfig().

Towards https://github.com/giantswarm/giantswarm/issues/6740