### PR TITLE
helm: move resource name to helm helpers

### DIFF
--- a/helm/kvm-operator/Chart.yaml
+++ b/helm/kvm-operator/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 name: kvm-operator
 home: https://github.com/giantswarm/kvm-operator
 description: Handles Kubernetes clusters running on a Kubernetes cluster with workers and masters in KVMs on bare metal
-version: [[ .Version ]]
-appVersion: [[ .AppVersion ]]
+version: "[[ .Version ]]"
+appVersion: "[[ .AppVersion ]]"

--- a/helm/kvm-operator/templates/_helpers.tpl
+++ b/helm/kvm-operator/templates/_helpers.tpl
@@ -2,34 +2,34 @@
 {{/*
 Expand the name of the chart.
 */}}
-{{- define "kvm-operator.name" -}}
+{{- define "name" -}}
 {{- .Chart.Name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*
 Create chart name and version as used by the chart label.
 */}}
-{{- define "kvm-operator.chart" -}}
+{{- define "chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*
 Common labels
 */}}
-{{- define "kvm-operator.labels" -}}
-app: {{ include "kvm-operator.name" . | quote }}
+{{- define "labels.common" -}}
+app: {{ include "name" . | quote }}
+{{ include "labels.selector" . }}
 app.giantswarm.io/branch: {{ .Values.project.branch | quote }}
 app.giantswarm.io/commit: {{ .Values.project.commit | quote }}
 app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
-helm.sh/chart: {{ include "kvm-operator.chart" . | quote }}
-{{ include "kvm-operator.selectorLabels" . }}
+helm.sh/chart: {{ include "chart" . | quote }}
 {{- end -}}
 
 {{/*
 Selector labels
 */}}
-{{- define "kvm-operator.selectorLabels" -}}
+{{- define "labels.selector" -}}
+app.kubernetes.io/name: {{ include "name" . | quote }}
 app.kubernetes.io/instance: {{ .Release.Name | quote }}
-app.kubernetes.io/name: {{ include "kvm-operator.name" . | quote }}
 {{- end -}}

--- a/helm/kvm-operator/templates/_resource.tpl
+++ b/helm/kvm-operator/templates/_resource.tpl
@@ -1,0 +1,24 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Create a name stem for resource names
+
+When pods for deployments are created they have an additional 16 character
+suffix appended, e.g. "-957c9d6ff-pkzgw". Given that Kubernetes allows 63
+characters for resource names, the stem is truncated to 47 characters to leave
+room for such suffix.
+*/}}
+{{- define "resource.default.name" -}}
+{{- .Release.Name | replace "." "-" | trunc 47 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "resource.psp.name" -}}
+{{- include "resource.default.name" . -}}-psp
+{{- end -}}
+
+{{- define "resource.pullSecret.name" -}}
+{{- include "resource.default.name" . -}}-pull-secret
+{{- end -}}
+
+{{- define "resource.default.namespace" -}}
+giantswarm
+{{- end -}}

--- a/helm/kvm-operator/templates/configmap.yaml
+++ b/helm/kvm-operator/templates/configmap.yaml
@@ -1,10 +1,10 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ tpl .Values.resource.default.name  . }}
-  namespace: {{ tpl .Values.resource.default.namespace  . }}
+  name: {{ include "resource.default.name"  . }}
+  namespace: {{ include "resource.default.namespace"  . }}
   labels:
-    {{- include "kvm-operator.labels" . | nindent 4 }}
+    {{- include "labels.common" . | nindent 4 }}
 data:
   config.yml: |
     server:
@@ -18,8 +18,8 @@ data:
         labelSelector: '{{ .Values.Installation.V1.GiantSwarm.KVMOperator.CRD.LabelSelector }}'
       rbac:
         clusterRole:
-          general: {{ tpl .Values.resource.default.name . }}
-          psp: {{ tpl .Values.resource.psp.name . }}
+          general: {{ include "resource.default.name" . }}
+          psp: {{ include "resource.psp.name" . }}
       kubernetes:
         address: ''
         inCluster: true

--- a/helm/kvm-operator/templates/deployment.yaml
+++ b/helm/kvm-operator/templates/deployment.yaml
@@ -1,16 +1,16 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ tpl .Values.resource.default.name  . }}
-  namespace: {{ tpl .Values.resource.default.namespace  . }}
+  name: {{ include "resource.default.name"  . }}
+  namespace: {{ include "resource.default.namespace"  . }}
   labels:
-    {{- include "kvm-operator.labels" . | nindent 4 }}
+    {{- include "labels.common" . | nindent 4 }}
 spec:
   replicas: 1
   revisionHistoryLimit: 3
   selector:
     matchLabels:
