### PR TITLE
Backporting get configmaps by labels into v24

### DIFF
--- a/service/controller/v24/resource/configmap/current.go
+++ b/service/controller/v24/resource/configmap/current.go
@@ -9,6 +9,8 @@ import (
 	apiv1 "k8s.io/api/core/v1"
 	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/giantswarm/kvm-operator/pkg/label"
+	"github.com/giantswarm/kvm-operator/pkg/project"
 	"github.com/giantswarm/kvm-operator/service/controller/v24/key"
 )
 
@@ -31,7 +33,12 @@ func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interf
 	var currentConfigMaps []*apiv1.ConfigMap
 	{
 		namespace := key.ClusterNamespace(customResource)
-		configMapList, err := r.k8sClient.CoreV1().ConfigMaps(namespace).List(apismetav1.ListOptions{})
+
+		lo := apismetav1.ListOptions{
+			LabelSelector: fmt.Sprintf("%s=%s", label.ManagedBy, project.Name()),
+		}
+
+		configMapList, err := r.k8sClient.CoreV1().ConfigMaps(namespace).List(lo)
 		if err != nil {
 			return nil, microerror.Mask(err)
 		} else {


### PR DESCRIPTION
Toward https://github.com/giantswarm/giantswarm/issues/7763

(Last patch)

Backporting a patch into v24 so only fetch configmaps with proper labels. 