### PR TITLE
'add clanupendpointips resource'

### DIFF
--- a/service/controller/deleter.go
+++ b/service/controller/deleter.go
@@ -1,6 +1,8 @@
 package controller
 
 import (
+	"time"
+
 	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
 	"github.com/giantswarm/certs"
 	"github.com/giantswarm/k8sclient"
@@ -21,6 +23,8 @@ import (
 	v25 "github.com/giantswarm/kvm-operator/service/controller/v25"
 	v26 "github.com/giantswarm/kvm-operator/service/controller/v26"
 )
+
+const deleterResyncPeriod = time.Minute * 2
 
 type DeleterConfig struct {
 	CertsSearcher certs.Interface
@@ -63,6 +67,7 @@ func NewDeleter(config DeleterConfig) (*Deleter, error) {
 			K8sClient:    config.K8sClient,
 			Logger:       config.Logger,
 			ResourceSets: resourceSets,
+			ResyncPeriod: deleterResyncPeriod,
 			NewRuntimeObjectFunc: func() runtime.Object {
 				return new(v1alpha1.KVMConfig)
 			},

--- a/service/controller/v20/deleter_resource_set.go
+++ b/service/controller/v20/deleter_resource_set.go
@@ -11,6 +11,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/giantswarm/kvm-operator/service/controller/v20/key"
+	"github.com/giantswarm/kvm-operator/service/controller/v20/resource/cleanupendpointips"
 	"github.com/giantswarm/kvm-operator/service/controller/v20/resource/node"
 )
 
@@ -38,6 +39,20 @@ func NewDeleterResourceSet(config DeleterResourceSetConfig) (*controller.Resourc
 		return false
 	}
 
+	var cleanupendpointipsResource resource.Interface
+	{
+		c := cleanupendpointips.Config{
+			K8sClient:     config.K8sClient,
+			Logger:        config.Logger,
+			TenantCluster: config.TenantCluster,
+		}
+
+		cleanupendpointipsResource, err = cleanupendpointips.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
 	var nodeResource resource.Interface
 	{
 		c := node.Config{
@@ -53,6 +68,7 @@ func NewDeleterResourceSet(config DeleterResourceSetConfig) (*controller.Resourc
 	}
 
 	resources := []resource.Interface{
+		cleanupendpointipsResource,
 		nodeResource,
 	}
 

--- a/service/controller/v20/resource/cleanupendpointips/create.go
+++ b/service/controller/v20/resource/cleanupendpointips/create.go
@@ -1,0 +1,191 @@
+package cleanupendpointips
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	"github.com/giantswarm/errors/tenant"
+	"github.com/giantswarm/k8sclient"
+	"github.com/giantswarm/kvm-operator/service/controller/v20/key"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/tenantcluster"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
+	customObject, err := key.ToCustomObject(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	// At first we need to create a Kubernetes client for the reconciled tenant
+	// cluster.
+	var k8sClient kubernetes.Interface
+	{
+		r.logger.LogCtx(ctx, "level", "debug", "message", "creating Kubernetes client for tenant cluster")
+
+		i := key.ClusterID(customObject)
+		e := key.ClusterAPIEndpoint(customObject)
+
+		restConfig, err := r.tenantCluster.NewRestConfig(ctx, i, e)
+		if tenantcluster.IsTimeout(err) {
+			r.logger.LogCtx(ctx, "level", "debug", "message", "did not create Kubernetes client for tenant cluster")
+			r.logger.LogCtx(ctx, "level", "debug", "message", "waiting for certificates timed out")
+			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+
+			return nil
+		} else if err != nil {
+			return microerror.Mask(err)
+		}
+		clientsConfig := k8sclient.ClientsConfig{
+			Logger:     r.logger,
+			RestConfig: restConfig,
+		}
+		k8sClients, err := k8sclient.NewClients(clientsConfig)
+		if tenant.IsAPINotAvailable(err) {
+			r.logger.LogCtx(ctx, "level", "debug", "message", "tenant cluster is not available")
+			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+
+			return nil
+		} else if err != nil {
+			return microerror.Mask(err)
+		}
+
+		k8sClient = k8sClients.K8sClient()
+		r.logger.LogCtx(ctx, "level", "debug", "message", "created Kubernetes client for tenant cluster")
+	}
+
+	// We need to fetch the nodes being registered within the tenant cluster's
+	// Kubernetes API.
+	var nodes []corev1.Node
+	{
+		list, err := k8sClient.CoreV1().Nodes().List(metav1.ListOptions{})
+		if tenant.IsAPINotAvailable(err) {
+			r.logger.LogCtx(ctx, "level", "debug", "message", "tenant cluster is not available")
+			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+
+			return nil
+		} else if err != nil {
+			return microerror.Mask(err)
+		}
+		nodes = list.Items
+	}
+
+	// Fetch the list of pods running on the control plane. These pods serve VMs
+	// which in turn run the tenant cluster nodes.
+	var pods []corev1.Pod
+	{
+		n := key.ClusterID(customObject)
+		list, err := r.k8sClient.CoreV1().Pods(n).List(metav1.ListOptions{})
+		if err != nil {
+			return microerror.Mask(err)
+		}
+		pods = list.Items
+	}
+	// Check if all k8s-kvm pods in CP are registered as nodes in the TC.
+	if podsEqualNodes(pods, nodes) {
+		n := key.ClusterID(customObject)
+
+		{
+			masterEndpoint, err := r.k8sClient.CoreV1().Endpoints(n).Get(key.MasterID, metav1.GetOptions{})
+			if err != nil {
+				return microerror.Mask(err)
+			}
+
+			epRemoved, masterEndpoint := removeDeadIPFromEndpoints(masterEndpoint, nodes)
+			if epRemoved > 0 {
+				r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("removing %d dead ips from the master endpoints", epRemoved))
+
+				_, err = r.k8sClient.CoreV1().Endpoints(n).Update(masterEndpoint)
+				if err != nil {
+					return microerror.Mask(err)
+				}
+			}
+		}
+
+		{
+			workerEndpoint, err := r.k8sClient.CoreV1().Endpoints(n).Get(key.WorkerID, metav1.GetOptions{})
+			if err != nil {
+				return microerror.Mask(err)
+			}
+
+			epRemoved, workerEndpoint := removeDeadIPFromEndpoints(workerEndpoint, nodes)
+			if epRemoved > 0 {
+				r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("removing %d dead ips from the worker endpoints", epRemoved))
+
+				_, err = r.k8sClient.CoreV1().Endpoints(n).Update(workerEndpoint)
+				if err != nil {
+					return microerror.Mask(err)
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// podsEqualNodes check if all k8s-kvm pods in CP are registered as nodes in the TC.
+func podsEqualNodes(pods []corev1.Pod, nodes []corev1.Node) bool {
+	if len(pods) != len(nodes) {
+		return false
+	}
+
+	// sort pods and nodes by name
+	sort.Slice(pods, func(i, j int) bool {
+		return pods[i].Name < pods[j].Name
+	})
+	sort.Slice(nodes, func(i, j int) bool {
+		return pods[i].Name < pods[j].Name
+	})
+
+	for i := 0; i < len(pods); i++ {
+		if pods[i].Name != nodes[i].Name {
+			return false
+		}
+	}
+	return true
+}
+
+// removeFromEndpointAddressList is removing slice elements from `addresses` defined by `indexesToRemove`.
+func removeFromEndpointAddressList(addresses []corev1.EndpointAddress, indexesToRemove []int) []corev1.EndpointAddress {
+	var newAddresses []corev1.EndpointAddress
+	for i, ip := range addresses {
+		remove := false
+		for _, j := range indexesToRemove {
+			if i == j {
+				remove = true
+			}
+		}
+		if !remove {
+			newAddresses = append(newAddresses, ip)
+		}
+	}
+	return newAddresses
+}
+
+// removeDeadIPFromEndpoints compares endpoint IPs with current state of nodes and
+// removes any IP addresses that does not belong to any node.
+func removeDeadIPFromEndpoints(endpoints *corev1.Endpoints, nodes []corev1.Node) (int, *corev1.Endpoints) {
+	endpointAddresses := endpoints.Subsets[0].Addresses
+
+	var indexesToDelete []int
+	for i, ip := range endpointAddresses {
+		found := false
+		// check if the ip belongs to any k8s node
+		for _, node := range nodes {
+			if node.Labels["ip"] == ip.IP {
+				found = true
+				break
+			}
+		}
+		// endpoint ip does not belong to any node, lets remove it
+		if !found {
+			indexesToDelete = append(indexesToDelete, i)
+		}
+	}
+	if len(indexesToDelete) > 0 {
+		endpoints.Subsets[0].Addresses = removeFromEndpointAddressList(endpointAddresses, indexesToDelete)
+	}
+	return len(indexesToDelete), endpoints
+}

--- a/service/controller/v20/resource/cleanupendpointips/create_test.go
+++ b/service/controller/v20/resource/cleanupendpointips/create_test.go
@@ -1,0 +1,515 @@
+package cleanupendpointips
+
+import (
+	"reflect"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func Test_Resource_CleanupEndpointIPs_removeFromEndpointAddressList(t *testing.T) {
+	testCases := []struct {
+		EndpointAddressList         []corev1.EndpointAddress
+		IndexesToRemove             []int
+		ExpectedEndpointAddressList []corev1.EndpointAddress
+	}{
+		{
+			EndpointAddressList: []corev1.EndpointAddress{
+				{
+					IP: "10.0.0.1",
+				},
+				{
+					IP: "10.0.0.2",
+				},
+				{
+					IP: "10.0.0.3",
+				},
+			},
+			IndexesToRemove: []int{0},
+			ExpectedEndpointAddressList: []corev1.EndpointAddress{
+				{
+					IP: "10.0.0.2",
+				},
+				{
+					IP: "10.0.0.3",
+				},
+			},
+		},
+		{
+			EndpointAddressList: []corev1.EndpointAddress{
+				{
+					IP: "10.0.0.1",
+				},
+				{
+					IP: "10.0.0.2",
+				},
+				{
+					IP: "10.0.0.3",
+				},
+			},
+			IndexesToRemove: []int{1},
+			ExpectedEndpointAddressList: []corev1.EndpointAddress{
+				{
+					IP: "10.0.0.1",
+				},
+				{
+					IP: "10.0.0.3",
+				},
+			},
+		},
+		{
+			EndpointAddressList: []corev1.EndpointAddress{
+				{
+					IP: "10.0.0.1",
+				},
+				{
+					IP: "10.0.0.2",
+				},
+				{
+					IP: "10.0.0.3",
+				},
+			},
+			IndexesToRemove: []int{2},
+			ExpectedEndpointAddressList: []corev1.EndpointAddress{
+				{
+					IP: "10.0.0.1",
+				},
+				{
+					IP: "10.0.0.2",
+				},
+			},
+		},
+		{
+			EndpointAddressList: []corev1.EndpointAddress{
+				{
+					IP: "10.0.0.1",
+				},
+				{
+					IP: "10.0.0.2",
+				},
+				{
+					IP: "10.0.0.3",
+				},
+			},
+			IndexesToRemove: []int{0, 2},
+			ExpectedEndpointAddressList: []corev1.EndpointAddress{
+				{
+					IP: "10.0.0.2",
+				},
+			},
+		},
+		{
+			EndpointAddressList: []corev1.EndpointAddress{
+				{
+					IP: "10.0.0.1",
+				},
+				{
+					IP: "10.0.0.2",
+				},
+				{
+					IP: "10.0.0.3",
+				},
+				{
+					IP: "10.0.0.4",
+				},
+			},
+			IndexesToRemove: []int{0, 1, 2},
+			ExpectedEndpointAddressList: []corev1.EndpointAddress{
+				{
+					IP: "10.0.0.4",
+				},
+			},
+		},
+	}
+
+	for i, tc := range testCases {
+		returnedEndpointAddressList := removeFromEndpointAddressList(tc.EndpointAddressList, tc.IndexesToRemove)
+		if !reflect.DeepEqual(returnedEndpointAddressList, tc.ExpectedEndpointAddressList) {
+			t.Fatalf("case %d expected %#v got %#v", i, tc.ExpectedEndpointAddressList, returnedEndpointAddressList)
+		}
+	}
+}
+
+func Test_Resource_CleanupEndpointIPs_removeDeadIPFromEndpoints(t *testing.T) {
+	testCases := []struct {
+		Endpoints               *corev1.Endpoints
+		Nodes                   []corev1.Node
+		ExpectedDeletedEndpoint int
+		ExpectedEndpoints       *corev1.Endpoints
+	}{
+		// case 0 no dead ip
+		{
+			Endpoints: &corev1.Endpoints{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "TestService",
+					Namespace: "TestNamespace",
+				},
+				Subsets: []corev1.EndpointSubset{
+					{
+						Addresses: []corev1.EndpointAddress{
+							{
+								IP: "1.2.3.4",
+							},
+							{
+								IP: "1.1.1.1",
+							},
+						},
+					},
+				},
+			},
+			Nodes: []corev1.Node{
+				{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "testNode1",
+						Labels: map[string]string{
+							"ip": "1.2.3.4",
+						},
+					},
+				},
+				{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "testNode2",
+						Labels: map[string]string{
+							"ip": "1.1.1.1",
+						},
+					},
+				},
+			},
+			ExpectedDeletedEndpoint: 0,
+			ExpectedEndpoints: &corev1.Endpoints{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "TestService",
+					Namespace: "TestNamespace",
+				},
+				Subsets: []corev1.EndpointSubset{
+					{
+						Addresses: []corev1.EndpointAddress{
+							{
+								IP: "1.2.3.4",
+							},
+							{
+								IP: "1.1.1.1",
+							},
+						},
+					},
+				},
+			},
+		},
+		// case 1 - 1 dead ip
+		{
+			Endpoints: &corev1.Endpoints{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "TestService",
+					Namespace: "TestNamespace",
+				},
+				Subsets: []corev1.EndpointSubset{
+					{
+						Addresses: []corev1.EndpointAddress{
+							{
+								IP: "1.2.3.4",
+							},
+							{
+								IP: "1.1.1.1",
+							},
+							{
+								IP: "1.1.1.4",
+							},
+						},
+					},
+				},
+			},
+			Nodes: []corev1.Node{
+				{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "testNode1",
+						Labels: map[string]string{
+							"ip": "1.2.3.4",
+						},
+					},
+				},
+				{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "testNode2",
+						Labels: map[string]string{
+							"ip": "1.1.1.1",
+						},
+					},
+				},
+			},
+			ExpectedDeletedEndpoint: 1,
+			ExpectedEndpoints: &corev1.Endpoints{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "TestService",
+					Namespace: "TestNamespace",
+				},
+				Subsets: []corev1.EndpointSubset{
+					{
+						Addresses: []corev1.EndpointAddress{
+							{
+								IP: "1.2.3.4",
+							},
+							{
+								IP: "1.1.1.1",
+							},
+						},
+					},
+				},
+			},
+		},
+		// case 2 - 2 dead ips
+		{
+			Endpoints: &corev1.Endpoints{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "TestService",
+					Namespace: "TestNamespace",
+				},
+				Subsets: []corev1.EndpointSubset{
+					{
+						Addresses: []corev1.EndpointAddress{
+							{
+								IP: "1.2.3.4",
+							},
+							{
+								IP: "1.1.1.1",
+							},
+							{
+								IP: "1.1.1.4",
+							},
+						},
+					},
+				},
+			},
+			Nodes: []corev1.Node{
+				{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "testNode1",
+						Labels: map[string]string{
+							"ip": "1.2.3.4",
+						},
+					},
+				},
+			},
+			ExpectedDeletedEndpoint: 2,
+			ExpectedEndpoints: &corev1.Endpoints{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "TestService",
+					Namespace: "TestNamespace",
+				},
+				Subsets: []corev1.EndpointSubset{
+					{
+						Addresses: []corev1.EndpointAddress{
+							{
+								IP: "1.2.3.4",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	for i, tc := range testCases {
+		deletedEndpoints, returnedEndpoints := removeDeadIPFromEndpoints(tc.Endpoints, tc.Nodes)
+
+		if deletedEndpoints != tc.ExpectedDeletedEndpoint {
+			t.Fatalf("case %d expected %d deleted endpoint ips got %d", i, tc.ExpectedDeletedEndpoint, deletedEndpoints)
+		}
+
+		if !reflect.DeepEqual(tc.ExpectedEndpoints, returnedEndpoints) {
+			t.Fatalf("case %d expected %#v got %#v", i, tc.ExpectedEndpoints, returnedEndpoints)
+		}
+	}
+}
+func Test_Resource_CleanupEndpointIPs_podsEqualNodes(t *testing.T) {
+	testCases := []struct {
+		Pods           []corev1.Pod
+		Nodes          []corev1.Node
+		ExpectedResult bool
+	}{
+		// case 1 pods equal nodes
+		{
+			Pods: []corev1.Pod{
+				{
+
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "worker-xxxx-test-1",
+					},
+				},
+			},
+			Nodes: []corev1.Node{
+				{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "worker-xxxx-test-1",
+					},
+				},
+			},
+			ExpectedResult: true,
+		},
+		// case 2 pods equal nodes
+		{
+			Pods: []corev1.Pod{
+				{
+
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "worker-xxxx-test-1",
+					},
+				},
+				{
+
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "worker-xxxx-test-2",
+					},
+				},
+			},
+			Nodes: []corev1.Node{
+				{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "worker-xxxx-test-1",
+					},
+				},
+				{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "worker-xxxx-test-2",
+					},
+				},
+			},
+			ExpectedResult: true,
+		},
+		// case 3 pods not equal nodes - missing node
+		{
+			Pods: []corev1.Pod{
+				{
+
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "worker-xxxx-test-1",
+					},
+				},
+				{
+
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "worker-xxxx-test-2",
+					},
+				},
+			},
+			Nodes: []corev1.Node{
+				{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "worker-xxxx-test-1",
+					},
+				},
+			},
+			ExpectedResult: false,
+		},
+		// case 4 pods not equal nodes - old node in TC API
+		{
+			Pods: []corev1.Pod{
+				{
+
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "worker-xxxx-test-1",
+					},
+				},
+				{
+
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "worker-xxxx-test-2",
+					},
+				},
+			},
+			Nodes: []corev1.Node{
+				{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "worker-xxxx-test-1",
+					},
+				},
+				{
+
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "worker-xxxx-test-OLD",
+					},
+				},
+			},
+			ExpectedResult: false,
+		},
+	}
+
+	for i, tc := range testCases {
+		result := podsEqualNodes(tc.Pods, tc.Nodes)
+
+		if result != tc.ExpectedResult {
+			t.Fatalf("case %d expected %t result got %t", i, tc.ExpectedResult, result)
+		}
+	}
+}

--- a/service/controller/v20/resource/cleanupendpointips/delete.go
+++ b/service/controller/v20/resource/cleanupendpointips/delete.go
@@ -1,0 +1,9 @@
+package cleanupendpointips
+
+import (
+	"context"
+)
+
+func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
+	return nil
+}

--- a/service/controller/v20/resource/cleanupendpointips/error.go
+++ b/service/controller/v20/resource/cleanupendpointips/error.go
@@ -1,0 +1,14 @@
+package cleanupendpointips
+
+import (
+	"github.com/giantswarm/microerror"
+)
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}

--- a/service/controller/v20/resource/cleanupendpointips/resource.go
+++ b/service/controller/v20/resource/cleanupendpointips/resource.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	Name = "cleanupendpointipsv26"
+	Name = "cleanupendpointipsv20"
 )
 
 type Config struct {

--- a/service/controller/v20/resource/cleanupendpointips/resource.go
+++ b/service/controller/v20/resource/cleanupendpointips/resource.go
@@ -1,0 +1,48 @@
+package cleanupendpointips
+
+import (
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/giantswarm/tenantcluster"
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	Name = "cleanupendpointipsv26"
+)
+
+type Config struct {
+	K8sClient     kubernetes.Interface
+	Logger        micrologger.Logger
+	TenantCluster tenantcluster.Interface
+}
+
+type Resource struct {
+	k8sClient     kubernetes.Interface
+	logger        micrologger.Logger
+	tenantCluster tenantcluster.Interface
+}
+
+func New(config Config) (*Resource, error) {
+	if config.K8sClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.K8sClient must not be empty", config)
+	}
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+	if config.TenantCluster == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.TenantCluster must not be empty", config)
+	}
+
+	r := &Resource{
+		k8sClient:     config.K8sClient,
+		logger:        config.Logger,
+		tenantCluster: config.TenantCluster,
+	}
+
+	return r, nil
+}
+
+func (r *Resource) Name() string {
+	return Name
+}

--- a/service/controller/v21/deleter_resource_set.go
+++ b/service/controller/v21/deleter_resource_set.go
@@ -11,6 +11,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/giantswarm/kvm-operator/service/controller/v21/key"
+	"github.com/giantswarm/kvm-operator/service/controller/v21/resource/cleanupendpointips"
 	"github.com/giantswarm/kvm-operator/service/controller/v21/resource/node"
 )
 
@@ -38,6 +39,20 @@ func NewDeleterResourceSet(config DeleterResourceSetConfig) (*controller.Resourc
 		return false
 	}
 
