### PR TITLE
flattening: pass provider cluster roles through from helm chart

### DIFF
--- a/flag/service/podsecuritypolicy/podsecuritypolicy.go
+++ b/flag/service/podsecuritypolicy/podsecuritypolicy.go
@@ -1,5 +1,0 @@
-package podsecuritypolicy
-
-type PodSecurityPolicy struct {
-	Name string
-}

--- a/flag/service/podsecuritypolicy/podsecuritypolicy.go
+++ b/flag/service/podsecuritypolicy/podsecuritypolicy.go
@@ -1,0 +1,5 @@
+package podsecuritypolicy
+
+type PodSecurityPolicy struct {
+	Name string
+}

--- a/flag/service/rbac/clusterrole/clusterrole.go
+++ b/flag/service/rbac/clusterrole/clusterrole.go
@@ -1,0 +1,6 @@
+package clusterrole
+
+type ClusterRole struct {
+	General string
+	PSP     string
+}

--- a/flag/service/rbac/rbac.go
+++ b/flag/service/rbac/rbac.go
@@ -1,0 +1,7 @@
+package rbac
+
+import "github.com/giantswarm/kvm-operator/flag/service/rbac/clusterrole"
+
+type RBAC struct {
+	ClusterRole clusterrole.ClusterRole
+}

--- a/flag/service/service.go
+++ b/flag/service/service.go
@@ -5,12 +5,14 @@ import (
 
 	"github.com/giantswarm/kvm-operator/flag/service/crd"
 	"github.com/giantswarm/kvm-operator/flag/service/installation"
+	"github.com/giantswarm/kvm-operator/flag/service/podsecuritypolicy"
 	"github.com/giantswarm/kvm-operator/flag/service/tenant"
 )
 
 type Service struct {
-	CRD          crd.CRD
-	Installation installation.Installation
-	Kubernetes   kubernetes.Kubernetes
-	Tenant       tenant.Tenant
+	CRD               crd.CRD
+	Installation      installation.Installation
+	Kubernetes        kubernetes.Kubernetes
+	PodSecurityPolicy podsecuritypolicy.PodSecurityPolicy
+	Tenant            tenant.Tenant
 }

--- a/flag/service/service.go
+++ b/flag/service/service.go
@@ -5,14 +5,14 @@ import (
 
 	"github.com/giantswarm/kvm-operator/flag/service/crd"
 	"github.com/giantswarm/kvm-operator/flag/service/installation"
-	"github.com/giantswarm/kvm-operator/flag/service/podsecuritypolicy"
+	"github.com/giantswarm/kvm-operator/flag/service/rbac"
 	"github.com/giantswarm/kvm-operator/flag/service/tenant"
 )
 
 type Service struct {
-	CRD               crd.CRD
-	Installation      installation.Installation
-	Kubernetes        kubernetes.Kubernetes
-	PodSecurityPolicy podsecuritypolicy.PodSecurityPolicy
-	Tenant            tenant.Tenant
+	CRD          crd.CRD
+	Installation installation.Installation
+	Kubernetes   kubernetes.Kubernetes
+	RBAC         rbac.RBAC
+	Tenant       tenant.Tenant
 }

--- a/helm/kvm-operator/templates/configmap.yaml
+++ b/helm/kvm-operator/templates/configmap.yaml
@@ -14,8 +14,10 @@ data:
     service:
       crd:
         labelSelector: '{{ .Values.Installation.V1.GiantSwarm.KVMOperator.CRD.LabelSelector }}'
-      podSecurityPolicy:
-        name: {{ tpl .Values.resource.psp.name . }}
+      rbac:
+        clusterRole:
+          general: {{ tpl .Values.resource.default.name . }}
+          psp: {{ tpl .Values.resource.psp.name . }}
       kubernetes:
         address: ''
         inCluster: true

