### PR TITLE
Backporting v24 to have proper labels in configmaps. 

### DIFF
--- a/service/controller/v24/resource/configmap/desired.go
+++ b/service/controller/v24/resource/configmap/desired.go
@@ -9,6 +9,8 @@ import (
 	apiv1 "k8s.io/api/core/v1"
 	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/giantswarm/kvm-operator/pkg/label"
+	"github.com/giantswarm/kvm-operator/pkg/project"
 	"github.com/giantswarm/kvm-operator/service/controller/v24/key"
 )
 
@@ -96,8 +98,13 @@ func (r *Resource) newConfigMap(customResource v1alpha1.KVMConfig, template stri
 			ObjectMeta: apismetav1.ObjectMeta{
 				Name: key.ConfigMapName(customResource, node, prefix),
 				Labels: map[string]string{
-					"cluster":  key.ClusterID(customResource),
-					"customer": key.ClusterCustomer(customResource),
+					// TODO: Delete two legacy labels from next release
+					// issues: https://github.com/giantswarm/giantswarm/issues/7771
+					"cluster":          key.ClusterID(customResource),
+					"customer":         key.ClusterCustomer(customResource),
+					label.Cluster:      key.ClusterID(customResource),
+					label.ManagedBy:    project.Name(),
+					label.Organization: key.ClusterCustomer(customResource),
 				},
 			},
 			Data: map[string]string{

--- a/service/controller/v24/resource/configmap/desired.go
+++ b/service/controller/v24/resource/configmap/desired.go
@@ -98,8 +98,6 @@ func (r *Resource) newConfigMap(customResource v1alpha1.KVMConfig, template stri
 			ObjectMeta: apismetav1.ObjectMeta{
 				Name: key.ConfigMapName(customResource, node, prefix),
 				Labels: map[string]string{
-					// TODO: Delete two legacy labels from next release
-					// issues: https://github.com/giantswarm/giantswarm/issues/7771
 					"cluster":          key.ClusterID(customResource),
 					"customer":         key.ClusterCustomer(customResource),
 					label.Cluster:      key.ClusterID(customResource),

--- a/service/controller/v24/resource/configmap/resource.go
+++ b/service/controller/v24/resource/configmap/resource.go
@@ -83,6 +83,25 @@ func containsConfigMap(list []*apiv1.ConfigMap, item *apiv1.ConfigMap) bool {
 	return true
 }
 
+// equals asseses the equality of ConfigMaps with regards to distinguishing
+// fields.
+func equals(a, b *apiv1.ConfigMap) bool {
+	if a.Name != b.Name {
+		return false
+	}
+	if a.Namespace != b.Namespace {
+		return false
+	}
+	if !reflect.DeepEqual(a.Data, b.Data) {
+		return false
+	}
+	if !reflect.DeepEqual(a.Labels, b.Labels) {
+		return false
+	}
+
+	return true
+}
+
 func getConfigMapByName(list []*apiv1.ConfigMap, name string) (*apiv1.ConfigMap, error) {
 	for _, l := range list {
 		if l.Name == name {
@@ -93,8 +112,13 @@ func getConfigMapByName(list []*apiv1.ConfigMap, name string) (*apiv1.ConfigMap,
 	return nil, microerror.Mask(notFoundError)
 }
 
-func isConfigMapModified(a, b *apiv1.ConfigMap) bool {
-	return !reflect.DeepEqual(a.Data, b.Data)
+// isEmpty checks if a ConfigMap is empty.
+func isEmpty(c *apiv1.ConfigMap) bool {
+	if c == nil {
+		return true
+	}
+
+	return equals(c, &apiv1.ConfigMap{})
 }
 
 func toConfigMaps(v interface{}) ([]*apiv1.ConfigMap, error) {

--- a/service/controller/v24/resource/configmap/update.go
+++ b/service/controller/v24/resource/configmap/update.go
@@ -85,7 +85,8 @@ func (r *Resource) newUpdateChange(ctx context.Context, obj, currentState, desir
 				return nil, microerror.Mask(err)
 			}
 
-			if isConfigMapModified(desiredConfigMap, currentConfigMap) {
+			isModified := !isEmpty(currentConfigMap) && !equals(currentConfigMap, desiredConfigMap)
+			if isModified {
 				configMapsToUpdate = append(configMapsToUpdate, desiredConfigMap)
 			}
 		}

--- a/service/controller/v25/resource/configmap/desired.go
+++ b/service/controller/v25/resource/configmap/desired.go
@@ -98,8 +98,6 @@ func (r *Resource) newConfigMap(customResource v1alpha1.KVMConfig, template stri
 			ObjectMeta: apismetav1.ObjectMeta{
 				Name: key.ConfigMapName(customResource, node, prefix),
 				Labels: map[string]string{
-					// TODO: Delete two legacy labels from next release
-					// issues: https://github.com/giantswarm/giantswarm/issues/7771
 					"cluster":          key.ClusterID(customResource),
 					"customer":         key.ClusterCustomer(customResource),
 					label.Cluster:      key.ClusterID(customResource),


### PR DESCRIPTION
Toward https://github.com/giantswarm/giantswarm/issues/7763

Many installations still using 8.4.0 release which linked to v24 in kvm-operator. 
It still doesn't have our fix from labeling. 