### PR TITLE
Backporting list by labels

### DIFF
--- a/service/controller/v25/resource/configmap/current.go
+++ b/service/controller/v25/resource/configmap/current.go
@@ -9,6 +9,8 @@ import (
 	apiv1 "k8s.io/api/core/v1"
 	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/giantswarm/kvm-operator/pkg/label"
+	"github.com/giantswarm/kvm-operator/pkg/project"
 	"github.com/giantswarm/kvm-operator/service/controller/v25/key"
 )
 
@@ -31,7 +33,12 @@ func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interf
 	var currentConfigMaps []*apiv1.ConfigMap
 	{
 		namespace := key.ClusterNamespace(customResource)
-		configMapList, err := r.k8sClient.CoreV1().ConfigMaps(namespace).List(apismetav1.ListOptions{})
+
+		lo := apismetav1.ListOptions{
+			LabelSelector: fmt.Sprintf("%s=%s", label.ManagedBy, project.Name()),
+		}
+
+		configMapList, err := r.k8sClient.CoreV1().ConfigMaps(namespace).List(lo)
 		if err != nil {
 			return nil, microerror.Mask(err)
 		} else {


### PR DESCRIPTION
Toward giantswarm/giantswarm#7763

Backporting changes from https://github.com/giantswarm/kvm-operator/pull/779 into v25. 