+	var cleanupendpointipsResource resource.Interface
+	{
+		c := cleanupendpointips.Config{
+			K8sClient:     config.K8sClient,
+			Logger:        config.Logger,
+			TenantCluster: config.TenantCluster,
+		}
+
+		cleanupendpointipsResource, err = cleanupendpointips.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
 	var nodeResource resource.Interface
 	{
 		c := node.Config{
@@ -53,6 +68,7 @@ func NewDeleterResourceSet(config DeleterResourceSetConfig) (*controller.Resourc
 	}
 
 	resources := []resource.Interface{
+		cleanupendpointipsResource,
 		nodeResource,
 	}
 

--- a/service/controller/v21/resource/cleanupendpointips/create.go
+++ b/service/controller/v21/resource/cleanupendpointips/create.go
@@ -1,0 +1,191 @@
+package cleanupendpointips
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	"github.com/giantswarm/errors/tenant"
+	"github.com/giantswarm/k8sclient"
+	"github.com/giantswarm/kvm-operator/service/controller/v21/key"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/tenantcluster"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
+	customObject, err := key.ToCustomObject(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	// At first we need to create a Kubernetes client for the reconciled tenant
+	// cluster.
+	var k8sClient kubernetes.Interface
+	{
+		r.logger.LogCtx(ctx, "level", "debug", "message", "creating Kubernetes client for tenant cluster")
+
+		i := key.ClusterID(customObject)
+		e := key.ClusterAPIEndpoint(customObject)
+
+		restConfig, err := r.tenantCluster.NewRestConfig(ctx, i, e)
+		if tenantcluster.IsTimeout(err) {
+			r.logger.LogCtx(ctx, "level", "debug", "message", "did not create Kubernetes client for tenant cluster")
+			r.logger.LogCtx(ctx, "level", "debug", "message", "waiting for certificates timed out")
+			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+
+			return nil
+		} else if err != nil {
+			return microerror.Mask(err)
+		}
+		clientsConfig := k8sclient.ClientsConfig{
+			Logger:     r.logger,
+			RestConfig: restConfig,
+		}
+		k8sClients, err := k8sclient.NewClients(clientsConfig)
+		if tenant.IsAPINotAvailable(err) {
+			r.logger.LogCtx(ctx, "level", "debug", "message", "tenant cluster is not available")
+			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+
+			return nil
+		} else if err != nil {
+			return microerror.Mask(err)
+		}
+
+		k8sClient = k8sClients.K8sClient()
+		r.logger.LogCtx(ctx, "level", "debug", "message", "created Kubernetes client for tenant cluster")
+	}
+
+	// We need to fetch the nodes being registered within the tenant cluster's
+	// Kubernetes API.
+	var nodes []corev1.Node
+	{
+		list, err := k8sClient.CoreV1().Nodes().List(metav1.ListOptions{})
+		if tenant.IsAPINotAvailable(err) {
+			r.logger.LogCtx(ctx, "level", "debug", "message", "tenant cluster is not available")
+			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+
+			return nil
+		} else if err != nil {
+			return microerror.Mask(err)
+		}
+		nodes = list.Items
+	}
+
+	// Fetch the list of pods running on the control plane. These pods serve VMs
+	// which in turn run the tenant cluster nodes.
+	var pods []corev1.Pod
+	{
+		n := key.ClusterID(customObject)
+		list, err := r.k8sClient.CoreV1().Pods(n).List(metav1.ListOptions{})
+		if err != nil {
+			return microerror.Mask(err)
+		}
+		pods = list.Items
+	}
+	// Check if all k8s-kvm pods in CP are registered as nodes in the TC.
+	if podsEqualNodes(pods, nodes) {
+		n := key.ClusterID(customObject)
+
+		{
+			masterEndpoint, err := r.k8sClient.CoreV1().Endpoints(n).Get(key.MasterID, metav1.GetOptions{})
+			if err != nil {
+				return microerror.Mask(err)
+			}
+
+			epRemoved, masterEndpoint := removeDeadIPFromEndpoints(masterEndpoint, nodes)
+			if epRemoved > 0 {
+				r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("removing %d dead ips from the master endpoints", epRemoved))
+
+				_, err = r.k8sClient.CoreV1().Endpoints(n).Update(masterEndpoint)
+				if err != nil {
+					return microerror.Mask(err)
+				}
+			}
+		}
+
+		{
+			workerEndpoint, err := r.k8sClient.CoreV1().Endpoints(n).Get(key.WorkerID, metav1.GetOptions{})
+			if err != nil {
+				return microerror.Mask(err)
+			}
+
+			epRemoved, workerEndpoint := removeDeadIPFromEndpoints(workerEndpoint, nodes)
+			if epRemoved > 0 {
+				r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("removing %d dead ips from the worker endpoints", epRemoved))
+
+				_, err = r.k8sClient.CoreV1().Endpoints(n).Update(workerEndpoint)
+				if err != nil {
+					return microerror.Mask(err)
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// podsEqualNodes check if all k8s-kvm pods in CP are registered as nodes in the TC.
+func podsEqualNodes(pods []corev1.Pod, nodes []corev1.Node) bool {
+	if len(pods) != len(nodes) {
+		return false
+	}
+
+	// sort pods and nodes by name
+	sort.Slice(pods, func(i, j int) bool {
+		return pods[i].Name < pods[j].Name
+	})
+	sort.Slice(nodes, func(i, j int) bool {
+		return pods[i].Name < pods[j].Name
+	})
+
+	for i := 0; i < len(pods); i++ {
+		if pods[i].Name != nodes[i].Name {
+			return false
+		}
+	}
+	return true
+}
+
+// removeFromEndpointAddressList is removing slice elements from `addresses` defined by `indexesToRemove`.
+func removeFromEndpointAddressList(addresses []corev1.EndpointAddress, indexesToRemove []int) []corev1.EndpointAddress {
+	var newAddresses []corev1.EndpointAddress
+	for i, ip := range addresses {
+		remove := false
+		for _, j := range indexesToRemove {
+			if i == j {
+				remove = true
+			}
+		}
+		if !remove {
+			newAddresses = append(newAddresses, ip)
+		}
+	}
+	return newAddresses
+}
+
+// removeDeadIPFromEndpoints compares endpoint IPs with current state of nodes and
+// removes any IP addresses that does not belong to any node.
+func removeDeadIPFromEndpoints(endpoints *corev1.Endpoints, nodes []corev1.Node) (int, *corev1.Endpoints) {
+	endpointAddresses := endpoints.Subsets[0].Addresses
+
+	var indexesToDelete []int
+	for i, ip := range endpointAddresses {
+		found := false
+		// check if the ip belongs to any k8s node
+		for _, node := range nodes {
+			if node.Labels["ip"] == ip.IP {
+				found = true
+				break
+			}
+		}
+		// endpoint ip does not belong to any node, lets remove it
+		if !found {
+			indexesToDelete = append(indexesToDelete, i)
+		}
+	}
+	if len(indexesToDelete) > 0 {
+		endpoints.Subsets[0].Addresses = removeFromEndpointAddressList(endpointAddresses, indexesToDelete)
+	}
+	return len(indexesToDelete), endpoints
+}

--- a/service/controller/v21/resource/cleanupendpointips/create_test.go
+++ b/service/controller/v21/resource/cleanupendpointips/create_test.go
@@ -1,0 +1,515 @@
+package cleanupendpointips
+
+import (
+	"reflect"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func Test_Resource_CleanupEndpointIPs_removeFromEndpointAddressList(t *testing.T) {
+	testCases := []struct {
+		EndpointAddressList         []corev1.EndpointAddress
+		IndexesToRemove             []int
+		ExpectedEndpointAddressList []corev1.EndpointAddress
+	}{
+		{
+			EndpointAddressList: []corev1.EndpointAddress{
+				{
+					IP: "10.0.0.1",
+				},
+				{
+					IP: "10.0.0.2",
+				},
+				{
+					IP: "10.0.0.3",
+				},
+			},
+			IndexesToRemove: []int{0},
+			ExpectedEndpointAddressList: []corev1.EndpointAddress{
+				{
+					IP: "10.0.0.2",
+				},
+				{
+					IP: "10.0.0.3",
+				},
+			},
+		},
+		{
+			EndpointAddressList: []corev1.EndpointAddress{
+				{
+					IP: "10.0.0.1",
+				},
+				{
+					IP: "10.0.0.2",
+				},
+				{
+					IP: "10.0.0.3",
+				},
+			},
+			IndexesToRemove: []int{1},
+			ExpectedEndpointAddressList: []corev1.EndpointAddress{
+				{
+					IP: "10.0.0.1",
+				},
+				{
+					IP: "10.0.0.3",
+				},
+			},
+		},
+		{
+			EndpointAddressList: []corev1.EndpointAddress{
+				{
+					IP: "10.0.0.1",
+				},
+				{
+					IP: "10.0.0.2",
+				},
+				{
+					IP: "10.0.0.3",
+				},
+			},
+			IndexesToRemove: []int{2},
+			ExpectedEndpointAddressList: []corev1.EndpointAddress{
+				{
+					IP: "10.0.0.1",
+				},
+				{
+					IP: "10.0.0.2",
+				},
+			},
+		},
+		{
+			EndpointAddressList: []corev1.EndpointAddress{
+				{
+					IP: "10.0.0.1",
+				},
+				{
+					IP: "10.0.0.2",
+				},
+				{
+					IP: "10.0.0.3",
+				},
+			},
+			IndexesToRemove: []int{0, 2},
+			ExpectedEndpointAddressList: []corev1.EndpointAddress{
+				{
+					IP: "10.0.0.2",
+				},
+			},
+		},
+		{
+			EndpointAddressList: []corev1.EndpointAddress{
+				{
+					IP: "10.0.0.1",
+				},
+				{
+					IP: "10.0.0.2",
+				},
+				{
+					IP: "10.0.0.3",
+				},
+				{
+					IP: "10.0.0.4",
+				},
+			},
+			IndexesToRemove: []int{0, 1, 2},
+			ExpectedEndpointAddressList: []corev1.EndpointAddress{
+				{
+					IP: "10.0.0.4",
+				},
+			},
+		},
+	}
+
+	for i, tc := range testCases {
+		returnedEndpointAddressList := removeFromEndpointAddressList(tc.EndpointAddressList, tc.IndexesToRemove)
+		if !reflect.DeepEqual(returnedEndpointAddressList, tc.ExpectedEndpointAddressList) {
+			t.Fatalf("case %d expected %#v got %#v", i, tc.ExpectedEndpointAddressList, returnedEndpointAddressList)
+		}
+	}
+}
+
+func Test_Resource_CleanupEndpointIPs_removeDeadIPFromEndpoints(t *testing.T) {
+	testCases := []struct {
+		Endpoints               *corev1.Endpoints
+		Nodes                   []corev1.Node
+		ExpectedDeletedEndpoint int
+		ExpectedEndpoints       *corev1.Endpoints
+	}{
+		// case 0 no dead ip
+		{
+			Endpoints: &corev1.Endpoints{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "TestService",
+					Namespace: "TestNamespace",
+				},
+				Subsets: []corev1.EndpointSubset{
+					{
+						Addresses: []corev1.EndpointAddress{
+							{
+								IP: "1.2.3.4",
+							},
+							{
+								IP: "1.1.1.1",
+							},
+						},
+					},
+				},
+			},
+			Nodes: []corev1.Node{
+				{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "testNode1",
+						Labels: map[string]string{
+							"ip": "1.2.3.4",
+						},
+					},
+				},
+				{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "testNode2",
+						Labels: map[string]string{
+							"ip": "1.1.1.1",
+						},
+					},
+				},
+			},
+			ExpectedDeletedEndpoint: 0,
+			ExpectedEndpoints: &corev1.Endpoints{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "TestService",
+					Namespace: "TestNamespace",
+				},
+				Subsets: []corev1.EndpointSubset{
+					{
+						Addresses: []corev1.EndpointAddress{
+							{
+								IP: "1.2.3.4",
+							},
+							{
+								IP: "1.1.1.1",
+							},
+						},
+					},
+				},
+			},
+		},
+		// case 1 - 1 dead ip
+		{
+			Endpoints: &corev1.Endpoints{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "TestService",
+					Namespace: "TestNamespace",
+				},
+				Subsets: []corev1.EndpointSubset{
+					{
+						Addresses: []corev1.EndpointAddress{
+							{
+								IP: "1.2.3.4",
+							},
+							{
+								IP: "1.1.1.1",
+							},
+							{
+								IP: "1.1.1.4",
+							},
+						},
+					},
+				},
+			},
+			Nodes: []corev1.Node{
+				{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "testNode1",
+						Labels: map[string]string{
+							"ip": "1.2.3.4",
+						},
+					},
+				},
+				{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "testNode2",
+						Labels: map[string]string{
+							"ip": "1.1.1.1",
+						},
+					},
+				},
+			},
+			ExpectedDeletedEndpoint: 1,
+			ExpectedEndpoints: &corev1.Endpoints{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "TestService",
+					Namespace: "TestNamespace",
+				},
+				Subsets: []corev1.EndpointSubset{
+					{
+						Addresses: []corev1.EndpointAddress{
+							{
+								IP: "1.2.3.4",
+							},
+							{
+								IP: "1.1.1.1",
+							},
+						},
+					},
+				},
+			},
+		},
+		// case 2 - 2 dead ips
+		{
+			Endpoints: &corev1.Endpoints{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "TestService",
+					Namespace: "TestNamespace",
+				},
+				Subsets: []corev1.EndpointSubset{
+					{
+						Addresses: []corev1.EndpointAddress{
+							{
+								IP: "1.2.3.4",
+							},
+							{
+								IP: "1.1.1.1",
+							},
+							{
+								IP: "1.1.1.4",
+							},
+						},
+					},
+				},
+			},
+			Nodes: []corev1.Node{
+				{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "testNode1",
+						Labels: map[string]string{
+							"ip": "1.2.3.4",
+						},
+					},
+				},
+			},
+			ExpectedDeletedEndpoint: 2,
+			ExpectedEndpoints: &corev1.Endpoints{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "TestService",
+					Namespace: "TestNamespace",
+				},
+				Subsets: []corev1.EndpointSubset{
+					{
+						Addresses: []corev1.EndpointAddress{
+							{
+								IP: "1.2.3.4",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	for i, tc := range testCases {
+		deletedEndpoints, returnedEndpoints := removeDeadIPFromEndpoints(tc.Endpoints, tc.Nodes)
+
+		if deletedEndpoints != tc.ExpectedDeletedEndpoint {
+			t.Fatalf("case %d expected %d deleted endpoint ips got %d", i, tc.ExpectedDeletedEndpoint, deletedEndpoints)
+		}
+
+		if !reflect.DeepEqual(tc.ExpectedEndpoints, returnedEndpoints) {
+			t.Fatalf("case %d expected %#v got %#v", i, tc.ExpectedEndpoints, returnedEndpoints)
+		}
+	}
+}
+func Test_Resource_CleanupEndpointIPs_podsEqualNodes(t *testing.T) {
+	testCases := []struct {
+		Pods           []corev1.Pod
+		Nodes          []corev1.Node
+		ExpectedResult bool
+	}{
+		// case 1 pods equal nodes
+		{
+			Pods: []corev1.Pod{
+				{
+
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "worker-xxxx-test-1",
+					},
+				},
+			},
+			Nodes: []corev1.Node{
+				{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "worker-xxxx-test-1",
+					},
+				},
+			},
+			ExpectedResult: true,
+		},
+		// case 2 pods equal nodes
+		{
+			Pods: []corev1.Pod{
+				{
+
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "worker-xxxx-test-1",
+					},
+				},
+				{
+
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "worker-xxxx-test-2",
+					},
+				},
+			},
+			Nodes: []corev1.Node{
+				{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "worker-xxxx-test-1",
+					},
+				},
+				{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "worker-xxxx-test-2",
+					},
+				},
+			},
+			ExpectedResult: true,
+		},
+		// case 3 pods not equal nodes - missing node
+		{
+			Pods: []corev1.Pod{
+				{
+
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "worker-xxxx-test-1",
+					},
+				},
+				{
+
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "worker-xxxx-test-2",
+					},
+				},
+			},
+			Nodes: []corev1.Node{
+				{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "worker-xxxx-test-1",
+					},
+				},
+			},
+			ExpectedResult: false,
+		},
+		// case 4 pods not equal nodes - old node in TC API
+		{
+			Pods: []corev1.Pod{
+				{
+
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "worker-xxxx-test-1",
+					},
+				},
+				{
+
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "worker-xxxx-test-2",
+					},
+				},
+			},
+			Nodes: []corev1.Node{
+				{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "worker-xxxx-test-1",
+					},
+				},
+				{
+
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "worker-xxxx-test-OLD",
+					},
+				},
+			},
+			ExpectedResult: false,
+		},
+	}
+
+	for i, tc := range testCases {
+		result := podsEqualNodes(tc.Pods, tc.Nodes)
+
+		if result != tc.ExpectedResult {
+			t.Fatalf("case %d expected %t result got %t", i, tc.ExpectedResult, result)
+		}
+	}
+}

--- a/service/controller/v21/resource/cleanupendpointips/delete.go
+++ b/service/controller/v21/resource/cleanupendpointips/delete.go
@@ -1,0 +1,9 @@
+package cleanupendpointips
+
+import (
+	"context"
+)
+
+func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
+	return nil
+}

--- a/service/controller/v21/resource/cleanupendpointips/error.go
+++ b/service/controller/v21/resource/cleanupendpointips/error.go
@@ -1,0 +1,14 @@
+package cleanupendpointips
+
+import (
+	"github.com/giantswarm/microerror"
+)
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}

--- a/service/controller/v21/resource/cleanupendpointips/resource.go
+++ b/service/controller/v21/resource/cleanupendpointips/resource.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	Name = "cleanupendpointipsv26"
+	Name = "cleanupendpointipsv21"
 )
 
 type Config struct {

--- a/service/controller/v21/resource/cleanupendpointips/resource.go
+++ b/service/controller/v21/resource/cleanupendpointips/resource.go
@@ -1,0 +1,48 @@
+package cleanupendpointips
+
+import (
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/giantswarm/tenantcluster"
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	Name = "cleanupendpointipsv26"
+)
+
+type Config struct {
+	K8sClient     kubernetes.Interface
+	Logger        micrologger.Logger
+	TenantCluster tenantcluster.Interface
+}
+
+type Resource struct {
+	k8sClient     kubernetes.Interface
+	logger        micrologger.Logger
+	tenantCluster tenantcluster.Interface
+}
+
+func New(config Config) (*Resource, error) {
+	if config.K8sClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.K8sClient must not be empty", config)
+	}
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+	if config.TenantCluster == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.TenantCluster must not be empty", config)
+	}
+
+	r := &Resource{
+		k8sClient:     config.K8sClient,
+		logger:        config.Logger,
+		tenantCluster: config.TenantCluster,
+	}
+
+	return r, nil
+}
+
+func (r *Resource) Name() string {
+	return Name
+}

--- a/service/controller/v22/deleter_resource_set.go
+++ b/service/controller/v22/deleter_resource_set.go
@@ -11,6 +11,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/giantswarm/kvm-operator/service/controller/v22/key"
+	"github.com/giantswarm/kvm-operator/service/controller/v22/resource/cleanupendpointips"
 	"github.com/giantswarm/kvm-operator/service/controller/v22/resource/node"
 )
 
@@ -38,6 +39,20 @@ func NewDeleterResourceSet(config DeleterResourceSetConfig) (*controller.Resourc
 		return false
 	}
 
