### PR TITLE
Remove dependabot from legacy branch

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -9,12 +9,3 @@ update_configs:
           # Ignore k8s.io dependencies which aren't 0.16.x
           dependency_name: "k8s.io/**"
           version_requirement: ">=0.17.0"
-  - package_manager: "go:modules"
-    directory: "/"
-    target_branch: "legacy-1-15"
-    update_schedule: "daily"
-    ignored_updates:
-      - match:
-          # Ignore k8s.io dependencies which aren't 0.16.x
-          dependency_name: "k8s.io/**"
-          version_requirement: ">=0.17.0"

--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -9,3 +9,15 @@ update_configs:
           # Ignore k8s.io dependencies which aren't 0.16.x
           dependency_name: "k8s.io/**"
           version_requirement: ">=0.17.0"
+  - package_manager: "go:modules"
+    directory: "/"
+    target_branch: "legacy-1-15"
+    update_schedule: "daily"
+    allowed_updates:
+      - match:
+          update_type: "security"
+    ignored_updates:
+      - match:
+          # Ignore k8s.io dependencies which aren't 0.16.x
+          dependency_name: "k8s.io/**"
+          version_requirement: ">=0.17.0"


### PR DESCRIPTION
I personally do not care about the legacy branch.
Nearly everything dependabot adds there is broken / worthless.