--- a/helm/kvm-operator/templates/configmap.yaml
+++ b/helm/kvm-operator/templates/configmap.yaml
@@ -14,6 +14,8 @@ data:
     service:
       crd:
         labelSelector: '{{ .Values.Installation.V1.GiantSwarm.KVMOperator.CRD.LabelSelector }}'
+      podSecurityPolicy:
+        name: {{ tpl .Values.resource.psp.name . }}
       kubernetes:
         address: ''
         inCluster: true

--- a/helm/kvm-operator/templates/rbac.yaml
+++ b/helm/kvm-operator/templates/rbac.yaml
@@ -61,11 +61,11 @@ rules:
       - get
       - create
       - delete
+      - update
   - apiGroups:
       - ""
     resources:
       - namespaces
-      - clusterrolebindings
       - serviceaccounts
     verbs:
       - get

--- a/helm/kvm-operator/templates/rbac.yaml
+++ b/helm/kvm-operator/templates/rbac.yaml
@@ -10,7 +10,7 @@ rules:
     verbs:
       - "*"
   - apiGroups:
-      - networking
+      - networking.k8s.io
     resources:
       - ingresses
     verbs:

--- a/main.go
+++ b/main.go
@@ -113,7 +113,8 @@ func mainError() error {
 	daemonCommand.PersistentFlags().String(f.Service.Installation.Tenant.Kubernetes.API.Auth.Provider.OIDC.GroupsClaim, "", "OIDC authorization provider GroupsClaim.")
 
 	daemonCommand.PersistentFlags().String(f.Service.CRD.LabelSelector, "", "Label selector for CRD informer ListOptions.")
-	daemonCommand.PersistentFlags().String(f.Service.PodSecurityPolicy.Name, "", "Name of existing PodSecurityPolicy to be used for tenant cluster node pods.")
+	daemonCommand.PersistentFlags().String(f.Service.RBAC.ClusterRole.General, "", "Name of existing general ClusterRole to be used for tenant cluster node pods.")
+	daemonCommand.PersistentFlags().String(f.Service.RBAC.ClusterRole.PSP, "", "Name of existing ClusterRole with PSP to be used for tenant cluster node pods.")
 
 	daemonCommand.PersistentFlags().String(f.Service.Kubernetes.Address, "http://127.0.0.1:6443", "Address used to connect to Kubernetes. When empty in-cluster config is created.")
 	daemonCommand.PersistentFlags().Bool(f.Service.Kubernetes.InCluster, false, "Whether to use the in-cluster config to authenticate with Kubernetes.")

--- a/main.go
+++ b/main.go
@@ -113,6 +113,7 @@ func mainError() error {
 	daemonCommand.PersistentFlags().String(f.Service.Installation.Tenant.Kubernetes.API.Auth.Provider.OIDC.GroupsClaim, "", "OIDC authorization provider GroupsClaim.")
 
 	daemonCommand.PersistentFlags().String(f.Service.CRD.LabelSelector, "", "Label selector for CRD informer ListOptions.")
+	daemonCommand.PersistentFlags().String(f.Service.PodSecurityPolicy.Name, "", "Name of existing PodSecurityPolicy to be used for tenant cluster node pods.")
 
 	daemonCommand.PersistentFlags().String(f.Service.Kubernetes.Address, "http://127.0.0.1:6443", "Address used to connect to Kubernetes. When empty in-cluster config is created.")
 	daemonCommand.PersistentFlags().Bool(f.Service.Kubernetes.InCluster, false, "Whether to use the in-cluster config to authenticate with Kubernetes.")

--- a/service/controller/cluster.go
+++ b/service/controller/cluster.go
@@ -21,14 +21,15 @@ type ClusterConfig struct {
 	Logger        micrologger.Logger
 	TenantCluster tenantcluster.Interface
 
-	CRDLabelSelector   string
-	DNSServers         string
-	GuestUpdateEnabled bool
-	IgnitionPath       string
-	NTPServers         string
-	OIDC               ClusterConfigOIDC
-	ProjectName        string
-	SSOPublicKey       string
+	CRDLabelSelector      string
+	DNSServers            string
+	GuestUpdateEnabled    bool
+	IgnitionPath          string
+	NTPServers            string
+	OIDC                  ClusterConfigOIDC
+	PodSecurityPolicyName string
+	ProjectName           string
+	SSOPublicKey          string
 }
 
 // ClusterConfigOIDC represents the configuration of the OIDC authorization
@@ -116,11 +117,12 @@ func newClusterResourceSets(config ClusterConfig) ([]*controller.ResourceSet, er
 			RandomkeysSearcher: randomkeysSearcher,
 			TenantCluster:      config.TenantCluster,
 
-			DNSServers:         config.DNSServers,
-			GuestUpdateEnabled: config.GuestUpdateEnabled,
-			IgnitionPath:       config.IgnitionPath,
-			NTPServers:         config.NTPServers,
-			ProjectName:        config.ProjectName,
+			DNSServers:            config.DNSServers,
+			GuestUpdateEnabled:    config.GuestUpdateEnabled,
+			IgnitionPath:          config.IgnitionPath,
+			NTPServers:            config.NTPServers,
+			PodSecurityPolicyName: config.PodSecurityPolicyName,
+			ProjectName:           config.ProjectName,
 			OIDC: cloudconfig.OIDCConfig{
 				ClientID:      config.OIDC.ClientID,
 				IssuerURL:     config.OIDC.IssuerURL,

--- a/service/controller/cluster.go
+++ b/service/controller/cluster.go
@@ -21,15 +21,16 @@ type ClusterConfig struct {
 	Logger        micrologger.Logger
 	TenantCluster tenantcluster.Interface
 
-	CRDLabelSelector      string
-	DNSServers            string
-	GuestUpdateEnabled    bool
-	IgnitionPath          string
-	NTPServers            string
-	OIDC                  ClusterConfigOIDC
-	PodSecurityPolicyName string
-	ProjectName           string
-	SSOPublicKey          string
+	ClusterRoleGeneral string
+	ClusterRolePSP     string
+	CRDLabelSelector   string
+	DNSServers         string
+	GuestUpdateEnabled bool
+	IgnitionPath       string
+	NTPServers         string
+	OIDC               ClusterConfigOIDC
+	ProjectName        string
+	SSOPublicKey       string
 }
 
 // ClusterConfigOIDC represents the configuration of the OIDC authorization
@@ -117,12 +118,13 @@ func newClusterResourceSets(config ClusterConfig) ([]*controller.ResourceSet, er
 			RandomkeysSearcher: randomkeysSearcher,
 			TenantCluster:      config.TenantCluster,
 
-			DNSServers:            config.DNSServers,
-			GuestUpdateEnabled:    config.GuestUpdateEnabled,
-			IgnitionPath:          config.IgnitionPath,
-			NTPServers:            config.NTPServers,
-			PodSecurityPolicyName: config.PodSecurityPolicyName,
-			ProjectName:           config.ProjectName,
+			ClusterRoleGeneral: config.ClusterRoleGeneral,
+			ClusterRolePSP:     config.ClusterRolePSP,
+			DNSServers:         config.DNSServers,
+			GuestUpdateEnabled: config.GuestUpdateEnabled,
+			IgnitionPath:       config.IgnitionPath,
+			NTPServers:         config.NTPServers,
+			ProjectName:        config.ProjectName,
 			OIDC: cloudconfig.OIDCConfig{
 				ClientID:      config.OIDC.ClientID,
 				IssuerURL:     config.OIDC.IssuerURL,

--- a/service/controller/cluster_resource_set.go
+++ b/service/controller/cluster_resource_set.go
@@ -38,14 +38,15 @@ type ClusterResourceSetConfig struct {
 	RandomkeysSearcher randomkeys.Interface
 	TenantCluster      tenantcluster.Interface
 
-	DNSServers            string
-	GuestUpdateEnabled    bool
-	IgnitionPath          string
-	NTPServers            string
-	OIDC                  cloudconfig.OIDCConfig
-	PodSecurityPolicyName string
-	ProjectName           string
-	SSOPublicKey          string
+	ClusterRoleGeneral string
+	ClusterRolePSP     string
+	DNSServers         string
+	GuestUpdateEnabled bool
+	IgnitionPath       string
+	NTPServers         string
+	OIDC               cloudconfig.OIDCConfig
+	ProjectName        string
+	SSOPublicKey       string
 }
 
 func NewClusterResourceSet(config ClusterResourceSetConfig) (*controller.ResourceSet, error) {
@@ -73,7 +74,8 @@ func NewClusterResourceSet(config ClusterResourceSetConfig) (*controller.Resourc
 			K8sClient: config.K8sClient.K8sClient(),
 			Logger:    config.Logger,
 
-			PodSecurityPolicyName: config.PodSecurityPolicyName,
+			ClusterRoleGeneral: config.ClusterRoleGeneral,
+			ClusterRolePSP:     config.ClusterRolePSP,
 		}
 
 		ops, err := clusterrolebinding.New(c)

--- a/service/controller/cluster_resource_set.go
+++ b/service/controller/cluster_resource_set.go
@@ -38,13 +38,14 @@ type ClusterResourceSetConfig struct {
 	RandomkeysSearcher randomkeys.Interface
 	TenantCluster      tenantcluster.Interface
 
-	DNSServers         string
-	GuestUpdateEnabled bool
-	IgnitionPath       string
-	NTPServers         string
-	OIDC               cloudconfig.OIDCConfig
-	ProjectName        string
-	SSOPublicKey       string
+	DNSServers            string
+	GuestUpdateEnabled    bool
+	IgnitionPath          string
+	NTPServers            string
+	OIDC                  cloudconfig.OIDCConfig
+	PodSecurityPolicyName string
+	ProjectName           string
+	SSOPublicKey          string
 }
 
 func NewClusterResourceSet(config ClusterResourceSetConfig) (*controller.ResourceSet, error) {
@@ -71,6 +72,8 @@ func NewClusterResourceSet(config ClusterResourceSetConfig) (*controller.Resourc
 		c := clusterrolebinding.Config{
 			K8sClient: config.K8sClient.K8sClient(),
 			Logger:    config.Logger,
+
+			PodSecurityPolicyName: config.PodSecurityPolicyName,
 		}
 
 		ops, err := clusterrolebinding.New(c)

--- a/service/controller/resource/clusterrolebinding/create_test.go
+++ b/service/controller/resource/clusterrolebinding/create_test.go
@@ -219,6 +219,8 @@ func Test_Resource_ClusterRoleBinding_newCreateChange(t *testing.T) {
 		resourceConfig := Config{
 			K8sClient: fake.NewSimpleClientset(),
 			Logger:    microloggertest.New(),
+
+			PodSecurityPolicyName: "test-psp",
 		}
 		newResource, err = New(resourceConfig)
 		if err != nil {

--- a/service/controller/resource/clusterrolebinding/create_test.go
+++ b/service/controller/resource/clusterrolebinding/create_test.go
@@ -220,7 +220,8 @@ func Test_Resource_ClusterRoleBinding_newCreateChange(t *testing.T) {
 			K8sClient: fake.NewSimpleClientset(),
 			Logger:    microloggertest.New(),
 
-			PodSecurityPolicyName: "test-psp",
+			ClusterRoleGeneral: "test-role",
+			ClusterRolePSP:     "test-role-psp",
 		}
 		newResource, err = New(resourceConfig)
 		if err != nil {

--- a/service/controller/resource/clusterrolebinding/delete_test.go
+++ b/service/controller/resource/clusterrolebinding/delete_test.go
@@ -266,7 +266,8 @@ func Test_Resource_ClusterRoleBinding_newDeleteChange(t *testing.T) {
 			K8sClient: fake.NewSimpleClientset(),
 			Logger:    microloggertest.New(),
 
-			PodSecurityPolicyName: "test-psp",
+			ClusterRoleGeneral: "test-role",
+			ClusterRolePSP:     "test-role-psp",
 		}
 
 		newResource, err = New(resourceConfig)

--- a/service/controller/resource/clusterrolebinding/delete_test.go
+++ b/service/controller/resource/clusterrolebinding/delete_test.go
@@ -265,6 +265,8 @@ func Test_Resource_ClusterRoleBinding_newDeleteChange(t *testing.T) {
 		resourceConfig := Config{
 			K8sClient: fake.NewSimpleClientset(),
 			Logger:    microloggertest.New(),
+
+			PodSecurityPolicyName: "test-psp",
 		}
 
 		newResource, err = New(resourceConfig)

--- a/service/controller/resource/clusterrolebinding/desired.go
+++ b/service/controller/resource/clusterrolebinding/desired.go
@@ -85,7 +85,7 @@ func (r *Resource) newClusterRoleBindings(customObject v1alpha1.KVMConfig) ([]*a
 		RoleRef: apiv1.RoleRef{
 			APIGroup: apiv1.GroupName,
 			Kind:     "ClusterRole",
-			Name:     "kvm-operator-psp",
+			Name:     r.podSecurityPolicyName,
 		},
 	}
 

--- a/service/controller/resource/clusterrolebinding/desired.go
+++ b/service/controller/resource/clusterrolebinding/desired.go
@@ -56,7 +56,7 @@ func (r *Resource) newClusterRoleBindings(customObject v1alpha1.KVMConfig) ([]*a
 		RoleRef: apiv1.RoleRef{
 			APIGroup: apiv1.GroupName,
 			Kind:     "ClusterRole",
-			Name:     "kvm-operator",
+			Name:     r.clusterRoleGeneral,
 		},
 	}
 
@@ -85,7 +85,7 @@ func (r *Resource) newClusterRoleBindings(customObject v1alpha1.KVMConfig) ([]*a
 		RoleRef: apiv1.RoleRef{
 			APIGroup: apiv1.GroupName,
 			Kind:     "ClusterRole",
-			Name:     r.podSecurityPolicyName,
+			Name:     r.clusterRolePSP,
 		},
 	}
 

--- a/service/controller/resource/clusterrolebinding/desired_test.go
+++ b/service/controller/resource/clusterrolebinding/desired_test.go
@@ -55,7 +55,8 @@ func Test_Resource_ClusterRoleBinding_GetDesiredState(t *testing.T) {
 			K8sClient: fake.NewSimpleClientset(),
 			Logger:    microloggertest.New(),
 
-			PodSecurityPolicyName: "test-psp",
+			ClusterRoleGeneral: "test-role",
+			ClusterRolePSP:     "test-role-psp",
 		}
 		newResource, err = New(resourceConfig)
 		if err != nil {

--- a/service/controller/resource/clusterrolebinding/desired_test.go
+++ b/service/controller/resource/clusterrolebinding/desired_test.go
@@ -54,6 +54,8 @@ func Test_Resource_ClusterRoleBinding_GetDesiredState(t *testing.T) {
 		resourceConfig := Config{
 			K8sClient: fake.NewSimpleClientset(),
 			Logger:    microloggertest.New(),
+
+			PodSecurityPolicyName: "test-psp",
 		}
 		newResource, err = New(resourceConfig)
 		if err != nil {

--- a/service/controller/resource/clusterrolebinding/resource.go
+++ b/service/controller/resource/clusterrolebinding/resource.go
@@ -19,7 +19,8 @@ type Config struct {
 	K8sClient kubernetes.Interface
 	Logger    micrologger.Logger
 
-	PodSecurityPolicyName string
+	ClusterRoleGeneral string
+	ClusterRolePSP     string
 }
 
 // Resource implements the config map resource.
@@ -27,7 +28,8 @@ type Resource struct {
 	k8sClient kubernetes.Interface
 	logger    micrologger.Logger
 
-	podSecurityPolicyName string
+	clusterRoleGeneral string
+	clusterRolePSP     string
 }
 
 // New creates a new configured config map resource.
@@ -38,15 +40,19 @@ func New(config Config) (*Resource, error) {
 	if config.Logger == nil {
 		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
 	}
-	if config.PodSecurityPolicyName == "" {
-		return nil, microerror.Maskf(invalidConfigError, "%T.PodSecurityPolicyName must not be empty", config)
+	if config.ClusterRoleGeneral == "" {
+		return nil, microerror.Maskf(invalidConfigError, "%T.ClusterRoleGeneral must not be empty", config)
+	}
+	if config.ClusterRolePSP == "" {
+		return nil, microerror.Maskf(invalidConfigError, "%T.ClusterRolePSP must not be empty", config)
 	}
 
 	newService := &Resource{
 		k8sClient: config.K8sClient,
 		logger:    config.Logger,
 
-		podSecurityPolicyName: config.PodSecurityPolicyName,
+		clusterRoleGeneral: config.ClusterRoleGeneral,
+		clusterRolePSP:     config.ClusterRolePSP,
 	}
 
 	return newService, nil

--- a/service/controller/resource/clusterrolebinding/resource.go
+++ b/service/controller/resource/clusterrolebinding/resource.go
@@ -43,9 +43,9 @@ func New(config Config) (*Resource, error) {
 	}
 
 	newService := &Resource{
-		k8sClient:             config.K8sClient,
-		logger:                config.Logger,
-		
+		k8sClient: config.K8sClient,
+		logger:    config.Logger,
+
 		podSecurityPolicyName: config.PodSecurityPolicyName,
 	}
 

--- a/service/controller/resource/clusterrolebinding/resource.go
+++ b/service/controller/resource/clusterrolebinding/resource.go
@@ -45,6 +45,7 @@ func New(config Config) (*Resource, error) {
 	newService := &Resource{
 		k8sClient:             config.K8sClient,
 		logger:                config.Logger,
+		
 		podSecurityPolicyName: config.PodSecurityPolicyName,
 	}
 

--- a/service/controller/resource/clusterrolebinding/resource.go
+++ b/service/controller/resource/clusterrolebinding/resource.go
@@ -18,26 +18,34 @@ const (
 type Config struct {
 	K8sClient kubernetes.Interface
 	Logger    micrologger.Logger
+
+	PodSecurityPolicyName string
 }
 
 // Resource implements the config map resource.
 type Resource struct {
 	k8sClient kubernetes.Interface
 	logger    micrologger.Logger
+
+	podSecurityPolicyName string
 }
 
 // New creates a new configured config map resource.
 func New(config Config) (*Resource, error) {
 	if config.K8sClient == nil {
-		return nil, microerror.Maskf(invalidConfigError, "config.K8sClient must not be empty")
+		return nil, microerror.Maskf(invalidConfigError, "%T.K8sClient must not be empty", config)
 	}
 	if config.Logger == nil {
-		return nil, microerror.Maskf(invalidConfigError, "config.Logger must not be empty")
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+	if config.PodSecurityPolicyName == "" {
+		return nil, microerror.Maskf(invalidConfigError, "%T.PodSecurityPolicyName must not be empty", config)
 	}
 
 	newService := &Resource{
-		k8sClient: config.K8sClient,
-		logger:    config.Logger,
+		k8sClient:             config.K8sClient,
+		logger:                config.Logger,
+		podSecurityPolicyName: config.PodSecurityPolicyName,
 	}
 
 	return newService, nil

--- a/service/controller/resource/clusterrolebinding/update_test.go
+++ b/service/controller/resource/clusterrolebinding/update_test.go
@@ -184,7 +184,8 @@ func Test_Resource_ClusterRoleBinding_newUpdateChange(t *testing.T) {
 			K8sClient: fake.NewSimpleClientset(),
 			Logger:    microloggertest.New(),
 
-			PodSecurityPolicyName: "test-psp",
+			ClusterRoleGeneral: "test-role",
+			ClusterRolePSP:     "test-role-psp",
 		}
 		newResource, err = New(resourceConfig)
 		if err != nil {

--- a/service/controller/resource/clusterrolebinding/update_test.go
+++ b/service/controller/resource/clusterrolebinding/update_test.go
@@ -183,6 +183,8 @@ func Test_Resource_ClusterRoleBinding_newUpdateChange(t *testing.T) {
 		resourceConfig := Config{
 			K8sClient: fake.NewSimpleClientset(),
 			Logger:    microloggertest.New(),
+
+			PodSecurityPolicyName: "test-psp",
 		}
 		newResource, err = New(resourceConfig)
 		if err != nil {

--- a/service/service.go
+++ b/service/service.go
@@ -136,9 +136,10 @@ func New(config Config) (*Service, error) {
 			Logger:        config.Logger,
 			TenantCluster: tenantCluster,
 
-			CRDLabelSelector:   config.Viper.GetString(config.Flag.Service.CRD.LabelSelector),
-			GuestUpdateEnabled: config.Viper.GetBool(config.Flag.Service.Tenant.Update.Enabled),
-			ProjectName:        project.Name(),
+			CRDLabelSelector:      config.Viper.GetString(config.Flag.Service.CRD.LabelSelector),
+			GuestUpdateEnabled:    config.Viper.GetBool(config.Flag.Service.Tenant.Update.Enabled),
+			PodSecurityPolicyName: config.Viper.GetString(config.Flag.Service.PodSecurityPolicy.Name),
+			ProjectName:           project.Name(),
 
 			DNSServers:   config.Viper.GetString(config.Flag.Service.Installation.DNS.Servers),
 			IgnitionPath: config.Viper.GetString(config.Flag.Service.Tenant.Ignition.Path),

--- a/service/service.go
+++ b/service/service.go
@@ -136,10 +136,11 @@ func New(config Config) (*Service, error) {
 			Logger:        config.Logger,
 			TenantCluster: tenantCluster,
 
-			CRDLabelSelector:      config.Viper.GetString(config.Flag.Service.CRD.LabelSelector),
-			GuestUpdateEnabled:    config.Viper.GetBool(config.Flag.Service.Tenant.Update.Enabled),
-			PodSecurityPolicyName: config.Viper.GetString(config.Flag.Service.PodSecurityPolicy.Name),
-			ProjectName:           project.Name(),
+			ClusterRoleGeneral: config.Viper.GetString(config.Flag.Service.RBAC.ClusterRole.General),
+			ClusterRolePSP:     config.Viper.GetString(config.Flag.Service.RBAC.ClusterRole.PSP),
+			CRDLabelSelector:   config.Viper.GetString(config.Flag.Service.CRD.LabelSelector),
+			GuestUpdateEnabled: config.Viper.GetBool(config.Flag.Service.Tenant.Update.Enabled),
+			ProjectName:        project.Name(),
 
 			DNSServers:   config.Viper.GetString(config.Flag.Service.Installation.DNS.Servers),
 			IgnitionPath: config.Viper.GetString(config.Flag.Service.Tenant.Ignition.Path),


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/7820

KVM TC nodes run in pods on the control plane. This operator creates unique service accounts for each TC, but the cluster role bound to the SA is shared between the operator and the pods and is created by the helm chart. It needs to be passed through from the helm chart to the `clusterrolebinding` resource so that pods use the cluster role corresponding to the operator that is reconciling it.