+	var cleanupendpointipsResource resource.Interface
+	{
+		c := cleanupendpointips.Config{
+			K8sClient:     config.K8sClient,
+			Logger:        config.Logger,
+			TenantCluster: config.TenantCluster,
+		}
+
+		cleanupendpointipsResource, err = cleanupendpointips.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
 	var nodeResource resource.Interface
 	{
 		c := node.Config{
@@ -53,6 +68,7 @@ func NewDeleterResourceSet(config DeleterResourceSetConfig) (*controller.Resourc
 	}
 
 	resources := []resource.Interface{
+		cleanupendpointipsResource,
 		nodeResource,
 	}
 

--- a/service/controller/v22/resource/cleanupendpointips/create.go
+++ b/service/controller/v22/resource/cleanupendpointips/create.go
@@ -1,0 +1,191 @@
+package cleanupendpointips
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	"github.com/giantswarm/errors/tenant"
+	"github.com/giantswarm/k8sclient"
+	"github.com/giantswarm/kvm-operator/service/controller/v22/key"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/tenantcluster"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
+	customObject, err := key.ToCustomObject(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	// At first we need to create a Kubernetes client for the reconciled tenant
+	// cluster.
+	var k8sClient kubernetes.Interface
+	{
+		r.logger.LogCtx(ctx, "level", "debug", "message", "creating Kubernetes client for tenant cluster")
+
+		i := key.ClusterID(customObject)
+		e := key.ClusterAPIEndpoint(customObject)
+
+		restConfig, err := r.tenantCluster.NewRestConfig(ctx, i, e)
+		if tenantcluster.IsTimeout(err) {
+			r.logger.LogCtx(ctx, "level", "debug", "message", "did not create Kubernetes client for tenant cluster")
+			r.logger.LogCtx(ctx, "level", "debug", "message", "waiting for certificates timed out")
+			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+
+			return nil
+		} else if err != nil {
+			return microerror.Mask(err)
+		}
+		clientsConfig := k8sclient.ClientsConfig{
+			Logger:     r.logger,
+			RestConfig: restConfig,
+		}
+		k8sClients, err := k8sclient.NewClients(clientsConfig)
+		if tenant.IsAPINotAvailable(err) {
+			r.logger.LogCtx(ctx, "level", "debug", "message", "tenant cluster is not available")
+			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+
+			return nil
+		} else if err != nil {
+			return microerror.Mask(err)
+		}
+
+		k8sClient = k8sClients.K8sClient()
+		r.logger.LogCtx(ctx, "level", "debug", "message", "created Kubernetes client for tenant cluster")
+	}
+
+	// We need to fetch the nodes being registered within the tenant cluster's
+	// Kubernetes API.
+	var nodes []corev1.Node
+	{
+		list, err := k8sClient.CoreV1().Nodes().List(metav1.ListOptions{})
+		if tenant.IsAPINotAvailable(err) {
+			r.logger.LogCtx(ctx, "level", "debug", "message", "tenant cluster is not available")
+			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+
+			return nil
+		} else if err != nil {
+			return microerror.Mask(err)
+		}
+		nodes = list.Items
+	}
+
+	// Fetch the list of pods running on the control plane. These pods serve VMs
+	// which in turn run the tenant cluster nodes.
+	var pods []corev1.Pod
+	{
+		n := key.ClusterID(customObject)
+		list, err := r.k8sClient.CoreV1().Pods(n).List(metav1.ListOptions{})
+		if err != nil {
+			return microerror.Mask(err)
+		}
+		pods = list.Items
+	}
+	// Check if all k8s-kvm pods in CP are registered as nodes in the TC.
+	if podsEqualNodes(pods, nodes) {
+		n := key.ClusterID(customObject)
+
+		{
+			masterEndpoint, err := r.k8sClient.CoreV1().Endpoints(n).Get(key.MasterID, metav1.GetOptions{})
+			if err != nil {
+				return microerror.Mask(err)
+			}
+
+			epRemoved, masterEndpoint := removeDeadIPFromEndpoints(masterEndpoint, nodes)
+			if epRemoved > 0 {
+				r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("removing %d dead ips from the master endpoints", epRemoved))
+
+				_, err = r.k8sClient.CoreV1().Endpoints(n).Update(masterEndpoint)
+				if err != nil {
+					return microerror.Mask(err)
+				}
+			}
+		}
+
+		{
+			workerEndpoint, err := r.k8sClient.CoreV1().Endpoints(n).Get(key.WorkerID, metav1.GetOptions{})
+			if err != nil {
+				return microerror.Mask(err)
+			}
+
+			epRemoved, workerEndpoint := removeDeadIPFromEndpoints(workerEndpoint, nodes)
+			if epRemoved > 0 {
+				r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("removing %d dead ips from the worker endpoints", epRemoved))
+
+				_, err = r.k8sClient.CoreV1().Endpoints(n).Update(workerEndpoint)
+				if err != nil {
+					return microerror.Mask(err)
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// podsEqualNodes check if all k8s-kvm pods in CP are registered as nodes in the TC.
+func podsEqualNodes(pods []corev1.Pod, nodes []corev1.Node) bool {
+	if len(pods) != len(nodes) {
+		return false
+	}
+
+	// sort pods and nodes by name
+	sort.Slice(pods, func(i, j int) bool {
+		return pods[i].Name < pods[j].Name
+	})
+	sort.Slice(nodes, func(i, j int) bool {
+		return pods[i].Name < pods[j].Name
+	})
+
+	for i := 0; i < len(pods); i++ {
+		if pods[i].Name != nodes[i].Name {
+			return false
+		}
+	}
+	return true
+}
+
+// removeFromEndpointAddressList is removing slice elements from `addresses` defined by `indexesToRemove`.
+func removeFromEndpointAddressList(addresses []corev1.EndpointAddress, indexesToRemove []int) []corev1.EndpointAddress {
+	var newAddresses []corev1.EndpointAddress
+	for i, ip := range addresses {
+		remove := false
+		for _, j := range indexesToRemove {
+			if i == j {
+				remove = true
+			}
+		}
+		if !remove {
+			newAddresses = append(newAddresses, ip)
+		}
+	}
+	return newAddresses
+}
+
+// removeDeadIPFromEndpoints compares endpoint IPs with current state of nodes and
+// removes any IP addresses that does not belong to any node.
+func removeDeadIPFromEndpoints(endpoints *corev1.Endpoints, nodes []corev1.Node) (int, *corev1.Endpoints) {
+	endpointAddresses := endpoints.Subsets[0].Addresses
+
+	var indexesToDelete []int
+	for i, ip := range endpointAddresses {
+		found := false
+		// check if the ip belongs to any k8s node
+		for _, node := range nodes {
+			if node.Labels["ip"] == ip.IP {
+				found = true
+				break
+			}
+		}
+		// endpoint ip does not belong to any node, lets remove it
+		if !found {
+			indexesToDelete = append(indexesToDelete, i)
+		}
+	}
+	if len(indexesToDelete) > 0 {
+		endpoints.Subsets[0].Addresses = removeFromEndpointAddressList(endpointAddresses, indexesToDelete)
+	}
+	return len(indexesToDelete), endpoints
+}

--- a/service/controller/v22/resource/cleanupendpointips/create_test.go
+++ b/service/controller/v22/resource/cleanupendpointips/create_test.go
@@ -1,0 +1,515 @@
+package cleanupendpointips
+
+import (
+	"reflect"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func Test_Resource_CleanupEndpointIPs_removeFromEndpointAddressList(t *testing.T) {
+	testCases := []struct {
+		EndpointAddressList         []corev1.EndpointAddress
+		IndexesToRemove             []int
+		ExpectedEndpointAddressList []corev1.EndpointAddress
+	}{
+		{
+			EndpointAddressList: []corev1.EndpointAddress{
+				{
+					IP: "10.0.0.1",
+				},
+				{
+					IP: "10.0.0.2",
+				},
+				{
+					IP: "10.0.0.3",
+				},
+			},
+			IndexesToRemove: []int{0},
+			ExpectedEndpointAddressList: []corev1.EndpointAddress{
+				{
+					IP: "10.0.0.2",
+				},
+				{
+					IP: "10.0.0.3",
+				},
+			},
+		},
+		{
+			EndpointAddressList: []corev1.EndpointAddress{
+				{
+					IP: "10.0.0.1",
+				},
+				{
+					IP: "10.0.0.2",
+				},
+				{
+					IP: "10.0.0.3",
+				},
+			},
+			IndexesToRemove: []int{1},
+			ExpectedEndpointAddressList: []corev1.EndpointAddress{
+				{
+					IP: "10.0.0.1",
+				},
+				{
+					IP: "10.0.0.3",
+				},
+			},
+		},
+		{
+			EndpointAddressList: []corev1.EndpointAddress{
+				{
+					IP: "10.0.0.1",
+				},
+				{
+					IP: "10.0.0.2",
+				},
+				{
+					IP: "10.0.0.3",
+				},
+			},
+			IndexesToRemove: []int{2},
+			ExpectedEndpointAddressList: []corev1.EndpointAddress{
+				{
+					IP: "10.0.0.1",
+				},
+				{
+					IP: "10.0.0.2",
+				},
+			},
+		},
+		{
+			EndpointAddressList: []corev1.EndpointAddress{
+				{
+					IP: "10.0.0.1",
+				},
+				{
+					IP: "10.0.0.2",
+				},
+				{
+					IP: "10.0.0.3",
+				},
+			},
+			IndexesToRemove: []int{0, 2},
+			ExpectedEndpointAddressList: []corev1.EndpointAddress{
+				{
+					IP: "10.0.0.2",
+				},
+			},
+		},
+		{
+			EndpointAddressList: []corev1.EndpointAddress{
+				{
+					IP: "10.0.0.1",
+				},
+				{
+					IP: "10.0.0.2",
+				},
+				{
+					IP: "10.0.0.3",
+				},
+				{
+					IP: "10.0.0.4",
+				},
+			},
+			IndexesToRemove: []int{0, 1, 2},
+			ExpectedEndpointAddressList: []corev1.EndpointAddress{
+				{
+					IP: "10.0.0.4",
+				},
+			},
+		},
+	}
+
+	for i, tc := range testCases {
+		returnedEndpointAddressList := removeFromEndpointAddressList(tc.EndpointAddressList, tc.IndexesToRemove)
+		if !reflect.DeepEqual(returnedEndpointAddressList, tc.ExpectedEndpointAddressList) {
+			t.Fatalf("case %d expected %#v got %#v", i, tc.ExpectedEndpointAddressList, returnedEndpointAddressList)
+		}
+	}
+}
+
+func Test_Resource_CleanupEndpointIPs_removeDeadIPFromEndpoints(t *testing.T) {
+	testCases := []struct {
+		Endpoints               *corev1.Endpoints
+		Nodes                   []corev1.Node
+		ExpectedDeletedEndpoint int
+		ExpectedEndpoints       *corev1.Endpoints
+	}{
+		// case 0 no dead ip
+		{
+			Endpoints: &corev1.Endpoints{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "TestService",
+					Namespace: "TestNamespace",
+				},
+				Subsets: []corev1.EndpointSubset{
+					{
+						Addresses: []corev1.EndpointAddress{
+							{
+								IP: "1.2.3.4",
+							},
+							{
+								IP: "1.1.1.1",
+							},
+						},
+					},
+				},
+			},
+			Nodes: []corev1.Node{
+				{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "testNode1",
+						Labels: map[string]string{
+							"ip": "1.2.3.4",
+						},
+					},
+				},
+				{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "testNode2",
+						Labels: map[string]string{
+							"ip": "1.1.1.1",
+						},
+					},
+				},
+			},
+			ExpectedDeletedEndpoint: 0,
+			ExpectedEndpoints: &corev1.Endpoints{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "TestService",
+					Namespace: "TestNamespace",
+				},
+				Subsets: []corev1.EndpointSubset{
+					{
+						Addresses: []corev1.EndpointAddress{
+							{
+								IP: "1.2.3.4",
+							},
+							{
+								IP: "1.1.1.1",
+							},
+						},
+					},
+				},
+			},
+		},
+		// case 1 - 1 dead ip
+		{
+			Endpoints: &corev1.Endpoints{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "TestService",
+					Namespace: "TestNamespace",
+				},
+				Subsets: []corev1.EndpointSubset{
+					{
+						Addresses: []corev1.EndpointAddress{
+							{
+								IP: "1.2.3.4",
+							},
+							{
+								IP: "1.1.1.1",
+							},
+							{
+								IP: "1.1.1.4",
+							},
+						},
+					},
+				},
+			},
+			Nodes: []corev1.Node{
+				{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "testNode1",
+						Labels: map[string]string{
+							"ip": "1.2.3.4",
+						},
+					},
+				},
+				{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "testNode2",
+						Labels: map[string]string{
+							"ip": "1.1.1.1",
+						},
+					},
+				},
+			},
+			ExpectedDeletedEndpoint: 1,
+			ExpectedEndpoints: &corev1.Endpoints{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "TestService",
+					Namespace: "TestNamespace",
+				},
+				Subsets: []corev1.EndpointSubset{
+					{
+						Addresses: []corev1.EndpointAddress{
+							{
+								IP: "1.2.3.4",
+							},
+							{
+								IP: "1.1.1.1",
+							},
+						},
+					},
+				},
+			},
+		},
+		// case 2 - 2 dead ips
+		{
+			Endpoints: &corev1.Endpoints{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "TestService",
+					Namespace: "TestNamespace",
+				},
+				Subsets: []corev1.EndpointSubset{
+					{
+						Addresses: []corev1.EndpointAddress{
+							{
+								IP: "1.2.3.4",
+							},
+							{
+								IP: "1.1.1.1",
+							},
+							{
+								IP: "1.1.1.4",
+							},
+						},
+					},
+				},
+			},
+			Nodes: []corev1.Node{
+				{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "testNode1",
+						Labels: map[string]string{
+							"ip": "1.2.3.4",
+						},
+					},
+				},
+			},
+			ExpectedDeletedEndpoint: 2,
+			ExpectedEndpoints: &corev1.Endpoints{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "TestService",
+					Namespace: "TestNamespace",
+				},
+				Subsets: []corev1.EndpointSubset{
+					{
+						Addresses: []corev1.EndpointAddress{
+							{
+								IP: "1.2.3.4",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	for i, tc := range testCases {
+		deletedEndpoints, returnedEndpoints := removeDeadIPFromEndpoints(tc.Endpoints, tc.Nodes)
+
+		if deletedEndpoints != tc.ExpectedDeletedEndpoint {
+			t.Fatalf("case %d expected %d deleted endpoint ips got %d", i, tc.ExpectedDeletedEndpoint, deletedEndpoints)
+		}
+
+		if !reflect.DeepEqual(tc.ExpectedEndpoints, returnedEndpoints) {
+			t.Fatalf("case %d expected %#v got %#v", i, tc.ExpectedEndpoints, returnedEndpoints)
+		}
+	}
+}
+func Test_Resource_CleanupEndpointIPs_podsEqualNodes(t *testing.T) {
+	testCases := []struct {
+		Pods           []corev1.Pod
+		Nodes          []corev1.Node
+		ExpectedResult bool
+	}{
+		// case 1 pods equal nodes
+		{
+			Pods: []corev1.Pod{
+				{
+
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "worker-xxxx-test-1",
+					},
+				},
+			},
+			Nodes: []corev1.Node{
+				{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "worker-xxxx-test-1",
+					},
+				},
+			},
+			ExpectedResult: true,
+		},
+		// case 2 pods equal nodes
+		{
+			Pods: []corev1.Pod{
+				{
+
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "worker-xxxx-test-1",
+					},
+				},
+				{
+
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "worker-xxxx-test-2",
+					},
+				},
+			},
+			Nodes: []corev1.Node{
+				{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "worker-xxxx-test-1",
+					},
+				},
+				{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "worker-xxxx-test-2",
+					},
+				},
+			},
+			ExpectedResult: true,
+		},
+		// case 3 pods not equal nodes - missing node
+		{
+			Pods: []corev1.Pod{
+				{
+
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "worker-xxxx-test-1",
+					},
+				},
+				{
+
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "worker-xxxx-test-2",
+					},
+				},
+			},
+			Nodes: []corev1.Node{
+				{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "worker-xxxx-test-1",
+					},
+				},
+			},
+			ExpectedResult: false,
+		},
+		// case 4 pods not equal nodes - old node in TC API
+		{
+			Pods: []corev1.Pod{
+				{
+
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "worker-xxxx-test-1",
+					},
+				},
+				{
+
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "worker-xxxx-test-2",
+					},
+				},
+			},
+			Nodes: []corev1.Node{
+				{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "worker-xxxx-test-1",
+					},
+				},
+				{
+
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "worker-xxxx-test-OLD",
+					},
+				},
+			},
+			ExpectedResult: false,
+		},
+	}
+
+	for i, tc := range testCases {
+		result := podsEqualNodes(tc.Pods, tc.Nodes)
+
+		if result != tc.ExpectedResult {
+			t.Fatalf("case %d expected %t result got %t", i, tc.ExpectedResult, result)
+		}
+	}
+}

--- a/service/controller/v22/resource/cleanupendpointips/delete.go
+++ b/service/controller/v22/resource/cleanupendpointips/delete.go
@@ -1,0 +1,9 @@
+package cleanupendpointips
+
+import (
+	"context"
+)
+
+func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
+	return nil
+}

--- a/service/controller/v22/resource/cleanupendpointips/error.go
+++ b/service/controller/v22/resource/cleanupendpointips/error.go
@@ -1,0 +1,14 @@
+package cleanupendpointips
+
+import (
+	"github.com/giantswarm/microerror"
+)
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}

--- a/service/controller/v22/resource/cleanupendpointips/resource.go
+++ b/service/controller/v22/resource/cleanupendpointips/resource.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	Name = "cleanupendpointipsv26"
+	Name = "cleanupendpointipsv22"
 )
 
 type Config struct {

--- a/service/controller/v22/resource/cleanupendpointips/resource.go
+++ b/service/controller/v22/resource/cleanupendpointips/resource.go
@@ -1,0 +1,48 @@
+package cleanupendpointips
+
+import (
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/giantswarm/tenantcluster"
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	Name = "cleanupendpointipsv26"
+)
+
+type Config struct {
+	K8sClient     kubernetes.Interface
+	Logger        micrologger.Logger
+	TenantCluster tenantcluster.Interface
+}
+
+type Resource struct {
+	k8sClient     kubernetes.Interface
+	logger        micrologger.Logger
+	tenantCluster tenantcluster.Interface
+}
+
+func New(config Config) (*Resource, error) {
+	if config.K8sClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.K8sClient must not be empty", config)
+	}
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+	if config.TenantCluster == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.TenantCluster must not be empty", config)
+	}
+
+	r := &Resource{
+		k8sClient:     config.K8sClient,
+		logger:        config.Logger,
+		tenantCluster: config.TenantCluster,
+	}
+
+	return r, nil
+}
+
+func (r *Resource) Name() string {
+	return Name
+}

--- a/service/controller/v23/deleter_resource_set.go
+++ b/service/controller/v23/deleter_resource_set.go
@@ -11,6 +11,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/giantswarm/kvm-operator/service/controller/v23/key"
+	"github.com/giantswarm/kvm-operator/service/controller/v23/resource/cleanupendpointips"
 	"github.com/giantswarm/kvm-operator/service/controller/v23/resource/node"
 )
 
@@ -38,6 +39,20 @@ func NewDeleterResourceSet(config DeleterResourceSetConfig) (*controller.Resourc
 		return false
 	}
 
