### PR TITLE
master: Move away from 1.16 deprecated API groups

### DIFF
--- a/helm/kvm-operator/templates/rbac.yaml
+++ b/helm/kvm-operator/templates/rbac.yaml
@@ -10,15 +10,8 @@ rules:
     verbs:
       - "*"
   - apiGroups:
-      - extensions
+      - networking
     resources:
-      - thirdpartyresources
-    verbs:
-      - "*"
-  - apiGroups:
-      - extensions
-    resources:
-      - deployments
       - ingresses
     verbs:
       - "*"
@@ -138,7 +131,7 @@ metadata:
   name: {{ tpl .Values.resource.psp.name . }}
 rules:
   - apiGroups:
-      - extensions
+      - policy
     resources:
       - podsecuritypolicies
     verbs:

--- a/service/controller/resource/clusterrolebinding/create.go
+++ b/service/controller/resource/clusterrolebinding/create.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	"github.com/giantswarm/microerror"
-	apiv1 "k8s.io/api/rbac/v1beta1"
+	apiv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 )
 
@@ -20,7 +20,7 @@ func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange inte
 		r.logger.LogCtx(ctx, "level", "debug", "message", "creating the cluster role bindings in the Kubernetes API")
 
 		for _, clusterRoleBinding := range clusterRoleBindingsToCreate {
-			_, err := r.k8sClient.RbacV1beta1().ClusterRoleBindings().Create(clusterRoleBinding)
+			_, err := r.k8sClient.RbacV1().ClusterRoleBindings().Create(clusterRoleBinding)
 			if apierrors.IsAlreadyExists(err) {
 			} else if err != nil {
 				return microerror.Mask(err)

--- a/service/controller/resource/clusterrolebinding/create_test.go
+++ b/service/controller/resource/clusterrolebinding/create_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
 	"github.com/giantswarm/micrologger/microloggertest"
-	apiv1 "k8s.io/api/rbac/v1beta1"
+	apiv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 )

--- a/service/controller/resource/clusterrolebinding/current.go
+++ b/service/controller/resource/clusterrolebinding/current.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	"github.com/giantswarm/microerror"
-	apiv1 "k8s.io/api/rbac/v1beta1"
+	apiv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -21,7 +21,7 @@ func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interf
 
 	var currentClusterRoleBinding []*apiv1.ClusterRoleBinding
 	{
-		clusterRoleBinding, err := r.k8sClient.RbacV1beta1().ClusterRoleBindings().Get(key.ClusterRoleBindingName(customObject), metav1.GetOptions{})
+		clusterRoleBinding, err := r.k8sClient.RbacV1().ClusterRoleBindings().Get(key.ClusterRoleBindingName(customObject), metav1.GetOptions{})
 		if apierrors.IsNotFound(err) {
 			r.logger.LogCtx(ctx, "level", "debug", "message", "did not find cluster role binding in the Kubernetes API")
 			// fall through
@@ -33,7 +33,7 @@ func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interf
 			currentClusterRoleBinding = append(currentClusterRoleBinding, clusterRoleBinding)
 		}
 
-		clusterRoleBindingPSP, err := r.k8sClient.RbacV1beta1().ClusterRoleBindings().Get(key.ClusterRoleBindingPSPName(customObject), metav1.GetOptions{})
+		clusterRoleBindingPSP, err := r.k8sClient.RbacV1().ClusterRoleBindings().Get(key.ClusterRoleBindingPSPName(customObject), metav1.GetOptions{})
 		if apierrors.IsNotFound(err) {
 			r.logger.LogCtx(ctx, "level", "debug", "message", "did not find cluster role binding psp in the Kubernetes API")
 			// fall through

--- a/service/controller/resource/clusterrolebinding/delete.go
+++ b/service/controller/resource/clusterrolebinding/delete.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/operatorkit/resource/crud"
-	apiv1 "k8s.io/api/rbac/v1beta1"
+	apiv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )

--- a/service/controller/resource/clusterrolebinding/delete_test.go
+++ b/service/controller/resource/clusterrolebinding/delete_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
 	"github.com/giantswarm/micrologger/microloggertest"
-	apiv1 "k8s.io/api/rbac/v1beta1"
+	apiv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 )

--- a/service/controller/resource/clusterrolebinding/desired.go
+++ b/service/controller/resource/clusterrolebinding/desired.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
 	"github.com/giantswarm/microerror"
-	apiv1 "k8s.io/api/rbac/v1beta1"
+	apiv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/giantswarm/kvm-operator/service/controller/key"

--- a/service/controller/resource/clusterrolebinding/desired_test.go
+++ b/service/controller/resource/clusterrolebinding/desired_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
 	"github.com/giantswarm/micrologger/microloggertest"
-	apiv1 "k8s.io/api/rbac/v1beta1"
+	apiv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 )

