### PR TITLE
flattening: remove master deployment temporarily

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,8 +12,3 @@ jobs:
     - run: ./architect build
     - store_test_results:
         path: /tmp/results
-    - deploy:
-        command: |
-          if [ "${CIRCLE_BRANCH}" == "master" ]; then
-            ./architect deploy
-          fi


### PR DESCRIPTION
The next steps of flattening with the following plan:
1. Stop master deployment (this PR)
2. Enable thiccc deployment https://github.com/giantswarm/kvm-operator/pull/812
3. Do all the helm changes in master https://github.com/giantswarm/kvm-operator/pull/816
4. Remove all the version bundles except WIP from master https://github.com/giantswarm/kvm-operator/pull/817
5. Add master to the app catalog :sparkles: 