### PR TITLE
Use operator version

### DIFF
--- a/pkg/label/label.go
+++ b/pkg/label/label.go
@@ -11,3 +11,7 @@ const (
 	// in the front-end.
 	Organization = "giantswarm.io/organization"
 )
+
+const (
+	OperatorVersion = "kvm-operator.giantswarm.io/version"
+)

--- a/service/controller/cluster_resource_set.go
+++ b/service/controller/cluster_resource_set.go
@@ -238,7 +238,7 @@ func NewClusterResourceSet(config ClusterResourceSetConfig) (*controller.Resourc
 			Logger:                   config.Logger,
 			RESTClient:               config.K8sClient.G8sClient().ProviderV1alpha1().RESTClient(),
 			TenantCluster:            config.TenantCluster,
-			VersionBundleVersionFunc: key.ToVersionBundleVersion,
+			VersionBundleVersionFunc: key.ToOperatorVersion,
 		}
 
 		statusResource, err = statusresource.NewResource(c)
@@ -281,12 +281,12 @@ func NewClusterResourceSet(config ClusterResourceSetConfig) (*controller.Resourc
 	}
 
 	handlesFunc := func(obj interface{}) bool {
-		kvmConfig, err := key.ToCustomObject(obj)
+		cr, err := key.ToCustomObject(obj)
 		if err != nil {
 			return false
 		}
 
-		if key.VersionBundleVersion(kvmConfig) == project.BundleVersion() {
+		if key.OperatorVersion(cr) == project.BundleVersion() {
 			return true
 		}
 

--- a/service/controller/deleter_resource_set.go
+++ b/service/controller/deleter_resource_set.go
@@ -27,12 +27,12 @@ func NewDeleterResourceSet(config DeleterResourceSetConfig) (*controller.Resourc
 	var err error
 
 	handlesFunc := func(obj interface{}) bool {
-		kvmConfig, err := key.ToCustomObject(obj)
+		cr, err := key.ToCustomObject(obj)
 		if err != nil {
 			return false
 		}
 
-		if key.VersionBundleVersion(kvmConfig) == project.BundleVersion() {
+		if key.OperatorVersion(cr) == project.BundleVersion() {
 			return true
 		}
 

--- a/service/controller/key/key.go
+++ b/service/controller/key/key.go
@@ -14,6 +14,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/util/intstr"
+
+	"github.com/giantswarm/kvm-operator/pkg/label"
 )
 
 const (
@@ -408,6 +410,10 @@ func NodeIndex(cr v1alpha1.KVMConfig, nodeID string) (int, bool) {
 	return idx, present
 }
 
+func OperatorVersion(cr v1alpha1.KVMConfig) string {
+	return cr.GetLabels()[label.OperatorVersion]
+}
+
 func PortMappings(customObject v1alpha1.KVMConfig) []corev1.ServicePort {
 	var ports []corev1.ServicePort
 
@@ -519,6 +525,15 @@ func ToNodeCount(v interface{}) (int, error) {
 	return nodeCount, nil
 }
 
+func ToOperatorVersion(v interface{}) (string, error) {
+	customObject, err := ToCustomObject(v)
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+
+	return OperatorVersion(customObject), nil
+}
+
 func ToPod(v interface{}) (*corev1.Pod, error) {
 	if v == nil {
 		return nil, nil
@@ -530,19 +545,6 @@ func ToPod(v interface{}) (*corev1.Pod, error) {
 	}
 
 	return pod, nil
-}
-
-func ToVersionBundleVersion(v interface{}) (string, error) {
-	customObject, err := ToCustomObject(v)
-	if err != nil {
-		return "", microerror.Mask(err)
-	}
-
-	return VersionBundleVersion(customObject), nil
-}
-
-func VersionBundleVersion(customObject v1alpha1.KVMConfig) string {
-	return customObject.Spec.VersionBundle.Version
 }
 
 func VersionBundleVersionFromPod(pod *corev1.Pod) (string, error) {

--- a/service/controller/key/spec.go
+++ b/service/controller/key/spec.go
@@ -1,0 +1,5 @@
+package key
+
+type LabelsGetter interface {
+	GetLabels() map[string]string
+}

--- a/service/controller/resource/deployment/master_deployment.go
+++ b/service/controller/resource/deployment/master_deployment.go
@@ -73,7 +73,7 @@ func newMasterDeployments(customResource v1alpha1.KVMConfig, dnsServers, ntpServ
 			ObjectMeta: metav1.ObjectMeta{
 				Name: key.DeploymentName(key.MasterID, masterNode.ID),
 				Annotations: map[string]string{
-					key.VersionBundleVersionAnnotation: key.VersionBundleVersion(customResource),
+					key.VersionBundleVersionAnnotation: key.OperatorVersion(customResource),
 				},
 				Labels: map[string]string{
 					key.LabelApp:          key.MasterID,
@@ -104,7 +104,7 @@ func newMasterDeployments(customResource v1alpha1.KVMConfig, dnsServers, ntpServ
 							key.AnnotationIp:            "",
 							key.AnnotationService:       key.MasterID,
 							key.AnnotationPodDrained:    "False",
-							key.AnnotationVersionBundle: key.VersionBundleVersion(customResource),
+							key.AnnotationVersionBundle: key.OperatorVersion(customResource),
 						},
 						GenerateName: key.MasterID,
 						Labels: map[string]string{

--- a/service/controller/resource/deployment/worker_deployment.go
+++ b/service/controller/resource/deployment/worker_deployment.go
@@ -42,7 +42,7 @@ func newWorkerDeployments(customResource v1alpha1.KVMConfig, dnsServers, ntpServ
 			ObjectMeta: metav1.ObjectMeta{
 				Name: key.DeploymentName(key.WorkerID, workerNode.ID),
 				Annotations: map[string]string{
-					key.VersionBundleVersionAnnotation: key.VersionBundleVersion(customResource),
+					key.VersionBundleVersionAnnotation: key.OperatorVersion(customResource),
 				},
 				Labels: map[string]string{
 					key.LabelApp:          key.WorkerID,
@@ -73,7 +73,7 @@ func newWorkerDeployments(customResource v1alpha1.KVMConfig, dnsServers, ntpServ
 							key.AnnotationIp:            "",
 							key.AnnotationService:       key.WorkerID,
 							key.AnnotationPodDrained:    "False",
-							key.AnnotationVersionBundle: key.VersionBundleVersion(customResource),
+							key.AnnotationVersionBundle: key.OperatorVersion(customResource),
 						},
 						Name: key.WorkerID,
 						Labels: map[string]string{

--- a/service/controller/resource/service/master_service.go
+++ b/service/controller/resource/service/master_service.go
@@ -23,7 +23,7 @@ func newMasterService(customObject v1alpha1.KVMConfig) *corev1.Service {
 				key.LabelApp:           key.MasterID,
 				key.LabelCluster:       key.ClusterID(customObject),
 				key.LabelOrganization:  key.ClusterCustomer(customObject),
-				key.LabelVersionBundle: key.VersionBundleVersion(customObject),
+				key.LabelVersionBundle: key.OperatorVersion(customObject),
 			},
 			Annotations: map[string]string{
 				key.AnnotationEtcdDomain:        key.ClusterEtcdDomain(customObject),

--- a/service/controller/resource/service/worker_service.go
+++ b/service/controller/resource/service/worker_service.go
@@ -23,7 +23,7 @@ func newWorkerService(customObject v1alpha1.KVMConfig) *corev1.Service {
 				key.LabelApp:           key.WorkerID,
 				key.LabelCluster:       key.ClusterID(customObject),
 				key.LabelOrganization:  key.ClusterCustomer(customObject),
-				key.LabelVersionBundle: key.VersionBundleVersion(customObject),
+				key.LabelVersionBundle: key.OperatorVersion(customObject),
 			},
 			Annotations: map[string]string{
 				"prometheus.io/path":   "/healthz",


### PR DESCRIPTION
Main difference here is that it is now using the label instead of the VBV spec field.

I was also so free and renamed the function to match `aws-operator` master in the same go.

towards https://github.com/giantswarm/giantswarm/issues/7820