### PR TITLE
Use k8s-kvm 0.2.0 with qemu 4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Fix cluster creation with `float64` wrapper in CRD.
-
+- Use `k8s-kvm:0.2.0` with QEMU 4.0.0.
 
 ## [3.11.1] 2020-04-30
 

--- a/service/controller/key/key.go
+++ b/service/controller/key/key.go
@@ -67,7 +67,7 @@ const (
 	FlatcarChannel  = "stable"
 
 	K8SEndpointUpdaterDocker = "quay.io/giantswarm/k8s-endpoint-updater:0.1.0"
-	K8SKVMDockerImage        = "quay.io/giantswarm/k8s-kvm:0.1.0"
+	K8SKVMDockerImage        = "quay.io/giantswarm/k8s-kvm:0.2.0"
 	K8SKVMHealthDocker       = "quay.io/giantswarm/k8s-kvm-health:0.1.0"
 	ShutdownDeferrerDocker   = "quay.io/giantswarm/shutdown-deferrer:0.1.0"
 


### PR DESCRIPTION
Tested with running clusters. Didn't find much issues. Except cluster is running 5min faster than with current version