+	var cleanupendpointipsResource resource.Interface
+	{
+		c := cleanupendpointips.Config{
+			K8sClient:     config.K8sClient,
+			Logger:        config.Logger,
+			TenantCluster: config.TenantCluster,
+		}
+
+		cleanupendpointipsResource, err = cleanupendpointips.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
 	var nodeResource resource.Interface
 	{
 		c := node.Config{
@@ -53,6 +68,7 @@ func NewDeleterResourceSet(config DeleterResourceSetConfig) (*controller.Resourc
 	}
 
 	resources := []resource.Interface{
+		cleanupendpointipsResource,
 		nodeResource,
 	}
 

--- a/service/controller/v23/resource/cleanupendpointips/create.go
+++ b/service/controller/v23/resource/cleanupendpointips/create.go
@@ -1,0 +1,191 @@
+package cleanupendpointips
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	"github.com/giantswarm/errors/tenant"
+	"github.com/giantswarm/k8sclient"
+	"github.com/giantswarm/kvm-operator/service/controller/v23/key"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/tenantcluster"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
+	customObject, err := key.ToCustomObject(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	// At first we need to create a Kubernetes client for the reconciled tenant
+	// cluster.
+	var k8sClient kubernetes.Interface
+	{
+		r.logger.LogCtx(ctx, "level", "debug", "message", "creating Kubernetes client for tenant cluster")
+
+		i := key.ClusterID(customObject)
+		e := key.ClusterAPIEndpoint(customObject)
+
+		restConfig, err := r.tenantCluster.NewRestConfig(ctx, i, e)
+		if tenantcluster.IsTimeout(err) {
+			r.logger.LogCtx(ctx, "level", "debug", "message", "did not create Kubernetes client for tenant cluster")
+			r.logger.LogCtx(ctx, "level", "debug", "message", "waiting for certificates timed out")
+			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+
+			return nil
+		} else if err != nil {
+			return microerror.Mask(err)
+		}
+		clientsConfig := k8sclient.ClientsConfig{
+			Logger:     r.logger,
+			RestConfig: restConfig,
+		}
+		k8sClients, err := k8sclient.NewClients(clientsConfig)
+		if tenant.IsAPINotAvailable(err) {
+			r.logger.LogCtx(ctx, "level", "debug", "message", "tenant cluster is not available")
+			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+
+			return nil
+		} else if err != nil {
+			return microerror.Mask(err)
+		}
+
+		k8sClient = k8sClients.K8sClient()
+		r.logger.LogCtx(ctx, "level", "debug", "message", "created Kubernetes client for tenant cluster")
+	}
+
+	// We need to fetch the nodes being registered within the tenant cluster's
+	// Kubernetes API.
+	var nodes []corev1.Node
+	{
+		list, err := k8sClient.CoreV1().Nodes().List(metav1.ListOptions{})
+		if tenant.IsAPINotAvailable(err) {
+			r.logger.LogCtx(ctx, "level", "debug", "message", "tenant cluster is not available")
+			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+
+			return nil
+		} else if err != nil {
+			return microerror.Mask(err)
+		}
+		nodes = list.Items
+	}
+
+	// Fetch the list of pods running on the control plane. These pods serve VMs
+	// which in turn run the tenant cluster nodes.
+	var pods []corev1.Pod
+	{
+		n := key.ClusterID(customObject)
+		list, err := r.k8sClient.CoreV1().Pods(n).List(metav1.ListOptions{})
+		if err != nil {
+			return microerror.Mask(err)
+		}
+		pods = list.Items
+	}
+	// Check if all k8s-kvm pods in CP are registered as nodes in the TC.
+	if podsEqualNodes(pods, nodes) {
+		n := key.ClusterID(customObject)
+
+		{
+			masterEndpoint, err := r.k8sClient.CoreV1().Endpoints(n).Get(key.MasterID, metav1.GetOptions{})
+			if err != nil {
+				return microerror.Mask(err)
+			}
+
+			epRemoved, masterEndpoint := removeDeadIPFromEndpoints(masterEndpoint, nodes)
+			if epRemoved > 0 {
+				r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("removing %d dead ips from the master endpoints", epRemoved))
+
+				_, err = r.k8sClient.CoreV1().Endpoints(n).Update(masterEndpoint)
+				if err != nil {
+					return microerror.Mask(err)
+				}
+			}
+		}
+
+		{
+			workerEndpoint, err := r.k8sClient.CoreV1().Endpoints(n).Get(key.WorkerID, metav1.GetOptions{})
+			if err != nil {
+				return microerror.Mask(err)
+			}
+
+			epRemoved, workerEndpoint := removeDeadIPFromEndpoints(workerEndpoint, nodes)
+			if epRemoved > 0 {
+				r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("removing %d dead ips from the worker endpoints", epRemoved))
+
+				_, err = r.k8sClient.CoreV1().Endpoints(n).Update(workerEndpoint)
+				if err != nil {
+					return microerror.Mask(err)
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// podsEqualNodes check if all k8s-kvm pods in CP are registered as nodes in the TC.
+func podsEqualNodes(pods []corev1.Pod, nodes []corev1.Node) bool {
+	if len(pods) != len(nodes) {
+		return false
+	}
+
+	// sort pods and nodes by name
+	sort.Slice(pods, func(i, j int) bool {
+		return pods[i].Name < pods[j].Name
+	})
+	sort.Slice(nodes, func(i, j int) bool {
+		return pods[i].Name < pods[j].Name
+	})
+
+	for i := 0; i < len(pods); i++ {
+		if pods[i].Name != nodes[i].Name {
+			return false
+		}
+	}
+	return true
+}
+
+// removeFromEndpointAddressList is removing slice elements from `addresses` defined by `indexesToRemove`.
+func removeFromEndpointAddressList(addresses []corev1.EndpointAddress, indexesToRemove []int) []corev1.EndpointAddress {
+	var newAddresses []corev1.EndpointAddress
+	for i, ip := range addresses {
+		remove := false
+		for _, j := range indexesToRemove {
+			if i == j {
+				remove = true
+			}
+		}
+		if !remove {
+			newAddresses = append(newAddresses, ip)
+		}
+	}
+	return newAddresses
+}
+
+// removeDeadIPFromEndpoints compares endpoint IPs with current state of nodes and
+// removes any IP addresses that does not belong to any node.
+func removeDeadIPFromEndpoints(endpoints *corev1.Endpoints, nodes []corev1.Node) (int, *corev1.Endpoints) {
+	endpointAddresses := endpoints.Subsets[0].Addresses
+
+	var indexesToDelete []int
+	for i, ip := range endpointAddresses {
+		found := false
+		// check if the ip belongs to any k8s node
+		for _, node := range nodes {
+			if node.Labels["ip"] == ip.IP {
+				found = true
+				break
+			}
+		}
+		// endpoint ip does not belong to any node, lets remove it
+		if !found {
+			indexesToDelete = append(indexesToDelete, i)
+		}
+	}
+	if len(indexesToDelete) > 0 {
+		endpoints.Subsets[0].Addresses = removeFromEndpointAddressList(endpointAddresses, indexesToDelete)
+	}
+	return len(indexesToDelete), endpoints
+}

--- a/service/controller/v23/resource/cleanupendpointips/create_test.go
+++ b/service/controller/v23/resource/cleanupendpointips/create_test.go
@@ -1,0 +1,515 @@
+package cleanupendpointips
+
+import (
+	"reflect"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func Test_Resource_CleanupEndpointIPs_removeFromEndpointAddressList(t *testing.T) {
+	testCases := []struct {
+		EndpointAddressList         []corev1.EndpointAddress
+		IndexesToRemove             []int
+		ExpectedEndpointAddressList []corev1.EndpointAddress
+	}{
+		{
+			EndpointAddressList: []corev1.EndpointAddress{
+				{
+					IP: "10.0.0.1",
+				},
+				{
+					IP: "10.0.0.2",
+				},
+				{
+					IP: "10.0.0.3",
+				},
+			},
+			IndexesToRemove: []int{0},
+			ExpectedEndpointAddressList: []corev1.EndpointAddress{
+				{
+					IP: "10.0.0.2",
+				},
+				{
+					IP: "10.0.0.3",
+				},
+			},
+		},
+		{
+			EndpointAddressList: []corev1.EndpointAddress{
+				{
+					IP: "10.0.0.1",
+				},
+				{
+					IP: "10.0.0.2",
+				},
+				{
+					IP: "10.0.0.3",
+				},
+			},
+			IndexesToRemove: []int{1},
+			ExpectedEndpointAddressList: []corev1.EndpointAddress{
+				{
+					IP: "10.0.0.1",
+				},
+				{
+					IP: "10.0.0.3",
+				},
+			},
+		},
+		{
+			EndpointAddressList: []corev1.EndpointAddress{
+				{
+					IP: "10.0.0.1",
+				},
+				{
+					IP: "10.0.0.2",
+				},
+				{
+					IP: "10.0.0.3",
+				},
+			},
+			IndexesToRemove: []int{2},
+			ExpectedEndpointAddressList: []corev1.EndpointAddress{
+				{
+					IP: "10.0.0.1",
+				},
+				{
+					IP: "10.0.0.2",
+				},
+			},
+		},
+		{
+			EndpointAddressList: []corev1.EndpointAddress{
+				{
+					IP: "10.0.0.1",
+				},
+				{
+					IP: "10.0.0.2",
+				},
+				{
+					IP: "10.0.0.3",
+				},
+			},
+			IndexesToRemove: []int{0, 2},
+			ExpectedEndpointAddressList: []corev1.EndpointAddress{
+				{
+					IP: "10.0.0.2",
+				},
+			},
+		},
+		{
+			EndpointAddressList: []corev1.EndpointAddress{
+				{
+					IP: "10.0.0.1",
+				},
+				{
+					IP: "10.0.0.2",
+				},
+				{
+					IP: "10.0.0.3",
+				},
+				{
+					IP: "10.0.0.4",
+				},
+			},
+			IndexesToRemove: []int{0, 1, 2},
+			ExpectedEndpointAddressList: []corev1.EndpointAddress{
+				{
+					IP: "10.0.0.4",
+				},
+			},
+		},
+	}
+
+	for i, tc := range testCases {
+		returnedEndpointAddressList := removeFromEndpointAddressList(tc.EndpointAddressList, tc.IndexesToRemove)
+		if !reflect.DeepEqual(returnedEndpointAddressList, tc.ExpectedEndpointAddressList) {
+			t.Fatalf("case %d expected %#v got %#v", i, tc.ExpectedEndpointAddressList, returnedEndpointAddressList)
+		}
+	}
+}
+
+func Test_Resource_CleanupEndpointIPs_removeDeadIPFromEndpoints(t *testing.T) {
+	testCases := []struct {
+		Endpoints               *corev1.Endpoints
+		Nodes                   []corev1.Node
+		ExpectedDeletedEndpoint int
+		ExpectedEndpoints       *corev1.Endpoints
+	}{
+		// case 0 no dead ip
+		{
+			Endpoints: &corev1.Endpoints{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "TestService",
+					Namespace: "TestNamespace",
+				},
+				Subsets: []corev1.EndpointSubset{
+					{
+						Addresses: []corev1.EndpointAddress{
+							{
+								IP: "1.2.3.4",
+							},
+							{
+								IP: "1.1.1.1",
+							},
+						},
+					},
+				},
+			},
+			Nodes: []corev1.Node{
+				{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "testNode1",
+						Labels: map[string]string{
+							"ip": "1.2.3.4",
+						},
+					},
+				},
+				{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "testNode2",
+						Labels: map[string]string{
+							"ip": "1.1.1.1",
+						},
+					},
+				},
+			},
+			ExpectedDeletedEndpoint: 0,
+			ExpectedEndpoints: &corev1.Endpoints{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "TestService",
+					Namespace: "TestNamespace",
+				},
+				Subsets: []corev1.EndpointSubset{
+					{
+						Addresses: []corev1.EndpointAddress{
+							{
+								IP: "1.2.3.4",
+							},
+							{
+								IP: "1.1.1.1",
+							},
+						},
+					},
+				},
+			},
+		},
+		// case 1 - 1 dead ip
+		{
+			Endpoints: &corev1.Endpoints{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "TestService",
+					Namespace: "TestNamespace",
+				},
+				Subsets: []corev1.EndpointSubset{
+					{
+						Addresses: []corev1.EndpointAddress{
+							{
+								IP: "1.2.3.4",
+							},
+							{
+								IP: "1.1.1.1",
+							},
+							{
+								IP: "1.1.1.4",
+							},
+						},
+					},
+				},
+			},
+			Nodes: []corev1.Node{
+				{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "testNode1",
+						Labels: map[string]string{
+							"ip": "1.2.3.4",
+						},
+					},
+				},
+				{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "testNode2",
+						Labels: map[string]string{
+							"ip": "1.1.1.1",
+						},
+					},
+				},
+			},
+			ExpectedDeletedEndpoint: 1,
+			ExpectedEndpoints: &corev1.Endpoints{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "TestService",
+					Namespace: "TestNamespace",
+				},
+				Subsets: []corev1.EndpointSubset{
+					{
+						Addresses: []corev1.EndpointAddress{
+							{
+								IP: "1.2.3.4",
+							},
+							{
+								IP: "1.1.1.1",
+							},
+						},
+					},
+				},
+			},
+		},
+		// case 2 - 2 dead ips
+		{
+			Endpoints: &corev1.Endpoints{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "TestService",
+					Namespace: "TestNamespace",
+				},
+				Subsets: []corev1.EndpointSubset{
+					{
+						Addresses: []corev1.EndpointAddress{
+							{
+								IP: "1.2.3.4",
+							},
+							{
+								IP: "1.1.1.1",
+							},
+							{
+								IP: "1.1.1.4",
+							},
+						},
+					},
+				},
+			},
+			Nodes: []corev1.Node{
+				{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "testNode1",
+						Labels: map[string]string{
+							"ip": "1.2.3.4",
+						},
+					},
+				},
+			},
+			ExpectedDeletedEndpoint: 2,
+			ExpectedEndpoints: &corev1.Endpoints{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "TestService",
+					Namespace: "TestNamespace",
+				},
+				Subsets: []corev1.EndpointSubset{
+					{
+						Addresses: []corev1.EndpointAddress{
+							{
+								IP: "1.2.3.4",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	for i, tc := range testCases {
+		deletedEndpoints, returnedEndpoints := removeDeadIPFromEndpoints(tc.Endpoints, tc.Nodes)
+
+		if deletedEndpoints != tc.ExpectedDeletedEndpoint {
+			t.Fatalf("case %d expected %d deleted endpoint ips got %d", i, tc.ExpectedDeletedEndpoint, deletedEndpoints)
+		}
+
+		if !reflect.DeepEqual(tc.ExpectedEndpoints, returnedEndpoints) {
+			t.Fatalf("case %d expected %#v got %#v", i, tc.ExpectedEndpoints, returnedEndpoints)
+		}
+	}
+}
+func Test_Resource_CleanupEndpointIPs_podsEqualNodes(t *testing.T) {
+	testCases := []struct {
+		Pods           []corev1.Pod
+		Nodes          []corev1.Node
+		ExpectedResult bool
+	}{
+		// case 1 pods equal nodes
+		{
+			Pods: []corev1.Pod{
+				{
+
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "worker-xxxx-test-1",
+					},
+				},
+			},
+			Nodes: []corev1.Node{
+				{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "worker-xxxx-test-1",
+					},
+				},
+			},
+			ExpectedResult: true,
+		},
+		// case 2 pods equal nodes
+		{
+			Pods: []corev1.Pod{
+				{
+
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "worker-xxxx-test-1",
+					},
+				},
+				{
+
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "worker-xxxx-test-2",
+					},
+				},
+			},
+			Nodes: []corev1.Node{
+				{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "worker-xxxx-test-1",
+					},
+				},
+				{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "worker-xxxx-test-2",
+					},
+				},
+			},
+			ExpectedResult: true,
+		},
+		// case 3 pods not equal nodes - missing node
+		{
+			Pods: []corev1.Pod{
+				{
+
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "worker-xxxx-test-1",
+					},
+				},
+				{
+
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "worker-xxxx-test-2",
+					},
+				},
+			},
+			Nodes: []corev1.Node{
+				{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "worker-xxxx-test-1",
+					},
+				},
+			},
+			ExpectedResult: false,
+		},
+		// case 4 pods not equal nodes - old node in TC API
+		{
+			Pods: []corev1.Pod{
+				{
+
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "worker-xxxx-test-1",
+					},
+				},
+				{
+
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "worker-xxxx-test-2",
+					},
+				},
+			},
+			Nodes: []corev1.Node{
+				{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "worker-xxxx-test-1",
+					},
+				},
+				{
+
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "worker-xxxx-test-OLD",
+					},
+				},
+			},
+			ExpectedResult: false,
+		},
+	}
+
+	for i, tc := range testCases {
+		result := podsEqualNodes(tc.Pods, tc.Nodes)
+
+		if result != tc.ExpectedResult {
+			t.Fatalf("case %d expected %t result got %t", i, tc.ExpectedResult, result)
+		}
+	}
+}

--- a/service/controller/v23/resource/cleanupendpointips/delete.go
+++ b/service/controller/v23/resource/cleanupendpointips/delete.go
@@ -1,0 +1,9 @@
+package cleanupendpointips
+
+import (
+	"context"
+)
+
+func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
+	return nil
+}

--- a/service/controller/v23/resource/cleanupendpointips/error.go
+++ b/service/controller/v23/resource/cleanupendpointips/error.go
@@ -1,0 +1,14 @@
+package cleanupendpointips
+
+import (
+	"github.com/giantswarm/microerror"
+)
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}

--- a/service/controller/v23/resource/cleanupendpointips/resource.go
+++ b/service/controller/v23/resource/cleanupendpointips/resource.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	Name = "cleanupendpointipsv26"
+	Name = "cleanupendpointipsv23"
 )
 
 type Config struct {

--- a/service/controller/v23/resource/cleanupendpointips/resource.go
+++ b/service/controller/v23/resource/cleanupendpointips/resource.go
@@ -1,0 +1,48 @@
+package cleanupendpointips
+
+import (
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/giantswarm/tenantcluster"
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	Name = "cleanupendpointipsv26"
+)
+
+type Config struct {
+	K8sClient     kubernetes.Interface
+	Logger        micrologger.Logger
+	TenantCluster tenantcluster.Interface
+}
+
+type Resource struct {
+	k8sClient     kubernetes.Interface
+	logger        micrologger.Logger
+	tenantCluster tenantcluster.Interface
+}
+
+func New(config Config) (*Resource, error) {
+	if config.K8sClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.K8sClient must not be empty", config)
+	}
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+	if config.TenantCluster == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.TenantCluster must not be empty", config)
+	}
+
+	r := &Resource{
+		k8sClient:     config.K8sClient,
+		logger:        config.Logger,
+		tenantCluster: config.TenantCluster,
+	}
+
+	return r, nil
+}
+
+func (r *Resource) Name() string {
+	return Name
+}

--- a/service/controller/v23patch1/deleter_resource_set.go
+++ b/service/controller/v23patch1/deleter_resource_set.go
@@ -11,6 +11,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/giantswarm/kvm-operator/service/controller/v23patch1/key"
+	"github.com/giantswarm/kvm-operator/service/controller/v23patch1/resource/cleanupendpointips"
 	"github.com/giantswarm/kvm-operator/service/controller/v23patch1/resource/node"
 )
 
@@ -38,6 +39,20 @@ func NewDeleterResourceSet(config DeleterResourceSetConfig) (*controller.Resourc
 		return false
 	}
 
+	var cleanupendpointipsResource resource.Interface
+	{
+		c := cleanupendpointips.Config{
+			K8sClient:     config.K8sClient,
+			Logger:        config.Logger,
+			TenantCluster: config.TenantCluster,
+		}
+
+		cleanupendpointipsResource, err = cleanupendpointips.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
 	var nodeResource resource.Interface
 	{
 		c := node.Config{
@@ -53,6 +68,7 @@ func NewDeleterResourceSet(config DeleterResourceSetConfig) (*controller.Resourc
 	}
 
 	resources := []resource.Interface{
+		cleanupendpointipsResource,
 		nodeResource,
 	}
 

--- a/service/controller/v23patch1/resource/cleanupendpointips/create.go
+++ b/service/controller/v23patch1/resource/cleanupendpointips/create.go
@@ -1,0 +1,191 @@
+package cleanupendpointips
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	"github.com/giantswarm/errors/tenant"
+	"github.com/giantswarm/k8sclient"
+	"github.com/giantswarm/kvm-operator/service/controller/v23patch1/key"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/tenantcluster"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
+	customObject, err := key.ToCustomObject(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	// At first we need to create a Kubernetes client for the reconciled tenant
+	// cluster.
+	var k8sClient kubernetes.Interface
+	{
+		r.logger.LogCtx(ctx, "level", "debug", "message", "creating Kubernetes client for tenant cluster")
+
+		i := key.ClusterID(customObject)
+		e := key.ClusterAPIEndpoint(customObject)
+
+		restConfig, err := r.tenantCluster.NewRestConfig(ctx, i, e)
+		if tenantcluster.IsTimeout(err) {
+			r.logger.LogCtx(ctx, "level", "debug", "message", "did not create Kubernetes client for tenant cluster")
+			r.logger.LogCtx(ctx, "level", "debug", "message", "waiting for certificates timed out")
+			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+
+			return nil
+		} else if err != nil {
+			return microerror.Mask(err)
+		}
+		clientsConfig := k8sclient.ClientsConfig{
+			Logger:     r.logger,
+			RestConfig: restConfig,
+		}
+		k8sClients, err := k8sclient.NewClients(clientsConfig)
+		if tenant.IsAPINotAvailable(err) {
+			r.logger.LogCtx(ctx, "level", "debug", "message", "tenant cluster is not available")
+			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+
+			return nil
+		} else if err != nil {
+			return microerror.Mask(err)
+		}
+
+		k8sClient = k8sClients.K8sClient()
+		r.logger.LogCtx(ctx, "level", "debug", "message", "created Kubernetes client for tenant cluster")
+	}
+
+	// We need to fetch the nodes being registered within the tenant cluster's
+	// Kubernetes API.
+	var nodes []corev1.Node
+	{
+		list, err := k8sClient.CoreV1().Nodes().List(metav1.ListOptions{})
+		if tenant.IsAPINotAvailable(err) {
+			r.logger.LogCtx(ctx, "level", "debug", "message", "tenant cluster is not available")
+			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+
+			return nil
+		} else if err != nil {
+			return microerror.Mask(err)
+		}
+		nodes = list.Items
+	}
+
+	// Fetch the list of pods running on the control plane. These pods serve VMs
+	// which in turn run the tenant cluster nodes.
+	var pods []corev1.Pod
+	{
+		n := key.ClusterID(customObject)
+		list, err := r.k8sClient.CoreV1().Pods(n).List(metav1.ListOptions{})
+		if err != nil {
+			return microerror.Mask(err)
+		}
+		pods = list.Items
+	}
+	// Check if all k8s-kvm pods in CP are registered as nodes in the TC.
+	if podsEqualNodes(pods, nodes) {
+		n := key.ClusterID(customObject)
+
+		{
+			masterEndpoint, err := r.k8sClient.CoreV1().Endpoints(n).Get(key.MasterID, metav1.GetOptions{})
+			if err != nil {
+				return microerror.Mask(err)
+			}
+
+			epRemoved, masterEndpoint := removeDeadIPFromEndpoints(masterEndpoint, nodes)
+			if epRemoved > 0 {
+				r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("removing %d dead ips from the master endpoints", epRemoved))
+
+				_, err = r.k8sClient.CoreV1().Endpoints(n).Update(masterEndpoint)
+				if err != nil {
+					return microerror.Mask(err)
+				}
+			}
+		}
+
+		{
+			workerEndpoint, err := r.k8sClient.CoreV1().Endpoints(n).Get(key.WorkerID, metav1.GetOptions{})
+			if err != nil {
+				return microerror.Mask(err)
+			}
+
+			epRemoved, workerEndpoint := removeDeadIPFromEndpoints(workerEndpoint, nodes)
+			if epRemoved > 0 {
+				r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("removing %d dead ips from the worker endpoints", epRemoved))
+
+				_, err = r.k8sClient.CoreV1().Endpoints(n).Update(workerEndpoint)
+				if err != nil {
+					return microerror.Mask(err)
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// podsEqualNodes check if all k8s-kvm pods in CP are registered as nodes in the TC.
+func podsEqualNodes(pods []corev1.Pod, nodes []corev1.Node) bool {
+	if len(pods) != len(nodes) {
+		return false
+	}
+
+	// sort pods and nodes by name
+	sort.Slice(pods, func(i, j int) bool {
+		return pods[i].Name < pods[j].Name
+	})
+	sort.Slice(nodes, func(i, j int) bool {
+		return pods[i].Name < pods[j].Name
+	})
+
+	for i := 0; i < len(pods); i++ {
+		if pods[i].Name != nodes[i].Name {
+			return false
+		}
+	}
+	return true
+}
+
+// removeFromEndpointAddressList is removing slice elements from `addresses` defined by `indexesToRemove`.
+func removeFromEndpointAddressList(addresses []corev1.EndpointAddress, indexesToRemove []int) []corev1.EndpointAddress {
+	var newAddresses []corev1.EndpointAddress
+	for i, ip := range addresses {
+		remove := false
+		for _, j := range indexesToRemove {
+			if i == j {
+				remove = true
+			}
+		}
+		if !remove {
+			newAddresses = append(newAddresses, ip)
+		}
+	}
+	return newAddresses
+}
+
+// removeDeadIPFromEndpoints compares endpoint IPs with current state of nodes and
+// removes any IP addresses that does not belong to any node.
+func removeDeadIPFromEndpoints(endpoints *corev1.Endpoints, nodes []corev1.Node) (int, *corev1.Endpoints) {
+	endpointAddresses := endpoints.Subsets[0].Addresses
+
+	var indexesToDelete []int
+	for i, ip := range endpointAddresses {
+		found := false
+		// check if the ip belongs to any k8s node
+		for _, node := range nodes {
+			if node.Labels["ip"] == ip.IP {
+				found = true
+				break
+			}
+		}
+		// endpoint ip does not belong to any node, lets remove it
+		if !found {
+			indexesToDelete = append(indexesToDelete, i)
+		}
+	}
+	if len(indexesToDelete) > 0 {
+		endpoints.Subsets[0].Addresses = removeFromEndpointAddressList(endpointAddresses, indexesToDelete)
+	}
+	return len(indexesToDelete), endpoints
+}

--- a/service/controller/v23patch1/resource/cleanupendpointips/create_test.go
+++ b/service/controller/v23patch1/resource/cleanupendpointips/create_test.go
@@ -1,0 +1,515 @@
+package cleanupendpointips
+
+import (
+	"reflect"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func Test_Resource_CleanupEndpointIPs_removeFromEndpointAddressList(t *testing.T) {
+	testCases := []struct {
+		EndpointAddressList         []corev1.EndpointAddress
+		IndexesToRemove             []int
+		ExpectedEndpointAddressList []corev1.EndpointAddress
+	}{
+		{
+			EndpointAddressList: []corev1.EndpointAddress{
+				{
+					IP: "10.0.0.1",
+				},
+				{
+					IP: "10.0.0.2",
+				},
+				{
+					IP: "10.0.0.3",
+				},
+			},
+			IndexesToRemove: []int{0},
+			ExpectedEndpointAddressList: []corev1.EndpointAddress{
+				{
+					IP: "10.0.0.2",
+				},
+				{
+					IP: "10.0.0.3",
+				},
+			},
+		},
+		{
+			EndpointAddressList: []corev1.EndpointAddress{
+				{
+					IP: "10.0.0.1",
+				},
+				{
+					IP: "10.0.0.2",
+				},
+				{
+					IP: "10.0.0.3",
+				},
+			},
+			IndexesToRemove: []int{1},
+			ExpectedEndpointAddressList: []corev1.EndpointAddress{
+				{
+					IP: "10.0.0.1",
+				},
+				{
+					IP: "10.0.0.3",
+				},
+			},
+		},
+		{
+			EndpointAddressList: []corev1.EndpointAddress{
+				{
+					IP: "10.0.0.1",
+				},
+				{
+					IP: "10.0.0.2",
+				},
+				{
+					IP: "10.0.0.3",
+				},
+			},
+			IndexesToRemove: []int{2},
+			ExpectedEndpointAddressList: []corev1.EndpointAddress{
+				{
+					IP: "10.0.0.1",
+				},
+				{
+					IP: "10.0.0.2",
+				},
+			},
+		},
+		{
+			EndpointAddressList: []corev1.EndpointAddress{
+				{
+					IP: "10.0.0.1",
+				},
+				{
+					IP: "10.0.0.2",
+				},
+				{
+					IP: "10.0.0.3",
+				},
+			},
+			IndexesToRemove: []int{0, 2},
+			ExpectedEndpointAddressList: []corev1.EndpointAddress{
+				{
+					IP: "10.0.0.2",
+				},
+			},
+		},
+		{
+			EndpointAddressList: []corev1.EndpointAddress{
+				{
+					IP: "10.0.0.1",
+				},
+				{
+					IP: "10.0.0.2",
+				},
+				{
+					IP: "10.0.0.3",
+				},
+				{
+					IP: "10.0.0.4",
+				},
+			},
+			IndexesToRemove: []int{0, 1, 2},
+			ExpectedEndpointAddressList: []corev1.EndpointAddress{
+				{
+					IP: "10.0.0.4",
+				},
+			},
+		},
+	}
+
+	for i, tc := range testCases {
+		returnedEndpointAddressList := removeFromEndpointAddressList(tc.EndpointAddressList, tc.IndexesToRemove)
+		if !reflect.DeepEqual(returnedEndpointAddressList, tc.ExpectedEndpointAddressList) {
+			t.Fatalf("case %d expected %#v got %#v", i, tc.ExpectedEndpointAddressList, returnedEndpointAddressList)
+		}
+	}
+}
+
+func Test_Resource_CleanupEndpointIPs_removeDeadIPFromEndpoints(t *testing.T) {
+	testCases := []struct {
+		Endpoints               *corev1.Endpoints
+		Nodes                   []corev1.Node
+		ExpectedDeletedEndpoint int
+		ExpectedEndpoints       *corev1.Endpoints
+	}{
+		// case 0 no dead ip
+		{
+			Endpoints: &corev1.Endpoints{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "TestService",
+					Namespace: "TestNamespace",
+				},
+				Subsets: []corev1.EndpointSubset{
+					{
+						Addresses: []corev1.EndpointAddress{
+							{
+								IP: "1.2.3.4",
+							},
+							{
+								IP: "1.1.1.1",
+							},
+						},
+					},
+				},
+			},
+			Nodes: []corev1.Node{
+				{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "testNode1",
+						Labels: map[string]string{
+							"ip": "1.2.3.4",
+						},
+					},
+				},
+				{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "testNode2",
+						Labels: map[string]string{
+							"ip": "1.1.1.1",
+						},
+					},
+				},
+			},
+			ExpectedDeletedEndpoint: 0,
+			ExpectedEndpoints: &corev1.Endpoints{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "TestService",
+					Namespace: "TestNamespace",
+				},
+				Subsets: []corev1.EndpointSubset{
+					{
+						Addresses: []corev1.EndpointAddress{
+							{
+								IP: "1.2.3.4",
+							},
+							{
+								IP: "1.1.1.1",
+							},
+						},
+					},
+				},
+			},
+		},
+		// case 1 - 1 dead ip
+		{
+			Endpoints: &corev1.Endpoints{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "TestService",
+					Namespace: "TestNamespace",
+				},
+				Subsets: []corev1.EndpointSubset{
+					{
+						Addresses: []corev1.EndpointAddress{
+							{
+								IP: "1.2.3.4",
+							},
+							{
+								IP: "1.1.1.1",
+							},
+							{
+								IP: "1.1.1.4",
+							},
+						},
+					},
+				},
+			},
+			Nodes: []corev1.Node{
+				{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "testNode1",
+						Labels: map[string]string{
+							"ip": "1.2.3.4",
+						},
+					},
+				},
+				{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "testNode2",
+						Labels: map[string]string{
+							"ip": "1.1.1.1",
+						},
+					},
+				},
+			},
+			ExpectedDeletedEndpoint: 1,
+			ExpectedEndpoints: &corev1.Endpoints{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "TestService",
+					Namespace: "TestNamespace",
+				},
+				Subsets: []corev1.EndpointSubset{
+					{
+						Addresses: []corev1.EndpointAddress{
+							{
+								IP: "1.2.3.4",
+							},
+							{
+								IP: "1.1.1.1",
+							},
+						},
+					},
+				},
+			},
+		},
+		// case 2 - 2 dead ips
+		{
+			Endpoints: &corev1.Endpoints{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "TestService",
+					Namespace: "TestNamespace",
+				},
+				Subsets: []corev1.EndpointSubset{
+					{
+						Addresses: []corev1.EndpointAddress{
+							{
+								IP: "1.2.3.4",
+							},
+							{
+								IP: "1.1.1.1",
+							},
+							{
+								IP: "1.1.1.4",
+							},
+						},
+					},
+				},
+			},
+			Nodes: []corev1.Node{
+				{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "testNode1",
+						Labels: map[string]string{
+							"ip": "1.2.3.4",
+						},
+					},
+				},
+			},
+			ExpectedDeletedEndpoint: 2,
+			ExpectedEndpoints: &corev1.Endpoints{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "TestService",
+					Namespace: "TestNamespace",
+				},
+				Subsets: []corev1.EndpointSubset{
+					{
+						Addresses: []corev1.EndpointAddress{
+							{
+								IP: "1.2.3.4",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	for i, tc := range testCases {
+		deletedEndpoints, returnedEndpoints := removeDeadIPFromEndpoints(tc.Endpoints, tc.Nodes)
+
+		if deletedEndpoints != tc.ExpectedDeletedEndpoint {
+			t.Fatalf("case %d expected %d deleted endpoint ips got %d", i, tc.ExpectedDeletedEndpoint, deletedEndpoints)
+		}
+
+		if !reflect.DeepEqual(tc.ExpectedEndpoints, returnedEndpoints) {
+			t.Fatalf("case %d expected %#v got %#v", i, tc.ExpectedEndpoints, returnedEndpoints)
+		}
+	}
+}
+func Test_Resource_CleanupEndpointIPs_podsEqualNodes(t *testing.T) {
+	testCases := []struct {
+		Pods           []corev1.Pod
+		Nodes          []corev1.Node
+		ExpectedResult bool
+	}{
+		// case 1 pods equal nodes
+		{
+			Pods: []corev1.Pod{
+				{
+
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "worker-xxxx-test-1",
+					},
+				},
+			},
+			Nodes: []corev1.Node{
+				{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "worker-xxxx-test-1",
+					},
+				},
+			},
+			ExpectedResult: true,
+		},
+		// case 2 pods equal nodes
+		{
+			Pods: []corev1.Pod{
+				{
+
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "worker-xxxx-test-1",
+					},
+				},
+				{
+
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "worker-xxxx-test-2",
+					},
+				},
+			},
+			Nodes: []corev1.Node{
+				{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "worker-xxxx-test-1",
+					},
+				},
+				{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "worker-xxxx-test-2",
+					},
+				},
+			},
+			ExpectedResult: true,
+		},
+		// case 3 pods not equal nodes - missing node
+		{
+			Pods: []corev1.Pod{
+				{
+
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "worker-xxxx-test-1",
+					},
+				},
+				{
+
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "worker-xxxx-test-2",
+					},
+				},
+			},
+			Nodes: []corev1.Node{
+				{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "worker-xxxx-test-1",
+					},
+				},
+			},
+			ExpectedResult: false,
+		},
+		// case 4 pods not equal nodes - old node in TC API
+		{
+			Pods: []corev1.Pod{
+				{
+
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "worker-xxxx-test-1",
+					},
+				},
+				{
+
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "worker-xxxx-test-2",
+					},
+				},
+			},
+			Nodes: []corev1.Node{
+				{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "worker-xxxx-test-1",
+					},
+				},
+				{
+
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "worker-xxxx-test-OLD",
+					},
+				},
+			},
+			ExpectedResult: false,
+		},
+	}
+
+	for i, tc := range testCases {
+		result := podsEqualNodes(tc.Pods, tc.Nodes)
+
+		if result != tc.ExpectedResult {
+			t.Fatalf("case %d expected %t result got %t", i, tc.ExpectedResult, result)
+		}
+	}
+}

