### PR TITLE
Re-create CRB during upgrade if trying to modify immutable field

### DIFF
--- a/service/controller/resource/clusterrolebinding/error.go
+++ b/service/controller/resource/clusterrolebinding/error.go
@@ -1,6 +1,25 @@
 package clusterrolebinding
 
-import "github.com/giantswarm/microerror"
+import (
+	"strings"
+
+	"github.com/giantswarm/microerror"
+)
+
+var fieldImmutableError = &microerror.Error{
+	Kind: "fieldImmutableError",
+}
+
+func isExternalFieldImmutableError(err error) bool {
+	// Would be nice to use validation.FieldImmutableErrorMsg here,
+	// but can't seem to get it from the wrapped error reliably
+	return strings.Contains(err.Error(), "cannot change roleRef")
+}
+
+// IsFieldImmutableError asserts fieldImmutableError
+func IsFieldImmutableError(err error) bool {
+	return microerror.Cause(err) == fieldImmutableError
+}
 
 var invalidConfigError = &microerror.Error{
 	Kind: "invalidConfigError",


### PR DESCRIPTION
Same fix as for legacy-1-15. During an upgrade, the name of a roleref might change. These are immutable, so we replace the CRB entirely