### PR TITLE
Release v3.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+*Note: This changelog only tracks changes in the `legacy-1-15` branch.*
+
 ## [Unreleased]
+
+## [3.9.1] - 2020-04-24
+
+### Added
+
+- First release as a flattened operator.
+- Support setting OIDC username and groups prefix.
 
 ### Changed
 
+- Use Flatcar linux instead of CoreOS.
 - Streamlined image templating for core components for quicker and easier releases in the future.
 - Retrieve component versions from `releases`.
 
-[Unreleased]: https://github.com/giantswarm/kvm-operator/compare/TODO...legacy-1-15
-[TODO First Release]: https://github.com/giantswarm/kvm-operator/releases/tag/TODO
+[Unreleased]: https://github.com/giantswarm/kvm-operator/compare/v3.9.1...legacy-1-15
+[3.9.1]: https://github.com/giantswarm/kvm-operator/releases/tag/v3.9.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,12 +15,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - First release as a flattened operator.
 - Support setting OIDC username and groups prefix.
+- Add `conntrackMaxPerCore` parameter in kube-proxy manifest.
 
 ### Changed
 
 - Use Flatcar linux instead of CoreOS.
 - Streamlined image templating for core components for quicker and easier releases in the future.
 - Retrieve component versions from `releases`.
+- Remove debug profiling from Controller Manager and Scheduler
+- Remove limit of calico node init container.
 
 [Unreleased]: https://github.com/giantswarm/kvm-operator/compare/v3.9.1...legacy-1-15
 [3.9.1]: https://github.com/giantswarm/kvm-operator/releases/tag/v3.9.1

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -5,7 +5,7 @@ var (
 	gitSHA             = "n/a"
 	name        string = "kvm-operator"
 	source      string = "https://github.com/giantswarm/kvm-operator"
-	version            = "3.9.1-dev"
+	version            = "3.9.1"
 )
 
 func Description() string {

--- a/pkg/project/version_bundle.go
+++ b/pkg/project/version_bundle.go
@@ -20,7 +20,7 @@ func NewVersionBundle() versionbundle.Bundle {
 			},
 			{
 				Name:    "containerlinux",
-				Version: "2191.5.0",
+				Version: "2345.3.1",
 			},
 			{
 				Name:    "docker",
@@ -32,7 +32,7 @@ func NewVersionBundle() versionbundle.Bundle {
 			},
 			{
 				Name:    "kubernetes",
-				Version: "1.15.5",
+				Version: "1.15.11",
 			},
 		},
 		Name:    Name(),


### PR DESCRIPTION
Update Changelog and set operator version. Component versions are now pulled from releases