### PR TITLE
pkg, service: replace `bundleVersion` with `version`

### DIFF
--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -1,17 +1,12 @@
 package project
 
 var (
-	bundleVersion        = "3.11.0-dev"
-	description   string = "The kvm-operator handles Kubernetes clusters running on a Kubernetes cluster."
-	gitSHA               = "n/a"
-	name          string = "kvm-operator"
-	source        string = "https://github.com/giantswarm/kvm-operator"
-	version              = "n/a"
+	description string = "The kvm-operator handles Kubernetes clusters running on a Kubernetes cluster."
+	gitSHA             = "n/a"
+	name        string = "kvm-operator"
+	source      string = "https://github.com/giantswarm/kvm-operator"
+	version            = "3.11.0-dev"
 )
-
-func BundleVersion() string {
-	return bundleVersion
-}
 
 func Description() string {
 	return description

--- a/pkg/project/version_bundle.go
+++ b/pkg/project/version_bundle.go
@@ -39,6 +39,6 @@ func NewVersionBundle() versionbundle.Bundle {
 			},
 		},
 		Name:    Name(),
-		Version: BundleVersion(),
+		Version: Version(),
 	}
 }

--- a/service/controller/cluster_resource_set.go
+++ b/service/controller/cluster_resource_set.go
@@ -291,7 +291,7 @@ func NewClusterResourceSet(config ClusterResourceSetConfig) (*controller.Resourc
 			return false
 		}
 
-		if key.OperatorVersion(cr) == project.BundleVersion() {
+		if key.OperatorVersion(cr) == project.Version() {
 			return true
 		}
 

--- a/service/controller/deleter_resource_set.go
+++ b/service/controller/deleter_resource_set.go
@@ -32,7 +32,7 @@ func NewDeleterResourceSet(config DeleterResourceSetConfig) (*controller.Resourc
 			return false
 		}
 
-		if key.OperatorVersion(cr) == project.BundleVersion() {
+		if key.OperatorVersion(cr) == project.Version() {
 			return true
 		}
 

--- a/service/controller/drainer_resource_set.go
+++ b/service/controller/drainer_resource_set.go
@@ -37,7 +37,7 @@ func NewDrainerResourceSet(config DrainerResourceSetConfig) (*controller.Resourc
 			return false
 		}
 
-		if v == project.BundleVersion() {
+		if v == project.Version() {
 			return true
 		}
 


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/8637

We want to invert how the project version is maintained and now that
it isn't injected during the build from git data, we can remove the
separate concept of _bundle version_ and replace it with just _version_.