--- a/service/controller/v23patch1/resource/cleanupendpointips/delete.go
+++ b/service/controller/v23patch1/resource/cleanupendpointips/delete.go
@@ -1,0 +1,9 @@
+package cleanupendpointips
+
+import (
+	"context"
+)
+
+func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
+	return nil
+}

--- a/service/controller/v23patch1/resource/cleanupendpointips/error.go
+++ b/service/controller/v23patch1/resource/cleanupendpointips/error.go
@@ -1,0 +1,14 @@
+package cleanupendpointips
+
+import (
+	"github.com/giantswarm/microerror"
+)
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}

--- a/service/controller/v23patch1/resource/cleanupendpointips/resource.go
+++ b/service/controller/v23patch1/resource/cleanupendpointips/resource.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	Name = "cleanupendpointipsv26"
+	Name = "cleanupendpointipsv23patch1"
 )
 
 type Config struct {

--- a/service/controller/v23patch1/resource/cleanupendpointips/resource.go
+++ b/service/controller/v23patch1/resource/cleanupendpointips/resource.go
@@ -1,0 +1,48 @@
+package cleanupendpointips
+
+import (
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/giantswarm/tenantcluster"
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	Name = "cleanupendpointipsv26"
+)
+
+type Config struct {
+	K8sClient     kubernetes.Interface
+	Logger        micrologger.Logger
+	TenantCluster tenantcluster.Interface
+}
+
+type Resource struct {
+	k8sClient     kubernetes.Interface
+	logger        micrologger.Logger
+	tenantCluster tenantcluster.Interface
+}
+
+func New(config Config) (*Resource, error) {
+	if config.K8sClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.K8sClient must not be empty", config)
+	}
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+	if config.TenantCluster == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.TenantCluster must not be empty", config)
+	}
+
+	r := &Resource{
+		k8sClient:     config.K8sClient,
+		logger:        config.Logger,
+		tenantCluster: config.TenantCluster,
+	}
+
+	return r, nil
+}
+
+func (r *Resource) Name() string {
+	return Name
+}

--- a/service/controller/v24/deleter_resource_set.go
+++ b/service/controller/v24/deleter_resource_set.go
@@ -11,6 +11,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/giantswarm/kvm-operator/service/controller/v24/key"
+	"github.com/giantswarm/kvm-operator/service/controller/v24/resource/cleanupendpointips"
 	"github.com/giantswarm/kvm-operator/service/controller/v24/resource/node"
 )
 
@@ -38,6 +39,20 @@ func NewDeleterResourceSet(config DeleterResourceSetConfig) (*controller.Resourc
 		return false
 	}
 
+	var cleanupendpointipsResource resource.Interface
+	{
+		c := cleanupendpointips.Config{
+			K8sClient:     config.K8sClient,
+			Logger:        config.Logger,
+			TenantCluster: config.TenantCluster,
+		}
+
+		cleanupendpointipsResource, err = cleanupendpointips.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
 	var nodeResource resource.Interface
 	{
 		c := node.Config{
@@ -53,6 +68,7 @@ func NewDeleterResourceSet(config DeleterResourceSetConfig) (*controller.Resourc
 	}
 
 	resources := []resource.Interface{
+		cleanupendpointipsResource,
 		nodeResource,
 	}
 

--- a/service/controller/v24/resource/cleanupendpointips/create.go
+++ b/service/controller/v24/resource/cleanupendpointips/create.go
@@ -1,0 +1,191 @@
+package cleanupendpointips
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	"github.com/giantswarm/errors/tenant"
+	"github.com/giantswarm/k8sclient"
+	"github.com/giantswarm/kvm-operator/service/controller/v24/key"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/tenantcluster"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
+	customObject, err := key.ToCustomObject(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	// At first we need to create a Kubernetes client for the reconciled tenant
+	// cluster.
+	var k8sClient kubernetes.Interface
+	{
+		r.logger.LogCtx(ctx, "level", "debug", "message", "creating Kubernetes client for tenant cluster")
+
+		i := key.ClusterID(customObject)
+		e := key.ClusterAPIEndpoint(customObject)
+
+		restConfig, err := r.tenantCluster.NewRestConfig(ctx, i, e)
+		if tenantcluster.IsTimeout(err) {
+			r.logger.LogCtx(ctx, "level", "debug", "message", "did not create Kubernetes client for tenant cluster")
+			r.logger.LogCtx(ctx, "level", "debug", "message", "waiting for certificates timed out")
+			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+
+			return nil
+		} else if err != nil {
+			return microerror.Mask(err)
+		}
+		clientsConfig := k8sclient.ClientsConfig{
+			Logger:     r.logger,
+			RestConfig: restConfig,
+		}
+		k8sClients, err := k8sclient.NewClients(clientsConfig)
+		if tenant.IsAPINotAvailable(err) {
+			r.logger.LogCtx(ctx, "level", "debug", "message", "tenant cluster is not available")
+			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+
+			return nil
+		} else if err != nil {
+			return microerror.Mask(err)
+		}
+
+		k8sClient = k8sClients.K8sClient()
+		r.logger.LogCtx(ctx, "level", "debug", "message", "created Kubernetes client for tenant cluster")
+	}
+
+	// We need to fetch the nodes being registered within the tenant cluster's
+	// Kubernetes API.
+	var nodes []corev1.Node
+	{
+		list, err := k8sClient.CoreV1().Nodes().List(metav1.ListOptions{})
+		if tenant.IsAPINotAvailable(err) {
+			r.logger.LogCtx(ctx, "level", "debug", "message", "tenant cluster is not available")
+			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+
+			return nil
+		} else if err != nil {
+			return microerror.Mask(err)
+		}
+		nodes = list.Items
+	}
+
+	// Fetch the list of pods running on the control plane. These pods serve VMs
+	// which in turn run the tenant cluster nodes.
+	var pods []corev1.Pod
+	{
+		n := key.ClusterID(customObject)
+		list, err := r.k8sClient.CoreV1().Pods(n).List(metav1.ListOptions{})
+		if err != nil {
+			return microerror.Mask(err)
+		}
+		pods = list.Items
+	}
+	// Check if all k8s-kvm pods in CP are registered as nodes in the TC.
+	if podsEqualNodes(pods, nodes) {
+		n := key.ClusterID(customObject)
+
+		{
+			masterEndpoint, err := r.k8sClient.CoreV1().Endpoints(n).Get(key.MasterID, metav1.GetOptions{})
+			if err != nil {
+				return microerror.Mask(err)
+			}
+
+			epRemoved, masterEndpoint := removeDeadIPFromEndpoints(masterEndpoint, nodes)
+			if epRemoved > 0 {
+				r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("removing %d dead ips from the master endpoints", epRemoved))
+
+				_, err = r.k8sClient.CoreV1().Endpoints(n).Update(masterEndpoint)
+				if err != nil {
+					return microerror.Mask(err)
+				}
+			}
+		}
+
+		{
+			workerEndpoint, err := r.k8sClient.CoreV1().Endpoints(n).Get(key.WorkerID, metav1.GetOptions{})
+			if err != nil {
+				return microerror.Mask(err)
+			}
+
+			epRemoved, workerEndpoint := removeDeadIPFromEndpoints(workerEndpoint, nodes)
+			if epRemoved > 0 {
+				r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("removing %d dead ips from the worker endpoints", epRemoved))
+
+				_, err = r.k8sClient.CoreV1().Endpoints(n).Update(workerEndpoint)
+				if err != nil {
+					return microerror.Mask(err)
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// podsEqualNodes check if all k8s-kvm pods in CP are registered as nodes in the TC.
+func podsEqualNodes(pods []corev1.Pod, nodes []corev1.Node) bool {
+	if len(pods) != len(nodes) {
+		return false
+	}
+
+	// sort pods and nodes by name
+	sort.Slice(pods, func(i, j int) bool {
+		return pods[i].Name < pods[j].Name
+	})
+	sort.Slice(nodes, func(i, j int) bool {
+		return pods[i].Name < pods[j].Name
+	})
+
+	for i := 0; i < len(pods); i++ {
+		if pods[i].Name != nodes[i].Name {
+			return false
+		}
+	}
+	return true
+}
+
+// removeFromEndpointAddressList is removing slice elements from `addresses` defined by `indexesToRemove`.
+func removeFromEndpointAddressList(addresses []corev1.EndpointAddress, indexesToRemove []int) []corev1.EndpointAddress {
+	var newAddresses []corev1.EndpointAddress
+	for i, ip := range addresses {
+		remove := false
+		for _, j := range indexesToRemove {
+			if i == j {
+				remove = true
+			}
+		}
+		if !remove {
+			newAddresses = append(newAddresses, ip)
+		}
+	}
+	return newAddresses
+}
+
+// removeDeadIPFromEndpoints compares endpoint IPs with current state of nodes and
+// removes any IP addresses that does not belong to any node.
+func removeDeadIPFromEndpoints(endpoints *corev1.Endpoints, nodes []corev1.Node) (int, *corev1.Endpoints) {
+	endpointAddresses := endpoints.Subsets[0].Addresses
+
+	var indexesToDelete []int
+	for i, ip := range endpointAddresses {
+		found := false
+		// check if the ip belongs to any k8s node
+		for _, node := range nodes {
+			if node.Labels["ip"] == ip.IP {
+				found = true
+				break
+			}
+		}
+		// endpoint ip does not belong to any node, lets remove it
+		if !found {
+			indexesToDelete = append(indexesToDelete, i)
+		}
+	}
+	if len(indexesToDelete) > 0 {
+		endpoints.Subsets[0].Addresses = removeFromEndpointAddressList(endpointAddresses, indexesToDelete)
+	}
+	return len(indexesToDelete), endpoints
+}

--- a/service/controller/v24/resource/cleanupendpointips/create_test.go
+++ b/service/controller/v24/resource/cleanupendpointips/create_test.go
@@ -1,0 +1,515 @@
+package cleanupendpointips
+
+import (
+	"reflect"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func Test_Resource_CleanupEndpointIPs_removeFromEndpointAddressList(t *testing.T) {
+	testCases := []struct {
+		EndpointAddressList         []corev1.EndpointAddress
+		IndexesToRemove             []int
+		ExpectedEndpointAddressList []corev1.EndpointAddress
+	}{
+		{
+			EndpointAddressList: []corev1.EndpointAddress{
+				{
+					IP: "10.0.0.1",
+				},
+				{
+					IP: "10.0.0.2",
+				},
+				{
+					IP: "10.0.0.3",
+				},
+			},
+			IndexesToRemove: []int{0},
+			ExpectedEndpointAddressList: []corev1.EndpointAddress{
+				{
+					IP: "10.0.0.2",
+				},
+				{
+					IP: "10.0.0.3",
+				},
+			},
+		},
+		{
+			EndpointAddressList: []corev1.EndpointAddress{
+				{
+					IP: "10.0.0.1",
+				},
+				{
+					IP: "10.0.0.2",
+				},
+				{
+					IP: "10.0.0.3",
+				},
+			},
+			IndexesToRemove: []int{1},
+			ExpectedEndpointAddressList: []corev1.EndpointAddress{
+				{
+					IP: "10.0.0.1",
+				},
+				{
+					IP: "10.0.0.3",
+				},
+			},
+		},
+		{
+			EndpointAddressList: []corev1.EndpointAddress{
+				{
+					IP: "10.0.0.1",
+				},
+				{
+					IP: "10.0.0.2",
+				},
+				{
+					IP: "10.0.0.3",
+				},
+			},
+			IndexesToRemove: []int{2},
+			ExpectedEndpointAddressList: []corev1.EndpointAddress{
+				{
+					IP: "10.0.0.1",
+				},
+				{
+					IP: "10.0.0.2",
+				},
+			},
+		},
+		{
+			EndpointAddressList: []corev1.EndpointAddress{
+				{
+					IP: "10.0.0.1",
+				},
+				{
+					IP: "10.0.0.2",
+				},
+				{
+					IP: "10.0.0.3",
+				},
+			},
+			IndexesToRemove: []int{0, 2},
+			ExpectedEndpointAddressList: []corev1.EndpointAddress{
+				{
+					IP: "10.0.0.2",
+				},
+			},
+		},
+		{
+			EndpointAddressList: []corev1.EndpointAddress{
+				{
+					IP: "10.0.0.1",
+				},
+				{
+					IP: "10.0.0.2",
+				},
+				{
+					IP: "10.0.0.3",
+				},
+				{
+					IP: "10.0.0.4",
+				},
+			},
+			IndexesToRemove: []int{0, 1, 2},
+			ExpectedEndpointAddressList: []corev1.EndpointAddress{
+				{
+					IP: "10.0.0.4",
+				},
+			},
+		},
+	}
+
+	for i, tc := range testCases {
+		returnedEndpointAddressList := removeFromEndpointAddressList(tc.EndpointAddressList, tc.IndexesToRemove)
+		if !reflect.DeepEqual(returnedEndpointAddressList, tc.ExpectedEndpointAddressList) {
+			t.Fatalf("case %d expected %#v got %#v", i, tc.ExpectedEndpointAddressList, returnedEndpointAddressList)
+		}
+	}
+}
+
+func Test_Resource_CleanupEndpointIPs_removeDeadIPFromEndpoints(t *testing.T) {
+	testCases := []struct {
+		Endpoints               *corev1.Endpoints
+		Nodes                   []corev1.Node
+		ExpectedDeletedEndpoint int
+		ExpectedEndpoints       *corev1.Endpoints
+	}{
+		// case 0 no dead ip
+		{
+			Endpoints: &corev1.Endpoints{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "TestService",
+					Namespace: "TestNamespace",
+				},
+				Subsets: []corev1.EndpointSubset{
+					{
+						Addresses: []corev1.EndpointAddress{
+							{
+								IP: "1.2.3.4",
+							},
+							{
+								IP: "1.1.1.1",
+							},
+						},
+					},
+				},
+			},
+			Nodes: []corev1.Node{
+				{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "testNode1",
+						Labels: map[string]string{
+							"ip": "1.2.3.4",
+						},
+					},
+				},
+				{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "testNode2",
+						Labels: map[string]string{
+							"ip": "1.1.1.1",
+						},
+					},
+				},
+			},
+			ExpectedDeletedEndpoint: 0,
+			ExpectedEndpoints: &corev1.Endpoints{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "TestService",
+					Namespace: "TestNamespace",
+				},
+				Subsets: []corev1.EndpointSubset{
+					{
+						Addresses: []corev1.EndpointAddress{
+							{
+								IP: "1.2.3.4",
+							},
+							{
+								IP: "1.1.1.1",
+							},
+						},
+					},
+				},
+			},
+		},
+		// case 1 - 1 dead ip
+		{
+			Endpoints: &corev1.Endpoints{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "TestService",
+					Namespace: "TestNamespace",
+				},
+				Subsets: []corev1.EndpointSubset{
+					{
+						Addresses: []corev1.EndpointAddress{
+							{
+								IP: "1.2.3.4",
+							},
+							{
+								IP: "1.1.1.1",
+							},
+							{
+								IP: "1.1.1.4",
+							},
+						},
+					},
+				},
+			},
+			Nodes: []corev1.Node{
+				{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "testNode1",
+						Labels: map[string]string{
+							"ip": "1.2.3.4",
+						},
+					},
+				},
+				{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "testNode2",
+						Labels: map[string]string{
+							"ip": "1.1.1.1",
+						},
+					},
+				},
+			},
+			ExpectedDeletedEndpoint: 1,
+			ExpectedEndpoints: &corev1.Endpoints{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "TestService",
+					Namespace: "TestNamespace",
+				},
+				Subsets: []corev1.EndpointSubset{
+					{
+						Addresses: []corev1.EndpointAddress{
+							{
+								IP: "1.2.3.4",
+							},
+							{
+								IP: "1.1.1.1",
+							},
+						},
+					},
+				},
+			},
+		},
+		// case 2 - 2 dead ips
+		{
+			Endpoints: &corev1.Endpoints{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "TestService",
+					Namespace: "TestNamespace",
+				},
+				Subsets: []corev1.EndpointSubset{
+					{
+						Addresses: []corev1.EndpointAddress{
+							{
+								IP: "1.2.3.4",
+							},
+							{
+								IP: "1.1.1.1",
+							},
+							{
+								IP: "1.1.1.4",
+							},
+						},
+					},
+				},
+			},
+			Nodes: []corev1.Node{
+				{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "testNode1",
+						Labels: map[string]string{
+							"ip": "1.2.3.4",
+						},
+					},
+				},
+			},
+			ExpectedDeletedEndpoint: 2,
+			ExpectedEndpoints: &corev1.Endpoints{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "TestService",
+					Namespace: "TestNamespace",
+				},
+				Subsets: []corev1.EndpointSubset{
+					{
+						Addresses: []corev1.EndpointAddress{
+							{
+								IP: "1.2.3.4",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	for i, tc := range testCases {
+		deletedEndpoints, returnedEndpoints := removeDeadIPFromEndpoints(tc.Endpoints, tc.Nodes)
+
+		if deletedEndpoints != tc.ExpectedDeletedEndpoint {
+			t.Fatalf("case %d expected %d deleted endpoint ips got %d", i, tc.ExpectedDeletedEndpoint, deletedEndpoints)
+		}
+
+		if !reflect.DeepEqual(tc.ExpectedEndpoints, returnedEndpoints) {
+			t.Fatalf("case %d expected %#v got %#v", i, tc.ExpectedEndpoints, returnedEndpoints)
+		}
+	}
+}
+func Test_Resource_CleanupEndpointIPs_podsEqualNodes(t *testing.T) {
+	testCases := []struct {
+		Pods           []corev1.Pod
+		Nodes          []corev1.Node
+		ExpectedResult bool
+	}{
+		// case 1 pods equal nodes
+		{
+			Pods: []corev1.Pod{
+				{
+
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "worker-xxxx-test-1",
+					},
+				},
+			},
+			Nodes: []corev1.Node{
+				{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "worker-xxxx-test-1",
+					},
+				},
+			},
+			ExpectedResult: true,
+		},
+		// case 2 pods equal nodes
+		{
+			Pods: []corev1.Pod{
+				{
+
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "worker-xxxx-test-1",
+					},
+				},
+				{
+
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "worker-xxxx-test-2",
+					},
+				},
+			},
+			Nodes: []corev1.Node{
+				{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "worker-xxxx-test-1",
+					},
+				},
+				{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "worker-xxxx-test-2",
+					},
+				},
+			},
+			ExpectedResult: true,
+		},
+		// case 3 pods not equal nodes - missing node
+		{
+			Pods: []corev1.Pod{
+				{
+
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "worker-xxxx-test-1",
+					},
+				},
+				{
+
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "worker-xxxx-test-2",
+					},
+				},
+			},
+			Nodes: []corev1.Node{
+				{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "worker-xxxx-test-1",
+					},
+				},
+			},
+			ExpectedResult: false,
+		},
+		// case 4 pods not equal nodes - old node in TC API
+		{
+			Pods: []corev1.Pod{
+				{
+
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "worker-xxxx-test-1",
+					},
+				},
+				{
+
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "worker-xxxx-test-2",
+					},
+				},
+			},
+			Nodes: []corev1.Node{
+				{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "worker-xxxx-test-1",
+					},
+				},
+				{
+
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "worker-xxxx-test-OLD",
+					},
+				},
+			},
+			ExpectedResult: false,
+		},
+	}
+
+	for i, tc := range testCases {
+		result := podsEqualNodes(tc.Pods, tc.Nodes)
+
+		if result != tc.ExpectedResult {
+			t.Fatalf("case %d expected %t result got %t", i, tc.ExpectedResult, result)
+		}
+	}
+}