-      {{- include "kvm-operator.selectorLabels" . | nindent 6 }}
+      {{- include "labels.selector" . | nindent 6 }}
   strategy:
     type: Recreate
   template:
@@ -18,16 +18,16 @@ spec:
       annotations:
         releasetime: {{ $.Release.Time }}
       labels:
-        {{- include "kvm-operator.selectorLabels" . | nindent 8 }}
+        {{- include "labels.selector" . | nindent 8 }}
     spec:
       volumes:
       - name: {{ .Chart.Name }}-configmap
         configMap:
-          name: {{ tpl .Values.resource.default.name  . }}
+          name: {{ include "resource.default.name"  . }}
           items:
           - key: config.yml
             path: config.yml
-      serviceAccountName: {{ tpl .Values.resource.default.name  . }}
+      serviceAccountName: {{ include "resource.default.name"  . }}
       securityContext:
         runAsUser: {{ .Values.pod.user.id }}
         runAsGroup: {{ .Values.pod.group.id }}
@@ -55,4 +55,4 @@ spec:
             cpu: 250m
             memory: 250Mi
       imagePullSecrets:
-      - name: {{ tpl .Values.resource.pullSecret.name . }}
+      - name: {{ include "resource.pullSecret.name" . }}

--- a/helm/kvm-operator/templates/psp.yaml
+++ b/helm/kvm-operator/templates/psp.yaml
@@ -1,9 +1,9 @@
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
-  name: {{ tpl .Values.resource.psp.name . }}
+  name: {{ include "resource.psp.name" . }}
   labels:
-    {{- include "kvm-operator.labels" . | nindent 4 }}
+    {{- include "labels.common" . | nindent 4 }}
 spec:
   privileged: false
   fsGroup:

--- a/helm/kvm-operator/templates/pull-secret.yml
+++ b/helm/kvm-operator/templates/pull-secret.yml
@@ -2,9 +2,9 @@ apiVersion: v1
 kind: Secret
 type: kubernetes.io/dockerconfigjson
 metadata:
-  name: {{ tpl .Values.resource.pullSecret.name . }}
-  namespace: {{ tpl .Values.resource.pullSecret.namespace . }}
+  name: {{ include "resource.pullSecret.name" . }}
+  namespace: {{ include "resource.default.namespace" . }}
   labels:
-    {{- include "kvm-operator.labels" . | nindent 4 }}
+    {{- include "labels.common" . | nindent 4 }}
 data:
   .dockerconfigjson: {{ .Values.Installation.V1.Secret.Registry.PullSecret.DockerConfigJSON | b64enc | quote }}

--- a/helm/kvm-operator/templates/rbac.yaml
+++ b/helm/kvm-operator/templates/rbac.yaml
@@ -1,9 +1,9 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ tpl .Values.resource.default.name  . }}
+  name: {{ include "resource.default.name"  . }}
   labels:
-    {{- include "kvm-operator.labels" . | nindent 4 }}
+    {{- include "labels.common" . | nindent 4 }}
 rules:
   - apiGroups:
       - apiextensions.k8s.io
@@ -123,24 +123,24 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ tpl .Values.resource.default.name  . }}
+  name: {{ include "resource.default.name"  . }}
   labels:
-    {{- include "kvm-operator.labels" . | nindent 4 }}
+    {{- include "labels.common" . | nindent 4 }}
 subjects:
   - kind: ServiceAccount
-    name: {{ tpl .Values.resource.default.name  . }}
-    namespace: {{ tpl .Values.resource.default.namespace  . }}
+    name: {{ include "resource.default.name"  . }}
+    namespace: {{ include "resource.default.namespace"  . }}
 roleRef:
   kind: ClusterRole
-  name: {{ tpl .Values.resource.default.name  . }}
+  name: {{ include "resource.default.name"  . }}
   apiGroup: rbac.authorization.k8s.io
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ tpl .Values.resource.psp.name . }}
+  name: {{ include "resource.psp.name" . }}
   labels:
-    {{- include "kvm-operator.labels" . | nindent 4 }}
+    {{- include "labels.common" . | nindent 4 }}
 rules:
   - apiGroups:
       - policy
@@ -149,19 +149,19 @@ rules:
     verbs:
       - use
     resourceNames:
-      - {{ tpl .Values.resource.psp.name . }}
+      - {{ include "resource.psp.name" . }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ tpl .Values.resource.psp.name . }}
+  name: {{ include "resource.psp.name" . }}
   labels:
-    {{- include "kvm-operator.labels" . | nindent 4 }}
+    {{- include "labels.common" . | nindent 4 }}
 subjects:
   - kind: ServiceAccount
