### PR TITLE
thiccc: change deploy branch to thiccc

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,6 +14,6 @@ jobs:
         path: /tmp/results
     - deploy:
         command: |
-          if [ "${CIRCLE_BRANCH}" == "master" ]; then
+          if [ "${CIRCLE_BRANCH}" == "thiccc" ]; then
             ./architect deploy
           fi


### PR DESCRIPTION
I am uncertain how to progress here now - this might break all installations because it might deploy all kvm-operators twice.

Input welcome.

towards https://github.com/giantswarm/giantswarm/issues/7820