--- a/service/controller/v24/resource/cleanupendpointips/delete.go
+++ b/service/controller/v24/resource/cleanupendpointips/delete.go
@@ -1,0 +1,9 @@
+package cleanupendpointips
+
+import (
+	"context"
+)
+
+func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
+	return nil
+}

--- a/service/controller/v24/resource/cleanupendpointips/error.go
+++ b/service/controller/v24/resource/cleanupendpointips/error.go
@@ -1,0 +1,14 @@
+package cleanupendpointips
+
+import (
+	"github.com/giantswarm/microerror"
+)
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}

--- a/service/controller/v24/resource/cleanupendpointips/resource.go
+++ b/service/controller/v24/resource/cleanupendpointips/resource.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	Name = "cleanupendpointipsv26"
+	Name = "cleanupendpointipsv24"
 )
 
 type Config struct {

--- a/service/controller/v24/resource/cleanupendpointips/resource.go
+++ b/service/controller/v24/resource/cleanupendpointips/resource.go
@@ -1,0 +1,48 @@
+package cleanupendpointips
+
+import (
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/giantswarm/tenantcluster"
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	Name = "cleanupendpointipsv26"
+)
+
+type Config struct {
+	K8sClient     kubernetes.Interface
+	Logger        micrologger.Logger
+	TenantCluster tenantcluster.Interface
+}
+
+type Resource struct {
+	k8sClient     kubernetes.Interface
+	logger        micrologger.Logger
+	tenantCluster tenantcluster.Interface
+}
+
+func New(config Config) (*Resource, error) {
+	if config.K8sClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.K8sClient must not be empty", config)
+	}
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+	if config.TenantCluster == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.TenantCluster must not be empty", config)
+	}
+
+	r := &Resource{
+		k8sClient:     config.K8sClient,
+		logger:        config.Logger,
+		tenantCluster: config.TenantCluster,
+	}
+
+	return r, nil
+}
+
+func (r *Resource) Name() string {
+	return Name
+}

--- a/service/controller/v24patch1/deleter_resource_set.go
+++ b/service/controller/v24patch1/deleter_resource_set.go
@@ -11,6 +11,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/giantswarm/kvm-operator/service/controller/v24patch1/key"
+	"github.com/giantswarm/kvm-operator/service/controller/v24patch1/resource/cleanupendpointips"
 	"github.com/giantswarm/kvm-operator/service/controller/v24patch1/resource/node"
 )
 
@@ -38,6 +39,20 @@ func NewDeleterResourceSet(config DeleterResourceSetConfig) (*controller.Resourc
 		return false
 	}
 
+	var cleanupendpointipsResource resource.Interface
+	{
+		c := cleanupendpointips.Config{
+			K8sClient:     config.K8sClient,
+			Logger:        config.Logger,
+			TenantCluster: config.TenantCluster,
+		}
+
+		cleanupendpointipsResource, err = cleanupendpointips.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
 	var nodeResource resource.Interface
 	{
 		c := node.Config{
@@ -53,6 +68,7 @@ func NewDeleterResourceSet(config DeleterResourceSetConfig) (*controller.Resourc
 	}
 
 	resources := []resource.Interface{
+		cleanupendpointipsResource,
 		nodeResource,
 	}
 

--- a/service/controller/v24patch1/resource/cleanupendpointips/create.go
+++ b/service/controller/v24patch1/resource/cleanupendpointips/create.go
@@ -1,0 +1,191 @@
+package cleanupendpointips
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	"github.com/giantswarm/errors/tenant"
+	"github.com/giantswarm/k8sclient"
+	"github.com/giantswarm/kvm-operator/service/controller/v24patch1/key"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/tenantcluster"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
+	customObject, err := key.ToCustomObject(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	// At first we need to create a Kubernetes client for the reconciled tenant
+	// cluster.
+	var k8sClient kubernetes.Interface
+	{
+		r.logger.LogCtx(ctx, "level", "debug", "message", "creating Kubernetes client for tenant cluster")
+
+		i := key.ClusterID(customObject)
+		e := key.ClusterAPIEndpoint(customObject)
+
+		restConfig, err := r.tenantCluster.NewRestConfig(ctx, i, e)
+		if tenantcluster.IsTimeout(err) {
+			r.logger.LogCtx(ctx, "level", "debug", "message", "did not create Kubernetes client for tenant cluster")
+			r.logger.LogCtx(ctx, "level", "debug", "message", "waiting for certificates timed out")
+			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+
+			return nil
+		} else if err != nil {
+			return microerror.Mask(err)
+		}
+		clientsConfig := k8sclient.ClientsConfig{
+			Logger:     r.logger,
+			RestConfig: restConfig,
+		}
+		k8sClients, err := k8sclient.NewClients(clientsConfig)
+		if tenant.IsAPINotAvailable(err) {
+			r.logger.LogCtx(ctx, "level", "debug", "message", "tenant cluster is not available")
+			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+
+			return nil
+		} else if err != nil {
+			return microerror.Mask(err)
+		}
+
+		k8sClient = k8sClients.K8sClient()
+		r.logger.LogCtx(ctx, "level", "debug", "message", "created Kubernetes client for tenant cluster")
+	}
+
+	// We need to fetch the nodes being registered within the tenant cluster's
+	// Kubernetes API.
+	var nodes []corev1.Node
+	{
+		list, err := k8sClient.CoreV1().Nodes().List(metav1.ListOptions{})
+		if tenant.IsAPINotAvailable(err) {
+			r.logger.LogCtx(ctx, "level", "debug", "message", "tenant cluster is not available")
+			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+
+			return nil
+		} else if err != nil {
+			return microerror.Mask(err)
+		}
+		nodes = list.Items
+	}
+
+	// Fetch the list of pods running on the control plane. These pods serve VMs
+	// which in turn run the tenant cluster nodes.
+	var pods []corev1.Pod
+	{
+		n := key.ClusterID(customObject)
+		list, err := r.k8sClient.CoreV1().Pods(n).List(metav1.ListOptions{})
+		if err != nil {
+			return microerror.Mask(err)
+		}
+		pods = list.Items
+	}
+	// Check if all k8s-kvm pods in CP are registered as nodes in the TC.
+	if podsEqualNodes(pods, nodes) {
+		n := key.ClusterID(customObject)
+
+		{
+			masterEndpoint, err := r.k8sClient.CoreV1().Endpoints(n).Get(key.MasterID, metav1.GetOptions{})
+			if err != nil {
+				return microerror.Mask(err)
+			}
+
+			epRemoved, masterEndpoint := removeDeadIPFromEndpoints(masterEndpoint, nodes)
+			if epRemoved > 0 {
+				r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("removing %d dead ips from the master endpoints", epRemoved))
+
+				_, err = r.k8sClient.CoreV1().Endpoints(n).Update(masterEndpoint)
+				if err != nil {
+					return microerror.Mask(err)
+				}
+			}
+		}
+
+		{
+			workerEndpoint, err := r.k8sClient.CoreV1().Endpoints(n).Get(key.WorkerID, metav1.GetOptions{})
+			if err != nil {
+				return microerror.Mask(err)
+			}
+
+			epRemoved, workerEndpoint := removeDeadIPFromEndpoints(workerEndpoint, nodes)
+			if epRemoved > 0 {
+				r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("removing %d dead ips from the worker endpoints", epRemoved))
+
+				_, err = r.k8sClient.CoreV1().Endpoints(n).Update(workerEndpoint)
+				if err != nil {
+					return microerror.Mask(err)
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// podsEqualNodes check if all k8s-kvm pods in CP are registered as nodes in the TC.
+func podsEqualNodes(pods []corev1.Pod, nodes []corev1.Node) bool {
+	if len(pods) != len(nodes) {
+		return false
+	}
+
+	// sort pods and nodes by name
+	sort.Slice(pods, func(i, j int) bool {
+		return pods[i].Name < pods[j].Name
+	})
+	sort.Slice(nodes, func(i, j int) bool {
+		return pods[i].Name < pods[j].Name
+	})
+
+	for i := 0; i < len(pods); i++ {
+		if pods[i].Name != nodes[i].Name {
+			return false
+		}
+	}
+	return true
+}
+
+// removeFromEndpointAddressList is removing slice elements from `addresses` defined by `indexesToRemove`.
+func removeFromEndpointAddressList(addresses []corev1.EndpointAddress, indexesToRemove []int) []corev1.EndpointAddress {
+	var newAddresses []corev1.EndpointAddress
+	for i, ip := range addresses {
+		remove := false
+		for _, j := range indexesToRemove {
+			if i == j {
+				remove = true
+			}
+		}
+		if !remove {
+			newAddresses = append(newAddresses, ip)
+		}
+	}
+	return newAddresses
+}
+
+// removeDeadIPFromEndpoints compares endpoint IPs with current state of nodes and
+// removes any IP addresses that does not belong to any node.
+func removeDeadIPFromEndpoints(endpoints *corev1.Endpoints, nodes []corev1.Node) (int, *corev1.Endpoints) {
+	endpointAddresses := endpoints.Subsets[0].Addresses
+
+	var indexesToDelete []int
+	for i, ip := range endpointAddresses {
+		found := false
+		// check if the ip belongs to any k8s node
+		for _, node := range nodes {
+			if node.Labels["ip"] == ip.IP {
+				found = true
+				break
+			}
+		}
+		// endpoint ip does not belong to any node, lets remove it
+		if !found {
+			indexesToDelete = append(indexesToDelete, i)
+		}
+	}
+	if len(indexesToDelete) > 0 {
+		endpoints.Subsets[0].Addresses = removeFromEndpointAddressList(endpointAddresses, indexesToDelete)
+	}
+	return len(indexesToDelete), endpoints
+}

--- a/service/controller/v24patch1/resource/cleanupendpointips/create_test.go
+++ b/service/controller/v24patch1/resource/cleanupendpointips/create_test.go
@@ -1,0 +1,515 @@
+package cleanupendpointips
+
+import (
+	"reflect"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func Test_Resource_CleanupEndpointIPs_removeFromEndpointAddressList(t *testing.T) {
+	testCases := []struct {
+		EndpointAddressList         []corev1.EndpointAddress
+		IndexesToRemove             []int
+		ExpectedEndpointAddressList []corev1.EndpointAddress
+	}{
+		{
+			EndpointAddressList: []corev1.EndpointAddress{
+				{
+					IP: "10.0.0.1",
+				},
+				{
+					IP: "10.0.0.2",
+				},
+				{
+					IP: "10.0.0.3",
+				},
+			},
+			IndexesToRemove: []int{0},
+			ExpectedEndpointAddressList: []corev1.EndpointAddress{
+				{
+					IP: "10.0.0.2",
+				},
+				{
+					IP: "10.0.0.3",
+				},
+			},
+		},
+		{
+			EndpointAddressList: []corev1.EndpointAddress{
+				{
+					IP: "10.0.0.1",
+				},
+				{
+					IP: "10.0.0.2",
+				},
+				{
+					IP: "10.0.0.3",
+				},
+			},
+			IndexesToRemove: []int{1},
+			ExpectedEndpointAddressList: []corev1.EndpointAddress{
+				{
+					IP: "10.0.0.1",
+				},
+				{
+					IP: "10.0.0.3",
+				},
+			},
+		},
+		{
+			EndpointAddressList: []corev1.EndpointAddress{
+				{
+					IP: "10.0.0.1",
+				},
+				{
+					IP: "10.0.0.2",
+				},
+				{
+					IP: "10.0.0.3",
+				},
+			},
+			IndexesToRemove: []int{2},
+			ExpectedEndpointAddressList: []corev1.EndpointAddress{
+				{
+					IP: "10.0.0.1",
+				},
+				{
+					IP: "10.0.0.2",
+				},
+			},
+		},
+		{
+			EndpointAddressList: []corev1.EndpointAddress{
+				{
+					IP: "10.0.0.1",
+				},
+				{
+					IP: "10.0.0.2",
+				},
+				{
+					IP: "10.0.0.3",
+				},
+			},
+			IndexesToRemove: []int{0, 2},
+			ExpectedEndpointAddressList: []corev1.EndpointAddress{
+				{
+					IP: "10.0.0.2",
+				},
+			},
+		},
+		{
+			EndpointAddressList: []corev1.EndpointAddress{
+				{
+					IP: "10.0.0.1",
+				},
+				{
+					IP: "10.0.0.2",
+				},
+				{
+					IP: "10.0.0.3",
+				},
+				{
+					IP: "10.0.0.4",
+				},
+			},
+			IndexesToRemove: []int{0, 1, 2},
+			ExpectedEndpointAddressList: []corev1.EndpointAddress{
+				{
+					IP: "10.0.0.4",
+				},
+			},
+		},
+	}
+
+	for i, tc := range testCases {
+		returnedEndpointAddressList := removeFromEndpointAddressList(tc.EndpointAddressList, tc.IndexesToRemove)
+		if !reflect.DeepEqual(returnedEndpointAddressList, tc.ExpectedEndpointAddressList) {
+			t.Fatalf("case %d expected %#v got %#v", i, tc.ExpectedEndpointAddressList, returnedEndpointAddressList)
+		}
+	}
+}
+
+func Test_Resource_CleanupEndpointIPs_removeDeadIPFromEndpoints(t *testing.T) {
+	testCases := []struct {
+		Endpoints               *corev1.Endpoints
+		Nodes                   []corev1.Node
+		ExpectedDeletedEndpoint int
+		ExpectedEndpoints       *corev1.Endpoints
+	}{
+		// case 0 no dead ip
+		{
+			Endpoints: &corev1.Endpoints{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "TestService",
+					Namespace: "TestNamespace",
+				},
+				Subsets: []corev1.EndpointSubset{
+					{
+						Addresses: []corev1.EndpointAddress{
+							{
+								IP: "1.2.3.4",
+							},
+							{
+								IP: "1.1.1.1",
+							},
+						},
+					},
+				},
+			},
+			Nodes: []corev1.Node{
+				{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "testNode1",
+						Labels: map[string]string{
+							"ip": "1.2.3.4",
+						},
+					},
+				},
+				{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "testNode2",
+						Labels: map[string]string{
+							"ip": "1.1.1.1",
+						},
+					},
+				},
+			},
+			ExpectedDeletedEndpoint: 0,
+			ExpectedEndpoints: &corev1.Endpoints{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "TestService",
+					Namespace: "TestNamespace",
+				},
+				Subsets: []corev1.EndpointSubset{
+					{
+						Addresses: []corev1.EndpointAddress{
+							{
+								IP: "1.2.3.4",
+							},
+							{
+								IP: "1.1.1.1",
+							},
+						},
+					},
+				},
+			},
+		},
+		// case 1 - 1 dead ip
+		{
+			Endpoints: &corev1.Endpoints{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "TestService",
+					Namespace: "TestNamespace",
+				},
+				Subsets: []corev1.EndpointSubset{
+					{
+						Addresses: []corev1.EndpointAddress{
+							{
+								IP: "1.2.3.4",
+							},
+							{
+								IP: "1.1.1.1",
+							},
+							{
+								IP: "1.1.1.4",
+							},
+						},
+					},
+				},
+			},
+			Nodes: []corev1.Node{
+				{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "testNode1",
+						Labels: map[string]string{
+							"ip": "1.2.3.4",
+						},
+					},
+				},
+				{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "testNode2",
+						Labels: map[string]string{
+							"ip": "1.1.1.1",
+						},
+					},
+				},
+			},
+			ExpectedDeletedEndpoint: 1,
+			ExpectedEndpoints: &corev1.Endpoints{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "TestService",
+					Namespace: "TestNamespace",
+				},
+				Subsets: []corev1.EndpointSubset{
+					{
+						Addresses: []corev1.EndpointAddress{
+							{
+								IP: "1.2.3.4",
+							},
+							{
+								IP: "1.1.1.1",
+							},
+						},
+					},
+				},
+			},
+		},
+		// case 2 - 2 dead ips
+		{
+			Endpoints: &corev1.Endpoints{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "TestService",
+					Namespace: "TestNamespace",
+				},
+				Subsets: []corev1.EndpointSubset{
+					{
+						Addresses: []corev1.EndpointAddress{
+							{
+								IP: "1.2.3.4",
+							},
+							{
+								IP: "1.1.1.1",
+							},
+							{
+								IP: "1.1.1.4",
+							},
+						},
+					},
+				},
+			},
+			Nodes: []corev1.Node{
+				{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "testNode1",
+						Labels: map[string]string{
+							"ip": "1.2.3.4",
+						},
+					},
+				},
+			},
+			ExpectedDeletedEndpoint: 2,
+			ExpectedEndpoints: &corev1.Endpoints{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "TestService",
+					Namespace: "TestNamespace",
+				},
+				Subsets: []corev1.EndpointSubset{
+					{
+						Addresses: []corev1.EndpointAddress{
+							{
+								IP: "1.2.3.4",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	for i, tc := range testCases {
+		deletedEndpoints, returnedEndpoints := removeDeadIPFromEndpoints(tc.Endpoints, tc.Nodes)
+
+		if deletedEndpoints != tc.ExpectedDeletedEndpoint {
+			t.Fatalf("case %d expected %d deleted endpoint ips got %d", i, tc.ExpectedDeletedEndpoint, deletedEndpoints)
+		}
+
+		if !reflect.DeepEqual(tc.ExpectedEndpoints, returnedEndpoints) {
+			t.Fatalf("case %d expected %#v got %#v", i, tc.ExpectedEndpoints, returnedEndpoints)
+		}
+	}
+}
+func Test_Resource_CleanupEndpointIPs_podsEqualNodes(t *testing.T) {
+	testCases := []struct {
+		Pods           []corev1.Pod
+		Nodes          []corev1.Node
+		ExpectedResult bool
+	}{
+		// case 1 pods equal nodes
+		{
+			Pods: []corev1.Pod{
+				{
+
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "worker-xxxx-test-1",
+					},
+				},
+			},
+			Nodes: []corev1.Node{
+				{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "worker-xxxx-test-1",
+					},
+				},
+			},
+			ExpectedResult: true,
+		},
+		// case 2 pods equal nodes
+		{
+			Pods: []corev1.Pod{
+				{
+
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "worker-xxxx-test-1",
+					},
+				},
+				{
+
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "worker-xxxx-test-2",
+					},
+				},
+			},
+			Nodes: []corev1.Node{
+				{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "worker-xxxx-test-1",
+					},
+				},
+				{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "worker-xxxx-test-2",
+					},
+				},
+			},
+			ExpectedResult: true,
+		},
+		// case 3 pods not equal nodes - missing node
+		{
+			Pods: []corev1.Pod{
+				{
+
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "worker-xxxx-test-1",
+					},
+				},
+				{
+
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "worker-xxxx-test-2",
+					},
+				},
+			},
+			Nodes: []corev1.Node{
+				{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "worker-xxxx-test-1",
+					},
+				},
+			},
+			ExpectedResult: false,
+		},
+		// case 4 pods not equal nodes - old node in TC API
+		{
+			Pods: []corev1.Pod{
+				{
+
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "worker-xxxx-test-1",
+					},
+				},
+				{
+
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "worker-xxxx-test-2",
+					},
+				},
+			},
+			Nodes: []corev1.Node{
+				{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "worker-xxxx-test-1",
+					},
+				},
+				{
+
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "worker-xxxx-test-OLD",
+					},
+				},
+			},
+			ExpectedResult: false,
+		},
+	}
+
+	for i, tc := range testCases {
+		result := podsEqualNodes(tc.Pods, tc.Nodes)
+
+		if result != tc.ExpectedResult {
+			t.Fatalf("case %d expected %t result got %t", i, tc.ExpectedResult, result)
+		}
+	}
+}

