### PR TITLE
Non empty changelogs

### DIFF
--- a/pkg/project/version_bundle.go
+++ b/pkg/project/version_bundle.go
@@ -6,6 +6,16 @@ import (
 
 func NewVersionBundle() versionbundle.Bundle {
 	return versionbundle.Bundle{
+		Changelogs: []versionbundle.Changelog{
+			{
+				Component:   "containerlinux",
+				Description: "Deprecate CoreOS and move to Flatcar Linux.",
+				Kind:        versionbundle.KindChanged,
+				URLs: []string{
+					"https://github.com/giantswarm/kvm-operator/pull/825",
+				},
+			},
+		},
 		Name:    Name(),
 		Version: Version(),
 	}


### PR DESCRIPTION
Apparently changelogs can't be empty. Am I missing a vendor @tfussell ?