### PR TITLE
Add resource version to endpoint calculation

### DIFF
--- a/service/controller/v26/resource/endpoint/create.go
+++ b/service/controller/v26/resource/endpoint/create.go
@@ -51,6 +51,7 @@ func (r *Resource) newCreateChange(ctx context.Context, obj, currentState, desir
 			Addresses:        ipsToAddresses(ips),
 			IPs:              ips,
 			Ports:            currentEndpoint.Ports,
+			ResourceVersion:  currentEndpoint.ResourceVersion,
 			ServiceName:      currentEndpoint.ServiceName,
 			ServiceNamespace: currentEndpoint.ServiceNamespace,
 		}

--- a/service/controller/v26/resource/endpoint/current.go
+++ b/service/controller/v26/resource/endpoint/current.go
@@ -72,6 +72,13 @@ func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interf
 			return nil, microerror.Mask(err)
 		}
 
+		if k8sEndpoints != nil {
+			// If we found a k8s endpoint then we set this resource version here.
+			// We do this to later guarantee that the endpoint did not change
+			// between gathering information and submitting our update.
+			endpoint.ResourceVersion = k8sEndpoints.ResourceVersion
+		}
+
 		for _, endpointSubset := range k8sEndpoints.Subsets {
 			for _, endpointAddress := range endpointSubset.Addresses {
 				if !containsIP(endpoint.IPs, endpointAddress.IP) {

--- a/service/controller/v26/resource/endpoint/current.go
+++ b/service/controller/v26/resource/endpoint/current.go
@@ -72,12 +72,10 @@ func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interf
 			return nil, microerror.Mask(err)
 		}
 
-		if k8sEndpoints != nil {
-			// If we found a k8s endpoint then we set this resource version here.
-			// We do this to later guarantee that the endpoint did not change
-			// between gathering information and submitting our update.
-			endpoint.ResourceVersion = k8sEndpoints.ResourceVersion
-		}
+		// If we found a k8s endpoint then we set this resource version here.
+		// We do this to later guarantee that the endpoint did not change
+		// between gathering information and submitting our update.
+		endpoint.ResourceVersion = k8sEndpoints.ResourceVersion
 
 		for _, endpointSubset := range k8sEndpoints.Subsets {
 			for _, endpointAddress := range endpointSubset.Addresses {

--- a/service/controller/v26/resource/endpoint/delete.go
+++ b/service/controller/v26/resource/endpoint/delete.go
@@ -70,6 +70,7 @@ func (r *Resource) newDeleteChange(ctx context.Context, obj, currentState, desir
 			Addresses:        ipsToAddresses(ips),
 			IPs:              ips,
 			Ports:            currentEndpoint.Ports,
+			ResourceVersion:  currentEndpoint.ResourceVersion,
 			ServiceName:      currentEndpoint.ServiceName,
 			ServiceNamespace: currentEndpoint.ServiceNamespace,
 		}

--- a/service/controller/v26/resource/endpoint/resource.go
+++ b/service/controller/v26/resource/endpoint/resource.go
@@ -57,8 +57,9 @@ func (r *Resource) newK8sEndpoint(endpoint *Endpoint) *corev1.Endpoints {
 			APIVersion: "v1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      endpoint.ServiceName,
-			Namespace: endpoint.ServiceNamespace,
+			Name:            endpoint.ServiceName,
+			Namespace:       endpoint.ServiceNamespace,
+			ResourceVersion: endpoint.ResourceVersion,
 		},
 	}
 

--- a/service/controller/v26/resource/endpoint/spec.go
+++ b/service/controller/v26/resource/endpoint/spec.go
@@ -17,7 +17,7 @@ type Endpoint struct {
 	// reconciled pod. When the desired state is computed the list contains only a
 	// single IP, which is the IP of the reconciled pod.
 	IPs              []string
+	ResourceVersion  string
 	ServiceName      string
 	ServiceNamespace string
-	ResourceVersion  string
 }

--- a/service/controller/v26/resource/endpoint/spec.go
+++ b/service/controller/v26/resource/endpoint/spec.go
@@ -19,4 +19,5 @@ type Endpoint struct {
 	IPs              []string
 	ServiceName      string
 	ServiceNamespace string
+	ResourceVersion  string
 }

--- a/service/controller/v26/resource/endpoint/update.go
+++ b/service/controller/v26/resource/endpoint/update.go
@@ -64,6 +64,7 @@ func (r *Resource) newUpdateChange(ctx context.Context, obj, currentState, desir
 		ips := ipsForUpdateChange(currentEndpoint.IPs, desiredEndpoint.IPs)
 
 		e := &Endpoint{
+			ResourceVersion:  currentEndpoint.ResourceVersion,
 			ServiceName:      currentEndpoint.ServiceName,
 			ServiceNamespace: currentEndpoint.ServiceNamespace,
 		}


### PR DESCRIPTION
This adds the resource version to the calculation and therefor ensures that the endpoint we update is in the same state as the one we read information from.

During a hangout with Tim we discovered that the following situation is likely causing us problems:
- We start the update of a cluster
- The old pods have a label with the old `VersionBundleVersion`
- Each new pod that gets started by the rolling update has the new `VersionBundleVersion`
- All pods with the old `VBV` are reconciled by the old controller (e.g. V1)
- All pods with the new `VBV` are reconciled by the new controller (e.g. V2)
- Both controllers are now editing the _single_ service which contains all endpoints for old and new pods
- Since neither controller is checking the resource version we get the following situation:
    - V1 reads the endpoints (E1,E2,E3)
    - V2 reads the endpoints (E1,E2,E3)
    - V1 adds the new endpoint E4 (E1,E2,E3,E4)
    - V2 removes an old endpoint E1 (E2,E3)
    - V2 writes its changes to k8s -> (E2,E3)
    - V1 does not check the resourceVersion and writes its changes to k8s -> (E1,E2,E3,E4)
-> We end up with one endpoint (E1) which has no more pod and both controllers exited without error 

towards https://github.com/giantswarm/giantswarm/issues/7283