--- a/service/controller/v24patch1/resource/cleanupendpointips/delete.go
+++ b/service/controller/v24patch1/resource/cleanupendpointips/delete.go
@@ -1,0 +1,9 @@
+package cleanupendpointips
+
+import (
+	"context"
+)
+
+func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
+	return nil
+}

--- a/service/controller/v24patch1/resource/cleanupendpointips/error.go
+++ b/service/controller/v24patch1/resource/cleanupendpointips/error.go
@@ -1,0 +1,14 @@
+package cleanupendpointips
+
+import (
+	"github.com/giantswarm/microerror"
+)
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}

--- a/service/controller/v24patch1/resource/cleanupendpointips/resource.go
+++ b/service/controller/v24patch1/resource/cleanupendpointips/resource.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	Name = "cleanupendpointipsv26"
+	Name = "cleanupendpointipsv24patch1"
 )
 
 type Config struct {

--- a/service/controller/v24patch1/resource/cleanupendpointips/resource.go
+++ b/service/controller/v24patch1/resource/cleanupendpointips/resource.go
@@ -1,0 +1,48 @@
+package cleanupendpointips
+
+import (
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/giantswarm/tenantcluster"
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	Name = "cleanupendpointipsv26"
+)
+
+type Config struct {
+	K8sClient     kubernetes.Interface
+	Logger        micrologger.Logger
+	TenantCluster tenantcluster.Interface
+}
+
+type Resource struct {
+	k8sClient     kubernetes.Interface
+	logger        micrologger.Logger
+	tenantCluster tenantcluster.Interface
+}
+
+func New(config Config) (*Resource, error) {
+	if config.K8sClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.K8sClient must not be empty", config)
+	}
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+	if config.TenantCluster == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.TenantCluster must not be empty", config)
+	}
+
+	r := &Resource{
+		k8sClient:     config.K8sClient,
+		logger:        config.Logger,
+		tenantCluster: config.TenantCluster,
+	}
+
+	return r, nil
+}
+
+func (r *Resource) Name() string {
+	return Name
+}

--- a/service/controller/v25/deleter_resource_set.go
+++ b/service/controller/v25/deleter_resource_set.go
@@ -11,6 +11,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/giantswarm/kvm-operator/service/controller/v25/key"
+	"github.com/giantswarm/kvm-operator/service/controller/v25/resource/cleanupendpointips"
 	"github.com/giantswarm/kvm-operator/service/controller/v25/resource/node"
 )
 
@@ -38,6 +39,20 @@ func NewDeleterResourceSet(config DeleterResourceSetConfig) (*controller.Resourc
 		return false
 	}
 
+	var cleanupendpointipsResource resource.Interface
+	{
+		c := cleanupendpointips.Config{
+			K8sClient:     config.K8sClient,
+			Logger:        config.Logger,
+			TenantCluster: config.TenantCluster,
+		}
+
+		cleanupendpointipsResource, err = cleanupendpointips.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
 	var nodeResource resource.Interface
 	{
 		c := node.Config{
@@ -53,6 +68,7 @@ func NewDeleterResourceSet(config DeleterResourceSetConfig) (*controller.Resourc
 	}
 
 	resources := []resource.Interface{
+		cleanupendpointipsResource,
 		nodeResource,
 	}
 

--- a/service/controller/v25/resource/cleanupendpointips/create.go
+++ b/service/controller/v25/resource/cleanupendpointips/create.go
@@ -1,0 +1,191 @@
+package cleanupendpointips
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	"github.com/giantswarm/errors/tenant"
+	"github.com/giantswarm/k8sclient"
+	"github.com/giantswarm/kvm-operator/service/controller/v25/key"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/tenantcluster"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
+	customObject, err := key.ToCustomObject(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	// At first we need to create a Kubernetes client for the reconciled tenant
+	// cluster.
+	var k8sClient kubernetes.Interface
+	{
+		r.logger.LogCtx(ctx, "level", "debug", "message", "creating Kubernetes client for tenant cluster")
+
+		i := key.ClusterID(customObject)
+		e := key.ClusterAPIEndpoint(customObject)
+
+		restConfig, err := r.tenantCluster.NewRestConfig(ctx, i, e)
+		if tenantcluster.IsTimeout(err) {
+			r.logger.LogCtx(ctx, "level", "debug", "message", "did not create Kubernetes client for tenant cluster")
+			r.logger.LogCtx(ctx, "level", "debug", "message", "waiting for certificates timed out")
+			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+
+			return nil
+		} else if err != nil {
+			return microerror.Mask(err)
+		}
+		clientsConfig := k8sclient.ClientsConfig{
+			Logger:     r.logger,
+			RestConfig: restConfig,
+		}
+		k8sClients, err := k8sclient.NewClients(clientsConfig)
+		if tenant.IsAPINotAvailable(err) {
+			r.logger.LogCtx(ctx, "level", "debug", "message", "tenant cluster is not available")
+			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+
+			return nil
+		} else if err != nil {
+			return microerror.Mask(err)
+		}
+
+		k8sClient = k8sClients.K8sClient()
+		r.logger.LogCtx(ctx, "level", "debug", "message", "created Kubernetes client for tenant cluster")
+	}
+
+	// We need to fetch the nodes being registered within the tenant cluster's
+	// Kubernetes API.
+	var nodes []corev1.Node
+	{
+		list, err := k8sClient.CoreV1().Nodes().List(metav1.ListOptions{})
+		if tenant.IsAPINotAvailable(err) {
+			r.logger.LogCtx(ctx, "level", "debug", "message", "tenant cluster is not available")
+			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+
+			return nil
+		} else if err != nil {
+			return microerror.Mask(err)
+		}
+		nodes = list.Items
+	}
+
+	// Fetch the list of pods running on the control plane. These pods serve VMs
+	// which in turn run the tenant cluster nodes.
+	var pods []corev1.Pod
+	{
+		n := key.ClusterID(customObject)
+		list, err := r.k8sClient.CoreV1().Pods(n).List(metav1.ListOptions{})
+		if err != nil {
+			return microerror.Mask(err)
+		}
+		pods = list.Items
+	}
+	// Check if all k8s-kvm pods in CP are registered as nodes in the TC.
+	if podsEqualNodes(pods, nodes) {
+		n := key.ClusterID(customObject)
+
+		{
+			masterEndpoint, err := r.k8sClient.CoreV1().Endpoints(n).Get(key.MasterID, metav1.GetOptions{})
+			if err != nil {
+				return microerror.Mask(err)
+			}
+
+			epRemoved, masterEndpoint := removeDeadIPFromEndpoints(masterEndpoint, nodes)
+			if epRemoved > 0 {
+				r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("removing %d dead ips from the master endpoints", epRemoved))
+
+				_, err = r.k8sClient.CoreV1().Endpoints(n).Update(masterEndpoint)
+				if err != nil {
+					return microerror.Mask(err)
+				}
+			}
+		}
+
+		{
+			workerEndpoint, err := r.k8sClient.CoreV1().Endpoints(n).Get(key.WorkerID, metav1.GetOptions{})
+			if err != nil {
+				return microerror.Mask(err)
+			}
+
+			epRemoved, workerEndpoint := removeDeadIPFromEndpoints(workerEndpoint, nodes)
+			if epRemoved > 0 {
+				r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("removing %d dead ips from the worker endpoints", epRemoved))
+
+				_, err = r.k8sClient.CoreV1().Endpoints(n).Update(workerEndpoint)
+				if err != nil {
+					return microerror.Mask(err)
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// podsEqualNodes check if all k8s-kvm pods in CP are registered as nodes in the TC.
+func podsEqualNodes(pods []corev1.Pod, nodes []corev1.Node) bool {
+	if len(pods) != len(nodes) {
+		return false
+	}
+
+	// sort pods and nodes by name
+	sort.Slice(pods, func(i, j int) bool {
+		return pods[i].Name < pods[j].Name
+	})
+	sort.Slice(nodes, func(i, j int) bool {
+		return pods[i].Name < pods[j].Name
+	})
+
+	for i := 0; i < len(pods); i++ {
+		if pods[i].Name != nodes[i].Name {
+			return false
+		}
+	}
+	return true
+}
+
+// removeFromEndpointAddressList is removing slice elements from `addresses` defined by `indexesToRemove`.
+func removeFromEndpointAddressList(addresses []corev1.EndpointAddress, indexesToRemove []int) []corev1.EndpointAddress {
+	var newAddresses []corev1.EndpointAddress
+	for i, ip := range addresses {
+		remove := false
+		for _, j := range indexesToRemove {
+			if i == j {
+				remove = true
+			}
+		}
+		if !remove {
+			newAddresses = append(newAddresses, ip)
+		}
+	}
+	return newAddresses
+}
+
+// removeDeadIPFromEndpoints compares endpoint IPs with current state of nodes and
+// removes any IP addresses that does not belong to any node.
+func removeDeadIPFromEndpoints(endpoints *corev1.Endpoints, nodes []corev1.Node) (int, *corev1.Endpoints) {
+	endpointAddresses := endpoints.Subsets[0].Addresses
+
+	var indexesToDelete []int
+	for i, ip := range endpointAddresses {
+		found := false
+		// check if the ip belongs to any k8s node
+		for _, node := range nodes {
+			if node.Labels["ip"] == ip.IP {
+				found = true
+				break
+			}
+		}
+		// endpoint ip does not belong to any node, lets remove it
+		if !found {
+			indexesToDelete = append(indexesToDelete, i)
+		}
+	}
+	if len(indexesToDelete) > 0 {
+		endpoints.Subsets[0].Addresses = removeFromEndpointAddressList(endpointAddresses, indexesToDelete)
+	}
+	return len(indexesToDelete), endpoints
+}

--- a/service/controller/v25/resource/cleanupendpointips/create_test.go
+++ b/service/controller/v25/resource/cleanupendpointips/create_test.go
@@ -1,0 +1,515 @@
+package cleanupendpointips
+
+import (
+	"reflect"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func Test_Resource_CleanupEndpointIPs_removeFromEndpointAddressList(t *testing.T) {
+	testCases := []struct {
+		EndpointAddressList         []corev1.EndpointAddress
+		IndexesToRemove             []int
+		ExpectedEndpointAddressList []corev1.EndpointAddress
+	}{
+		{
+			EndpointAddressList: []corev1.EndpointAddress{
+				{
+					IP: "10.0.0.1",
+				},
+				{
+					IP: "10.0.0.2",
+				},
+				{
+					IP: "10.0.0.3",
+				},
+			},
+			IndexesToRemove: []int{0},
+			ExpectedEndpointAddressList: []corev1.EndpointAddress{
+				{
+					IP: "10.0.0.2",
+				},
+				{
+					IP: "10.0.0.3",
+				},
+			},
+		},
+		{
+			EndpointAddressList: []corev1.EndpointAddress{
+				{
+					IP: "10.0.0.1",
+				},
+				{
+					IP: "10.0.0.2",
+				},
+				{
+					IP: "10.0.0.3",
+				},
+			},
+			IndexesToRemove: []int{1},
+			ExpectedEndpointAddressList: []corev1.EndpointAddress{
+				{
+					IP: "10.0.0.1",
+				},
+				{
+					IP: "10.0.0.3",
+				},
+			},
+		},
+		{
+			EndpointAddressList: []corev1.EndpointAddress{
+				{
+					IP: "10.0.0.1",
+				},
+				{
+					IP: "10.0.0.2",
+				},
+				{
+					IP: "10.0.0.3",
+				},
+			},
+			IndexesToRemove: []int{2},
+			ExpectedEndpointAddressList: []corev1.EndpointAddress{
+				{
+					IP: "10.0.0.1",
+				},
+				{
+					IP: "10.0.0.2",
+				},
+			},
+		},
+		{
+			EndpointAddressList: []corev1.EndpointAddress{
+				{
+					IP: "10.0.0.1",
+				},
+				{
+					IP: "10.0.0.2",
+				},
+				{
+					IP: "10.0.0.3",
+				},
+			},
+			IndexesToRemove: []int{0, 2},
+			ExpectedEndpointAddressList: []corev1.EndpointAddress{
+				{
+					IP: "10.0.0.2",
+				},
+			},
+		},
+		{
+			EndpointAddressList: []corev1.EndpointAddress{
+				{
+					IP: "10.0.0.1",
+				},
+				{
+					IP: "10.0.0.2",
+				},
+				{
+					IP: "10.0.0.3",
+				},
+				{
+					IP: "10.0.0.4",
+				},
+			},
+			IndexesToRemove: []int{0, 1, 2},
+			ExpectedEndpointAddressList: []corev1.EndpointAddress{
+				{
+					IP: "10.0.0.4",
+				},
+			},
+		},
+	}
+
+	for i, tc := range testCases {
+		returnedEndpointAddressList := removeFromEndpointAddressList(tc.EndpointAddressList, tc.IndexesToRemove)
+		if !reflect.DeepEqual(returnedEndpointAddressList, tc.ExpectedEndpointAddressList) {
+			t.Fatalf("case %d expected %#v got %#v", i, tc.ExpectedEndpointAddressList, returnedEndpointAddressList)
+		}
+	}
+}
+
+func Test_Resource_CleanupEndpointIPs_removeDeadIPFromEndpoints(t *testing.T) {
+	testCases := []struct {
+		Endpoints               *corev1.Endpoints
+		Nodes                   []corev1.Node
+		ExpectedDeletedEndpoint int
+		ExpectedEndpoints       *corev1.Endpoints
+	}{
+		// case 0 no dead ip
+		{
+			Endpoints: &corev1.Endpoints{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "TestService",
+					Namespace: "TestNamespace",
+				},
+				Subsets: []corev1.EndpointSubset{
+					{
+						Addresses: []corev1.EndpointAddress{
+							{
+								IP: "1.2.3.4",
+							},
+							{
+								IP: "1.1.1.1",
+							},
+						},
+					},
+				},
+			},
+			Nodes: []corev1.Node{
+				{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "testNode1",
+						Labels: map[string]string{
+							"ip": "1.2.3.4",
+						},
+					},
+				},
+				{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "testNode2",
+						Labels: map[string]string{
+							"ip": "1.1.1.1",
+						},
+					},
+				},
+			},
+			ExpectedDeletedEndpoint: 0,
+			ExpectedEndpoints: &corev1.Endpoints{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "TestService",
+					Namespace: "TestNamespace",
+				},
+				Subsets: []corev1.EndpointSubset{
+					{
+						Addresses: []corev1.EndpointAddress{
+							{
+								IP: "1.2.3.4",
+							},
+							{
+								IP: "1.1.1.1",
+							},
+						},
+					},
+				},
+			},
+		},
+		// case 1 - 1 dead ip
+		{
+			Endpoints: &corev1.Endpoints{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "TestService",
+					Namespace: "TestNamespace",
+				},
+				Subsets: []corev1.EndpointSubset{
+					{
+						Addresses: []corev1.EndpointAddress{
+							{
+								IP: "1.2.3.4",
+							},
+							{
+								IP: "1.1.1.1",
+							},
+							{
+								IP: "1.1.1.4",
+							},
+						},
+					},
+				},
+			},
+			Nodes: []corev1.Node{
+				{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "testNode1",
+						Labels: map[string]string{
+							"ip": "1.2.3.4",
+						},
+					},
+				},
+				{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "testNode2",
+						Labels: map[string]string{
+							"ip": "1.1.1.1",
+						},
+					},
+				},
+			},
+			ExpectedDeletedEndpoint: 1,
+			ExpectedEndpoints: &corev1.Endpoints{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "TestService",
+					Namespace: "TestNamespace",
+				},
+				Subsets: []corev1.EndpointSubset{
+					{
+						Addresses: []corev1.EndpointAddress{
+							{
+								IP: "1.2.3.4",
+							},
+							{
+								IP: "1.1.1.1",
+							},
+						},
+					},
+				},
+			},
+		},
+		// case 2 - 2 dead ips
+		{
+			Endpoints: &corev1.Endpoints{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "TestService",
+					Namespace: "TestNamespace",
+				},
+				Subsets: []corev1.EndpointSubset{
+					{
+						Addresses: []corev1.EndpointAddress{
+							{
+								IP: "1.2.3.4",
+							},
+							{
+								IP: "1.1.1.1",
+							},
+							{
+								IP: "1.1.1.4",
+							},
+						},
+					},
+				},
+			},
+			Nodes: []corev1.Node{
+				{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "testNode1",
+						Labels: map[string]string{
+							"ip": "1.2.3.4",
+						},
+					},
+				},
+			},
+			ExpectedDeletedEndpoint: 2,
+			ExpectedEndpoints: &corev1.Endpoints{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "TestService",
+					Namespace: "TestNamespace",
+				},
+				Subsets: []corev1.EndpointSubset{
+					{
+						Addresses: []corev1.EndpointAddress{
+							{
+								IP: "1.2.3.4",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	for i, tc := range testCases {
+		deletedEndpoints, returnedEndpoints := removeDeadIPFromEndpoints(tc.Endpoints, tc.Nodes)
+
+		if deletedEndpoints != tc.ExpectedDeletedEndpoint {
+			t.Fatalf("case %d expected %d deleted endpoint ips got %d", i, tc.ExpectedDeletedEndpoint, deletedEndpoints)
+		}
+
+		if !reflect.DeepEqual(tc.ExpectedEndpoints, returnedEndpoints) {
+			t.Fatalf("case %d expected %#v got %#v", i, tc.ExpectedEndpoints, returnedEndpoints)
+		}
+	}
+}
+func Test_Resource_CleanupEndpointIPs_podsEqualNodes(t *testing.T) {
+	testCases := []struct {
+		Pods           []corev1.Pod
+		Nodes          []corev1.Node
+		ExpectedResult bool
+	}{
+		// case 1 pods equal nodes
+		{
+			Pods: []corev1.Pod{
+				{
+
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "worker-xxxx-test-1",
+					},
+				},
+			},
+			Nodes: []corev1.Node{
+				{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "worker-xxxx-test-1",
+					},
+				},
+			},
+			ExpectedResult: true,
+		},
+		// case 2 pods equal nodes
+		{
+			Pods: []corev1.Pod{
+				{
+
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "worker-xxxx-test-1",
+					},
+				},
+				{
+
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "worker-xxxx-test-2",
+					},
+				},
+			},
+			Nodes: []corev1.Node{
+				{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "worker-xxxx-test-1",
+					},
+				},
+				{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "worker-xxxx-test-2",
+					},
+				},
+			},
+			ExpectedResult: true,
+		},
+		// case 3 pods not equal nodes - missing node
+		{
+			Pods: []corev1.Pod{
+				{
+
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "worker-xxxx-test-1",
+					},
+				},
+				{
+
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "worker-xxxx-test-2",
+					},
+				},
+			},
+			Nodes: []corev1.Node{
+				{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "worker-xxxx-test-1",
+					},
+				},
+			},
+			ExpectedResult: false,
+		},
+		// case 4 pods not equal nodes - old node in TC API
+		{
+			Pods: []corev1.Pod{
+				{
+
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "worker-xxxx-test-1",
+					},
+				},
+				{
+
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "worker-xxxx-test-2",
+					},
+				},
+			},
+			Nodes: []corev1.Node{
+				{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "worker-xxxx-test-1",
+					},
+				},
+				{
+
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "worker-xxxx-test-OLD",
+					},
+				},
+			},
+			ExpectedResult: false,
+		},
+	}
+
+	for i, tc := range testCases {
+		result := podsEqualNodes(tc.Pods, tc.Nodes)
+
+		if result != tc.ExpectedResult {
+			t.Fatalf("case %d expected %t result got %t", i, tc.ExpectedResult, result)
+		}
+	}
+}

--- a/service/controller/v25/resource/cleanupendpointips/delete.go
+++ b/service/controller/v25/resource/cleanupendpointips/delete.go
@@ -1,0 +1,9 @@
+package cleanupendpointips
+
+import (
+	"context"
+)
+
+func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
+	return nil
+}

--- a/service/controller/v25/resource/cleanupendpointips/error.go
+++ b/service/controller/v25/resource/cleanupendpointips/error.go
@@ -1,0 +1,14 @@
+package cleanupendpointips
+
+import (
+	"github.com/giantswarm/microerror"
+)
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}

--- a/service/controller/v25/resource/cleanupendpointips/resource.go
+++ b/service/controller/v25/resource/cleanupendpointips/resource.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	Name = "cleanupendpointipsv26"
+	Name = "cleanupendpointipsv25"
 )
 
 type Config struct {

--- a/service/controller/v25/resource/cleanupendpointips/resource.go
+++ b/service/controller/v25/resource/cleanupendpointips/resource.go
@@ -1,0 +1,48 @@
+package cleanupendpointips
+
+import (
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/giantswarm/tenantcluster"
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	Name = "cleanupendpointipsv26"
+)
+
+type Config struct {
+	K8sClient     kubernetes.Interface
+	Logger        micrologger.Logger
+	TenantCluster tenantcluster.Interface
+}
+
+type Resource struct {
+	k8sClient     kubernetes.Interface
+	logger        micrologger.Logger
+	tenantCluster tenantcluster.Interface
+}
+
+func New(config Config) (*Resource, error) {
+	if config.K8sClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.K8sClient must not be empty", config)
+	}
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+	if config.TenantCluster == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.TenantCluster must not be empty", config)
+	}
+
+	r := &Resource{
+		k8sClient:     config.K8sClient,
+		logger:        config.Logger,
+		tenantCluster: config.TenantCluster,
+	}
+
+	return r, nil
+}
+
+func (r *Resource) Name() string {
+	return Name
+}

--- a/service/controller/v26/deleter_resource_set.go
+++ b/service/controller/v26/deleter_resource_set.go
@@ -1,7 +1,6 @@
 package v26
 
 import (
-	"github.com/giantswarm/kvm-operator/service/controller/v26/resource/cleanupendpointips"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
 	"github.com/giantswarm/operatorkit/controller"
@@ -12,6 +11,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/giantswarm/kvm-operator/service/controller/v26/key"
+	"github.com/giantswarm/kvm-operator/service/controller/v26/resource/cleanupendpointips"
 	"github.com/giantswarm/kvm-operator/service/controller/v26/resource/node"
 )
 