--- a/service/controller/resource/clusterrolebinding/resource.go
+++ b/service/controller/resource/clusterrolebinding/resource.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
-	apiv1 "k8s.io/api/rbac/v1beta1"
+	apiv1 "k8s.io/api/rbac/v1"
 	"k8s.io/client-go/kubernetes"
 )
 

--- a/service/controller/resource/clusterrolebinding/update.go
+++ b/service/controller/resource/clusterrolebinding/update.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/operatorkit/resource/crud"
-	apiv1 "k8s.io/api/rbac/v1beta1"
+	apiv1 "k8s.io/api/rbac/v1"
 )
 
 func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateChange interface{}) error {
@@ -20,7 +20,7 @@ func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateChange inte
 
 		// Create the cluster role bindings in the Kubernetes API.
 		for _, clusterRoleBinding := range clusterRoleBindingsToUpdate {
-			_, err := r.k8sClient.RbacV1beta1().ClusterRoleBindings().Update(clusterRoleBinding)
+			_, err := r.k8sClient.RbacV1().ClusterRoleBindings().Update(clusterRoleBinding)
 			if err != nil {
 				return microerror.Mask(err)
 			}

--- a/service/controller/resource/clusterrolebinding/update_test.go
+++ b/service/controller/resource/clusterrolebinding/update_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
 	"github.com/giantswarm/micrologger/microloggertest"
-	apiv1 "k8s.io/api/rbac/v1beta1"
+	apiv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 )

--- a/service/controller/resource/ingress/api_ingress.go
+++ b/service/controller/resource/ingress/api_ingress.go
@@ -2,18 +2,18 @@ package ingress
 
 import (
 	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
-	extensionsv1 "k8s.io/api/extensions/v1beta1"
+	networkingv1beta1 "k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
 	"github.com/giantswarm/kvm-operator/service/controller/key"
 )
 
-func newAPIIngress(customObject v1alpha1.KVMConfig) *extensionsv1.Ingress {
-	ingress := &extensionsv1.Ingress{
+func newAPIIngress(customObject v1alpha1.KVMConfig) *networkingv1beta1.Ingress {
+	ingress := &networkingv1beta1.Ingress{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Ingress",
-			APIVersion: "extensions/v1beta",
+			APIVersion: "networking/v1beta",
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name: APIID,
@@ -26,23 +26,23 @@ func newAPIIngress(customObject v1alpha1.KVMConfig) *extensionsv1.Ingress {
 				"nginx.ingress.kubernetes.io/ssl-passthrough": "true",
 			},
 		},
-		Spec: extensionsv1.IngressSpec{
-			TLS: []extensionsv1.IngressTLS{
+		Spec: networkingv1beta1.IngressSpec{
+			TLS: []networkingv1beta1.IngressTLS{
 				{
 					Hosts: []string{
 						customObject.Spec.Cluster.Kubernetes.API.Domain,
 					},
 				},
 			},
-			Rules: []extensionsv1.IngressRule{
+			Rules: []networkingv1beta1.IngressRule{
 				{
 					Host: customObject.Spec.Cluster.Kubernetes.API.Domain,
-					IngressRuleValue: extensionsv1.IngressRuleValue{
-						HTTP: &extensionsv1.HTTPIngressRuleValue{
-							Paths: []extensionsv1.HTTPIngressPath{
+					IngressRuleValue: networkingv1beta1.IngressRuleValue{
+						HTTP: &networkingv1beta1.HTTPIngressRuleValue{
+							Paths: []networkingv1beta1.HTTPIngressPath{
 								{
 									Path: "/",
-									Backend: extensionsv1.IngressBackend{
+									Backend: networkingv1beta1.IngressBackend{
 										ServiceName: key.MasterID,
 										ServicePort: intstr.FromInt(customObject.Spec.Cluster.Kubernetes.API.SecurePort),
 									},

--- a/service/controller/resource/ingress/create.go
+++ b/service/controller/resource/ingress/create.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	"github.com/giantswarm/microerror"
-	"k8s.io/api/extensions/v1beta1"
+	"k8s.io/api/networking/v1beta1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 
 	"github.com/giantswarm/kvm-operator/service/controller/key"
@@ -26,7 +26,7 @@ func (r *Resource) ApplyCreateChange(ctx context.Context, obj, createChange inte
 
 		namespace := key.ClusterNamespace(customObject)
 		for _, ingress := range ingressesToCreate {
-			_, err := r.k8sClient.ExtensionsV1beta1().Ingresses(namespace).Create(ingress)
+			_, err := r.k8sClient.NetworkingV1beta1().Ingresses(namespace).Create(ingress)
 			if apierrors.IsAlreadyExists(err) {
 				// fall through
 			} else if err != nil {

--- a/service/controller/resource/ingress/create_test.go
+++ b/service/controller/resource/ingress/create_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
 	"github.com/giantswarm/micrologger/microloggertest"
-	"k8s.io/api/extensions/v1beta1"
+	"k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 )

--- a/service/controller/resource/ingress/current.go
+++ b/service/controller/resource/ingress/current.go
@@ -7,7 +7,7 @@ import (
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/operatorkit/controller/context/finalizerskeptcontext"
 	"github.com/giantswarm/operatorkit/controller/context/resourcecanceledcontext"
-	"k8s.io/api/extensions/v1beta1"
+	"k8s.io/api/networking/v1beta1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -31,7 +31,7 @@ func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interf
 	}
 
 	for _, name := range ingressNames {
-		manifest, err := r.k8sClient.ExtensionsV1beta1().Ingresses(namespace).Get(name, metav1.GetOptions{})
+		manifest, err := r.k8sClient.NetworkingV1beta1().Ingresses(namespace).Get(name, metav1.GetOptions{})
 		if apierrors.IsNotFound(err) {
 			r.logger.LogCtx(ctx, "level", "debug", "message", "did not find a ingress in the Kubernetes API")
 			// fall through

--- a/service/controller/resource/ingress/delete.go
+++ b/service/controller/resource/ingress/delete.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/operatorkit/resource/crud"
-	"k8s.io/api/extensions/v1beta1"
+	"k8s.io/api/networking/v1beta1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -28,7 +28,7 @@ func (r *Resource) ApplyDeleteChange(ctx context.Context, obj, deleteChange inte
 
 		namespace := key.ClusterNamespace(customObject)
 		for _, ingress := range ingressesToDelete {
-			err := r.k8sClient.ExtensionsV1beta1().Ingresses(namespace).Delete(ingress.Name, &metav1.DeleteOptions{})
+			err := r.k8sClient.NetworkingV1beta1().Ingresses(namespace).Delete(ingress.Name, &metav1.DeleteOptions{})
 			if apierrors.IsNotFound(err) {
 				// fall through
 			} else if err != nil {

--- a/service/controller/resource/ingress/delete_test.go
+++ b/service/controller/resource/ingress/delete_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
 	"github.com/giantswarm/micrologger/microloggertest"
-	"k8s.io/api/extensions/v1beta1"
+	"k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 )

--- a/service/controller/resource/ingress/desired.go
+++ b/service/controller/resource/ingress/desired.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	"github.com/giantswarm/microerror"
-	"k8s.io/api/extensions/v1beta1"
+	"k8s.io/api/networking/v1beta1"
 
 	"github.com/giantswarm/kvm-operator/service/controller/key"
 )

--- a/service/controller/resource/ingress/desired_test.go
+++ b/service/controller/resource/ingress/desired_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
 	"github.com/giantswarm/micrologger/microloggertest"
-	"k8s.io/api/extensions/v1beta1"
+	"k8s.io/api/networking/v1beta1"
 	"k8s.io/client-go/kubernetes/fake"
 )
 

--- a/service/controller/resource/ingress/etcd_ingress.go
+++ b/service/controller/resource/ingress/etcd_ingress.go
@@ -2,18 +2,18 @@ package ingress
 
 import (
 	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
-	extensionsv1 "k8s.io/api/extensions/v1beta1"
+	"k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
 	"github.com/giantswarm/kvm-operator/service/controller/key"
 )
 
-func newEtcdIngress(customObject v1alpha1.KVMConfig) *extensionsv1.Ingress {
-	ingress := &extensionsv1.Ingress{
+func newEtcdIngress(customObject v1alpha1.KVMConfig) *v1beta1.Ingress {
+	ingress := &v1beta1.Ingress{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Ingress",
-			APIVersion: "extensions/v1beta",
+			APIVersion: "networking/v1beta",
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name: EtcdID,
@@ -26,23 +26,23 @@ func newEtcdIngress(customObject v1alpha1.KVMConfig) *extensionsv1.Ingress {
 				"nginx.ingress.kubernetes.io/ssl-passthrough": "true",
 			},
 		},
-		Spec: extensionsv1.IngressSpec{
-			TLS: []extensionsv1.IngressTLS{
+		Spec: v1beta1.IngressSpec{
+			TLS: []v1beta1.IngressTLS{
 				{
 					Hosts: []string{
 						customObject.Spec.Cluster.Etcd.Domain,
 					},
 				},
 			},
-			Rules: []extensionsv1.IngressRule{
+			Rules: []v1beta1.IngressRule{
 				{
 					Host: customObject.Spec.Cluster.Etcd.Domain,
-					IngressRuleValue: extensionsv1.IngressRuleValue{
-						HTTP: &extensionsv1.HTTPIngressRuleValue{
-							Paths: []extensionsv1.HTTPIngressPath{
+					IngressRuleValue: v1beta1.IngressRuleValue{
+						HTTP: &v1beta1.HTTPIngressRuleValue{
+							Paths: []v1beta1.HTTPIngressPath{
 								{
 									Path: "/",
-									Backend: extensionsv1.IngressBackend{
+									Backend: v1beta1.IngressBackend{
 										ServiceName: key.MasterID,
 										ServicePort: intstr.FromInt(2379),
 									},

--- a/service/controller/resource/ingress/resource.go
+++ b/service/controller/resource/ingress/resource.go
@@ -3,7 +3,7 @@ package ingress
 import (
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
-	"k8s.io/api/extensions/v1beta1"
+	"k8s.io/api/networking/v1beta1"
 	"k8s.io/client-go/kubernetes"
 )
 


### PR DESCRIPTION
Includes the following:
- Change `extensions/ingresses` => `networking/ingresses`
- Change `extensions/podsecuritypolicy` => `policy/podsecuritypolicy`
- Remove `thirdpartyresources` from RBAC, not used anymore
- Change `rbac/v1beta1` => `rbac/v1`