-    name: {{ tpl .Values.resource.default.name  . }}
-    namespace: {{ tpl .Values.resource.default.namespace  . }}
+    name: {{ include "resource.default.name"  . }}
+    namespace: {{ include "resource.default.namespace"  . }}
 roleRef:
   kind: ClusterRole
-  name: {{ tpl .Values.resource.psp.name . }}
+  name: {{ include "resource.psp.name" . }}
   apiGroup: rbac.authorization.k8s.io

--- a/helm/kvm-operator/templates/service-account.yaml
+++ b/helm/kvm-operator/templates/service-account.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ tpl .Values.resource.default.name  . }}
-  namespace: {{ tpl .Values.resource.default.namespace  . }}
+  name: {{ include "resource.default.name"  . }}
+  namespace: {{ include "resource.default.namespace"  . }}
   labels:
-    {{- include "kvm-operator.labels" . | nindent 4 }}
+    {{- include "labels.common" . | nindent 4 }}

--- a/helm/kvm-operator/templates/service.yaml
+++ b/helm/kvm-operator/templates/service.yaml
@@ -1,14 +1,14 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ tpl .Values.resource.default.name  . }}
-  namespace: {{ tpl .Values.resource.default.namespace  . }}
+  name: {{ include "resource.default.name"  . }}
+  namespace: {{ include "resource.default.namespace"  . }}
   labels:
-    {{- include "kvm-operator.labels" . | nindent 4 }}
+    {{- include "labels.common" . | nindent 4 }}
   annotations:
     prometheus.io/scrape: "true"
 spec:
   ports:
   - port: 8000
   selector:
-    {{- include "kvm-operator.selectorLabels" . | nindent 4 }}
+    {{- include "labels.selector" . | nindent 4 }}

--- a/helm/kvm-operator/values.yaml
+++ b/helm/kvm-operator/values.yaml
@@ -1,6 +1,6 @@
 project:
   branch: "[[ .Branch ]]"
-  commit: "[[ .SHA ]]"
+  commit: "[[ .SHA  ]]"
 image:
   name: "giantswarm/kvm-operator"
   tag: "[[ .Version ]]"

--- a/helm/kvm-operator/values.yaml
+++ b/helm/kvm-operator/values.yaml
@@ -1,9 +1,9 @@
 project:
-  branch: "[[ .Branch ]]"
-  commit: "[[ .SHA  ]]"
+  branch: "test"
+  commit: "test"
 image:
   name: "giantswarm/kvm-operator"
-  tag: "[[ .Version ]]"
+  tag: "test"
 Installation:
   V1:
     Registry:
@@ -22,7 +22,7 @@ pod:
 # correctly in the templates. This is because helm doesn't template values.yaml
 # file and it has to be a valid json. Example usage:
 #
-#     {{ tpl .Values.resource.default.name . }}.
+#     {{ include "resource.default.name" . }}.
 #
 resource:
   default:

--- a/helm/kvm-operator/values.yaml
+++ b/helm/kvm-operator/values.yaml
@@ -13,23 +13,3 @@ pod:
     id: 1000
   group:
     id: 1000
-# Resource names are truncated to 47 characters. Kubernetes allows 63 characters
-# limit for resource names. When pods for deployments are created they have
-# additional 16 characters suffix, e.g. "-957c9d6ff-pkzgw" and we want to have
-# room for those suffixes.
-#
-# NOTE: All values under resource key need to be used with `tpl` to render them
-# correctly in the templates. This is because helm doesn't template values.yaml
-# file and it has to be a valid json. Example usage:
-#
-#     {{ include "resource.default.name" . }}.
-#
-resource:
-  default:
-    name: '{{ .Release.Name | replace "." "-" | trunc 47 }}'
-    namespace: "giantswarm"
-  psp:
-    name: '{{ .Release.Name | replace "." "-" | trunc 47 }}-psp'
-  pullSecret:
-    name: '{{ .Release.Name | replace "." "-" | trunc 47 }}-pull-secret'
-    namespace: "giantswarm"

--- a/helm/kvm-operator/values.yaml
+++ b/helm/kvm-operator/values.yaml
@@ -1,9 +1,9 @@
 project:
-  branch: "test"
-  commit: "test"
+  branch: "[[ .Branch ]]"
+  commit: "[[ .SHA ]]"
 image:
   name: "giantswarm/kvm-operator"
-  tag: "test"
+  tag: "[[ .Version ]]"
 Installation:
   V1:
     Registry:


### PR DESCRIPTION
Towards: giantswarm/giantswarm#9878

Move helm chart variables to helm helpers to reduce repetition in charts' values.yaml file.