--- a/service/controller/v26/deleter_resource_set.go
+++ b/service/controller/v26/deleter_resource_set.go
@@ -1,6 +1,7 @@
 package v26
 
 import (
+	"github.com/giantswarm/kvm-operator/service/controller/v26/resource/cleanupendpointips"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
 	"github.com/giantswarm/operatorkit/controller"
@@ -38,6 +39,20 @@ func NewDeleterResourceSet(config DeleterResourceSetConfig) (*controller.Resourc
 		return false
 	}
 
+	var cleanupendpointipsResource resource.Interface
+	{
+		c := cleanupendpointips.Config{
+			K8sClient:     config.K8sClient,
+			Logger:        config.Logger,
+			TenantCluster: config.TenantCluster,
+		}
+
+		cleanupendpointipsResource, err = cleanupendpointips.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
 	var nodeResource resource.Interface
 	{
 		c := node.Config{
@@ -53,6 +68,7 @@ func NewDeleterResourceSet(config DeleterResourceSetConfig) (*controller.Resourc
 	}
 
 	resources := []resource.Interface{
+		cleanupendpointipsResource,
 		nodeResource,
 	}
 

--- a/service/controller/v26/resource/cleanupendpointips/create.go
+++ b/service/controller/v26/resource/cleanupendpointips/create.go
@@ -94,7 +94,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 				return microerror.Mask(err)
 			}
 
-			epRemoved, masterEndpoint := r.removeDeadIPFromEndpoints(masterEndpoint, nodes)
+			epRemoved, masterEndpoint := removeDeadIPFromEndpoints(masterEndpoint, nodes)
 			if epRemoved > 0 {
 				r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("removing %d dead ips from the master endpoints", epRemoved))
 
@@ -111,7 +111,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 				return microerror.Mask(err)
 			}
 
-			epRemoved, workerEndpoint := r.removeDeadIPFromEndpoints(workerEndpoint, nodes)
+			epRemoved, workerEndpoint := removeDeadIPFromEndpoints(workerEndpoint, nodes)
 			if epRemoved > 0 {
 				r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("removing %d dead ips from the worker endpoints", epRemoved))
 
@@ -144,7 +144,7 @@ func removeFromEndpointAddressList(addresses []corev1.EndpointAddress, indexesTo
 
 // removeDeadIPFromEndpoints compares endpoint IPs with current state of nodes and
 // removes any IP addresses that does not belong to any node.
-func (r *Resource) removeDeadIPFromEndpoints(endpoints *corev1.Endpoints, nodes []corev1.Node) (int, *corev1.Endpoints) {
+func removeDeadIPFromEndpoints(endpoints *corev1.Endpoints, nodes []corev1.Node) (int, *corev1.Endpoints) {
 	endpointAddresses := endpoints.Subsets[0].Addresses
 
 	var indexesToDelete []int

--- a/service/controller/v26/resource/cleanupendpointips/create.go
+++ b/service/controller/v26/resource/cleanupendpointips/create.go
@@ -1,0 +1,169 @@
+package cleanupendpointips
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/giantswarm/errors/tenant"
+	"github.com/giantswarm/k8sclient"
+	"github.com/giantswarm/kvm-operator/service/controller/v26/key"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/tenantcluster"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
+	customObject, err := key.ToCustomObject(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	// At first we need to create a Kubernetes client for the reconciled tenant
+	// cluster.
+	var k8sClient kubernetes.Interface
+	{
+		r.logger.LogCtx(ctx, "level", "debug", "message", "creating Kubernetes client for tenant cluster")
+
+		i := key.ClusterID(customObject)
+		e := key.ClusterAPIEndpoint(customObject)
+
+		restConfig, err := r.tenantCluster.NewRestConfig(ctx, i, e)
+		if tenantcluster.IsTimeout(err) {
+			r.logger.LogCtx(ctx, "level", "debug", "message", "did not create Kubernetes client for tenant cluster")
+			r.logger.LogCtx(ctx, "level", "debug", "message", "waiting for certificates timed out")
+			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+
+			return nil
+		} else if err != nil {
+			return microerror.Mask(err)
+		}
+		clientsConfig := k8sclient.ClientsConfig{
+			Logger:     r.logger,
+			RestConfig: restConfig,
+		}
+		k8sClients, err := k8sclient.NewClients(clientsConfig)
+		if tenant.IsAPINotAvailable(err) {
+			r.logger.LogCtx(ctx, "level", "debug", "message", "tenant cluster is not available")
+			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+
+			return nil
+		} else if err != nil {
+			return microerror.Mask(err)
+		}
+
+		k8sClient = k8sClients.K8sClient()
+		r.logger.LogCtx(ctx, "level", "debug", "message", "created Kubernetes client for tenant cluster")
+	}
+
+	// We need to fetch the nodes being registered within the tenant cluster's
+	// Kubernetes API.
+	var nodes []corev1.Node
+	{
+		list, err := k8sClient.CoreV1().Nodes().List(metav1.ListOptions{})
+		if tenant.IsAPINotAvailable(err) {
+			r.logger.LogCtx(ctx, "level", "debug", "message", "tenant cluster is not available")
+			r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
+
+			return nil
+		} else if err != nil {
+			return microerror.Mask(err)
+		}
+		nodes = list.Items
+	}
+
+	// Fetch the list of pods running on the control plane. These pods serve VMs
+	// which in turn run the tenant cluster nodes.
+	var pods []corev1.Pod
+	{
+		n := key.ClusterID(customObject)
+		list, err := r.k8sClient.CoreV1().Pods(n).List(metav1.ListOptions{})
+		if err != nil {
+			return microerror.Mask(err)
+		}
+		pods = list.Items
+	}
+	// Clear dead endpoint IPs only when the cluster is not in transitioning state.
+	// The amount of nodes should be equal to amount of pods.
+	if len(nodes) == len(pods) {
+		n := key.ClusterID(customObject)
+
+		{
+			masterEndpoint, err := r.k8sClient.CoreV1().Endpoints(n).Get(key.MasterID, metav1.GetOptions{})
+			if err != nil {
+				return microerror.Mask(err)
+			}
+
+			epRemoved, masterEndpoint := r.removeDeadIPFromEndpoints(masterEndpoint, nodes)
+			if epRemoved > 0 {
+				r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("removing %d dead ips from the master endpoints", epRemoved))
+
+				_, err = r.k8sClient.CoreV1().Endpoints(n).Update(masterEndpoint)
+				if err != nil {
+					return microerror.Mask(err)
+				}
+			}
+		}
+
+		{
+			workerEndpoint, err := r.k8sClient.CoreV1().Endpoints(n).Get(key.WorkerID, metav1.GetOptions{})
+			if err != nil {
+				return microerror.Mask(err)
+			}
+
+			epRemoved, workerEndpoint := r.removeDeadIPFromEndpoints(workerEndpoint, nodes)
+			if epRemoved > 0 {
+				r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("removing %d dead ips from the worker endpoints", epRemoved))
+
+				_, err = r.k8sClient.CoreV1().Endpoints(n).Update(workerEndpoint)
+				if err != nil {
+					return microerror.Mask(err)
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// removeFromEndpointAddressList is removing slice elements from `addresses` defined by `indexesToRemove`.
+func removeFromEndpointAddressList(addresses []corev1.EndpointAddress, indexesToRemove []int) []corev1.EndpointAddress {
+	var newAddresses []corev1.EndpointAddress
+	for i, ip := range addresses {
+		remove := false
+		for _, j := range indexesToRemove {
+			if i == j {
+				remove = true
+			}
+		}
+		if !remove {
+			newAddresses = append(newAddresses, ip)
+		}
+	}
+	return newAddresses
+}
+
+// removeDeadIPFromEndpoints compares endpoint IPs with current state of nodes and
+// removes any IP addresses that does not belong to any node.
+func (r *Resource) removeDeadIPFromEndpoints(endpoints *corev1.Endpoints, nodes []corev1.Node) (int, *corev1.Endpoints) {
+	endpointAddresses := endpoints.Subsets[0].Addresses
+
+	var indexesToDelete []int
+	for i, ip := range endpointAddresses {
+		found := false
+		// check if the ip belongs to any k8s node
+		for _, node := range nodes {
+			if node.Labels["ip"] == ip.IP {
+				found = true
+				break
+			}
+		}
+		// endpoint ip does not belong to any node, lets remove it
+		if !found {
+			indexesToDelete = append(indexesToDelete, i)
+		}
+	}
+	if len(indexesToDelete) > 0 {
+		endpoints.Subsets[0].Addresses = removeFromEndpointAddressList(endpointAddresses, indexesToDelete)
+	}
+	return len(indexesToDelete), endpoints
+}

--- a/service/controller/v26/resource/cleanupendpointips/create.go
+++ b/service/controller/v26/resource/cleanupendpointips/create.go
@@ -3,6 +3,7 @@ package cleanupendpointips
 import (
 	"context"
 	"fmt"
+	"sort"
 
 	"github.com/giantswarm/errors/tenant"
 	"github.com/giantswarm/k8sclient"
@@ -129,8 +130,16 @@ func podsEqualNodes(pods []corev1.Pod, nodes []corev1.Node) bool {
 	if len(pods) != len(nodes) {
 		return false
 	}
+
+	// sort pods and nodes by name
+	sort.Slice(pods, func(i, j int) bool {
+		return pods[i].Name < pods[j].Name
+	})
+	sort.Slice(nodes, func(i, j int) bool {
+		return pods[i].Name < pods[j].Name
+	})
+
 	for i := 0; i < len(pods); i++ {
-		// k8s api return result alphabetically sorted by name so we can simply compare indexes
 		if pods[i].Name != nodes[i].Name {
 			return false
 		}

--- a/service/controller/v26/resource/cleanupendpointips/create_test.go
+++ b/service/controller/v26/resource/cleanupendpointips/create_test.go
@@ -1,0 +1,355 @@
+package cleanupendpointips
+
+import (
+	"reflect"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func Test_Resource_CleanupEndpointIPs_removeFromEndpointAddressList(t *testing.T) {
+	testCases := []struct {
+		EndpointAddressList         []corev1.EndpointAddress
+		IndexesToRemove             []int
+		ExpectedEndpointAddressList []corev1.EndpointAddress
+	}{
+		{
+			EndpointAddressList: []corev1.EndpointAddress{
+				{
+					IP: "10.0.0.1",
+				},
+				{
+					IP: "10.0.0.2",
+				},
+				{
+					IP: "10.0.0.3",
+				},
+			},
+			IndexesToRemove: []int{0},
+			ExpectedEndpointAddressList: []corev1.EndpointAddress{
+				{
+					IP: "10.0.0.2",
+				},
+				{
+					IP: "10.0.0.3",
+				},
+			},
+		},
+		{
+			EndpointAddressList: []corev1.EndpointAddress{
+				{
+					IP: "10.0.0.1",
+				},
+				{
+					IP: "10.0.0.2",
+				},
+				{
+					IP: "10.0.0.3",
+				},
+			},
+			IndexesToRemove: []int{1},
+			ExpectedEndpointAddressList: []corev1.EndpointAddress{
+				{
+					IP: "10.0.0.1",
+				},
+				{
+					IP: "10.0.0.3",
+				},
+			},
+		},
+		{
+			EndpointAddressList: []corev1.EndpointAddress{
+				{
+					IP: "10.0.0.1",
+				},
+				{
+					IP: "10.0.0.2",
+				},
+				{
+					IP: "10.0.0.3",
+				},
+			},
+			IndexesToRemove: []int{2},
+			ExpectedEndpointAddressList: []corev1.EndpointAddress{
+				{
+					IP: "10.0.0.1",
+				},
+				{
+					IP: "10.0.0.2",
+				},
+			},
+		},
+		{
+			EndpointAddressList: []corev1.EndpointAddress{
+				{
+					IP: "10.0.0.1",
+				},
+				{
+					IP: "10.0.0.2",
+				},
+				{
+					IP: "10.0.0.3",
+				},
+			},
+			IndexesToRemove: []int{0, 2},
+			ExpectedEndpointAddressList: []corev1.EndpointAddress{
+				{
+					IP: "10.0.0.2",
+				},
+			},
+		},
+		{
+			EndpointAddressList: []corev1.EndpointAddress{
+				{
+					IP: "10.0.0.1",
+				},
+				{
+					IP: "10.0.0.2",
+				},
+				{
+					IP: "10.0.0.3",
+				},
+				{
+					IP: "10.0.0.4",
+				},
+			},
+			IndexesToRemove: []int{0, 1, 2},
+			ExpectedEndpointAddressList: []corev1.EndpointAddress{
+				{
+					IP: "10.0.0.4",
+				},
+			},
+		},
+	}
+
+	for i, tc := range testCases {
+		returnedEndpointAddressList := removeFromEndpointAddressList(tc.EndpointAddressList, tc.IndexesToRemove)
+		if !reflect.DeepEqual(returnedEndpointAddressList, tc.ExpectedEndpointAddressList) {
+			t.Fatalf("case %d expected %#v got %#v", i, tc.ExpectedEndpointAddressList, returnedEndpointAddressList)
+		}
+	}
+}
+
+func Test_Resource_CleanupEndpointIPs_removeDeadIPFromEndpoints(t *testing.T) {
+	testCases := []struct {
+		Endpoints               *corev1.Endpoints
+		Nodes                   []corev1.Node
+		ExpectedDeletedEndpoint int
+		ExpectedEndpoints       *corev1.Endpoints
+	}{
+		// case 0 no dead ip
+		{
+			Endpoints: &corev1.Endpoints{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "TestService",
+					Namespace: "TestNamespace",
+				},
+				Subsets: []corev1.EndpointSubset{
+					{
+						Addresses: []corev1.EndpointAddress{
+							{
+								IP: "1.2.3.4",
+							},
+							{
+								IP: "1.1.1.1",
+							},
+						},
+					},
+				},
+			},
+			Nodes: []corev1.Node{
+				{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "testNode1",
+						Labels: map[string]string{
+							"ip": "1.2.3.4",
+						},
+					},
+				},
+				{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "testNode2",
+						Labels: map[string]string{
+							"ip": "1.1.1.1",
+						},
+					},
+				},
+			},
+			ExpectedDeletedEndpoint: 0,
+			ExpectedEndpoints: &corev1.Endpoints{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "TestService",
+					Namespace: "TestNamespace",
+				},
+				Subsets: []corev1.EndpointSubset{
+					{
+						Addresses: []corev1.EndpointAddress{
+							{
+								IP: "1.2.3.4",
+							},
+							{
+								IP: "1.1.1.1",
+							},
+						},
+					},
+				},
+			},
+		},
+		// case 1 - 1 dead ip
+		{
+			Endpoints: &corev1.Endpoints{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "TestService",
+					Namespace: "TestNamespace",
+				},
+				Subsets: []corev1.EndpointSubset{
+					{
+						Addresses: []corev1.EndpointAddress{
+							{
+								IP: "1.2.3.4",
+							},
+							{
+								IP: "1.1.1.1",
+							},
+							{
+								IP: "1.1.1.4",
+							},
+						},
+					},
+				},
+			},
+			Nodes: []corev1.Node{
+				{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "testNode1",
+						Labels: map[string]string{
+							"ip": "1.2.3.4",
+						},
+					},
+				},
+				{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "testNode2",
+						Labels: map[string]string{
+							"ip": "1.1.1.1",
+						},
+					},
+				},
+			},
+			ExpectedDeletedEndpoint: 1,
+			ExpectedEndpoints: &corev1.Endpoints{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "TestService",
+					Namespace: "TestNamespace",
+				},
+				Subsets: []corev1.EndpointSubset{
+					{
+						Addresses: []corev1.EndpointAddress{
+							{
+								IP: "1.2.3.4",
+							},
+							{
+								IP: "1.1.1.1",
+							},
+						},
+					},
+				},
+			},
+		},
+		// case 2 - 2 dead ips
+		{
+			Endpoints: &corev1.Endpoints{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "TestService",
+					Namespace: "TestNamespace",
+				},
+				Subsets: []corev1.EndpointSubset{
+					{
+						Addresses: []corev1.EndpointAddress{
+							{
+								IP: "1.2.3.4",
+							},
+							{
+								IP: "1.1.1.1",
+							},
+							{
+								IP: "1.1.1.4",
+							},
+						},
+					},
+				},
+			},
+			Nodes: []corev1.Node{
+				{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "testNode1",
+						Labels: map[string]string{
+							"ip": "1.2.3.4",
+						},
+					},
+				},
+			},
+			ExpectedDeletedEndpoint: 2,
+			ExpectedEndpoints: &corev1.Endpoints{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "TestService",
+					Namespace: "TestNamespace",
+				},
+				Subsets: []corev1.EndpointSubset{
+					{
+						Addresses: []corev1.EndpointAddress{
+							{
+								IP: "1.2.3.4",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	for i, tc := range testCases {
+		deletedEndpoints, returnedEndpoints := removeDeadIPFromEndpoints(tc.Endpoints, tc.Nodes)
+
+		if deletedEndpoints != tc.ExpectedDeletedEndpoint {
+			t.Fatalf("case %d expected %d deleted endpoint ips got %d", i, tc.ExpectedDeletedEndpoint, deletedEndpoints)
+		}
+
+		if !reflect.DeepEqual(tc.ExpectedEndpoints, returnedEndpoints) {
+			t.Fatalf("case %d expected %#v got %#v", i, tc.ExpectedEndpoints, returnedEndpoints)
+		}
+	}
+}

--- a/service/controller/v26/resource/cleanupendpointips/create_test.go
+++ b/service/controller/v26/resource/cleanupendpointips/create_test.go
@@ -353,3 +353,163 @@ func Test_Resource_CleanupEndpointIPs_removeDeadIPFromEndpoints(t *testing.T) {
 		}
 	}
 }
+func Test_Resource_CleanupEndpointIPs_podsEqualNodes(t *testing.T) {
+	testCases := []struct {
+		Pods           []corev1.Pod
+		Nodes          []corev1.Node
+		ExpectedResult bool
+	}{
+		// case 1 pods equal nodes
+		{
+			Pods: []corev1.Pod{
+				{
+
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "worker-xxxx-test-1",
+					},
+				},
+			},
+			Nodes: []corev1.Node{
+				{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "worker-xxxx-test-1",
+					},
+				},
+			},
+			ExpectedResult: true,
+		},
+		// case 2 pods equal nodes
+		{
+			Pods: []corev1.Pod{
+				{
+
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "worker-xxxx-test-1",
+					},
+				},
+				{
+
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "worker-xxxx-test-2",
+					},
+				},
+			},
+			Nodes: []corev1.Node{
+				{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "worker-xxxx-test-1",
+					},
+				},
+				{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "worker-xxxx-test-2",
+					},
+				},
+			},
+			ExpectedResult: true,
+		},
+		// case 3 pods not equal nodes - missing node
+		{
+			Pods: []corev1.Pod{
+				{
+
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "worker-xxxx-test-1",
+					},
+				},
+				{
+
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "worker-xxxx-test-2",
+					},
+				},
+			},
+			Nodes: []corev1.Node{
+				{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "worker-xxxx-test-1",
+					},
+				},
+			},
+			ExpectedResult: false,
+		},
+		// case 4 pods not equal nodes - old node in TC API
+		{
+			Pods: []corev1.Pod{
+				{
+
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "worker-xxxx-test-1",
+					},
+				},
+				{
+
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "worker-xxxx-test-2",
+					},
+				},
+			},
+			Nodes: []corev1.Node{
+				{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "worker-xxxx-test-1",
+					},
+				},
+				{
+
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: "v1",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "worker-xxxx-test-OLD",
+					},
+				},
+			},
+			ExpectedResult: false,
+		},
+	}
+
+	for i, tc := range testCases {
+		result := podsEqualNodes(tc.Pods, tc.Nodes)
+
+		if result != tc.ExpectedResult {
+			t.Fatalf("case %d expected %t result got %t", i, tc.ExpectedResult, result)
+		}
+	}
+}

--- a/service/controller/v26/resource/cleanupendpointips/delete.go
+++ b/service/controller/v26/resource/cleanupendpointips/delete.go
@@ -1,0 +1,9 @@
+package cleanupendpointips
+
+import (
+	"context"
+)
+
+func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
+	return nil
+}

--- a/service/controller/v26/resource/cleanupendpointips/error.go
+++ b/service/controller/v26/resource/cleanupendpointips/error.go
@@ -1,0 +1,14 @@
+package cleanupendpointips
+
+import (
+	"github.com/giantswarm/microerror"
+)
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}

--- a/service/controller/v26/resource/cleanupendpointips/resource.go
+++ b/service/controller/v26/resource/cleanupendpointips/resource.go
@@ -1,0 +1,48 @@
+package cleanupendpointips
+
+import (
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/giantswarm/tenantcluster"
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	Name = "nodev26"
+)
+
+type Config struct {
+	K8sClient     kubernetes.Interface
+	Logger        micrologger.Logger
+	TenantCluster tenantcluster.Interface
+}
+
+type Resource struct {
+	k8sClient     kubernetes.Interface
+	logger        micrologger.Logger
+	tenantCluster tenantcluster.Interface
+}
+
+func New(config Config) (*Resource, error) {
+	if config.K8sClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.K8sClient must not be empty", config)
+	}
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+	if config.TenantCluster == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.TenantCluster must not be empty", config)
+	}
+
+	r := &Resource{
+		k8sClient:     config.K8sClient,
+		logger:        config.Logger,
+		tenantCluster: config.TenantCluster,
+	}
+
+	return r, nil
+}
+
+func (r *Resource) Name() string {
+	return Name
+}

--- a/service/controller/v26/resource/cleanupendpointips/resource.go
+++ b/service/controller/v26/resource/cleanupendpointips/resource.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	Name = "nodev26"
+	Name = "cleanupendpointipsv26"
 )
 
 type Config struct {


### PR DESCRIPTION
replacement of https://github.com/giantswarm/kvm-operator/pull/826

towards: https://github.com/giantswarm/giantswarm/issues/8840

add new resource for cleaning dead endpoints

that will :
* check if the cluster is not transitioning state ( number of nodes in TC == number of pods in CP)
*  go thru all endpoint IPs and compare to the nodes and remove any IP that  does not belong to any node
* do it for both master and worker endpoints

```
{"caller":"github.com/giantswarm/kvm-operator/service/controller/v26/resource/cleanupendpointips/create.go:116","controller":"kvm-operator-deleter","event":"update","level":"debug","loop":"8","message":"removing 2 dead ips from the worker endpoints","object":"/apis/provider.giantswarm.io/v1alpha1/namespaces/default/kvmconfigs/vm3fq","resource":"cleanupendpointipsv26","time":"2020-02-24T16:37:54.362485+00:00","version":"196686615"}
```

wainting for feedback than will backport to all old versions.