### PR TITLE
Prepare next dev

### DIFF
--- a/.github/workflows/zz_generated.create_release.yaml
+++ b/.github/workflows/zz_generated.create_release.yaml
@@ -120,7 +120,10 @@ jobs:
         uses: actions/checkout@v2
       - name: Update project.go
         id: update_project_go
+        env:
+          branch: "${{ github.ref }}-version-bump"
         run: |
+          git checkout -b ${{ env.branch }}
           file="${{ needs.gather_facts.outputs.project_go_path }}"
           version="${{ needs.gather_facts.outputs.version }}"
           new_version="$(semver bump patch $version)-dev"
@@ -137,12 +140,22 @@ jobs:
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
           git add $file
-          git commit -m "pkg/project: bump version to ${{ steps.update_project_go.outputs.new_version }}"
+          git commit -m "Bump version to ${{ steps.update_project_go.outputs.new_version }}"
       - name: Push changes
         env:
           REMOTE_REPO: "https://${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git"
+          branch: "${{ github.ref }}-version-bump"
         run: |
-          git push "${REMOTE_REPO}" HEAD:${{ github.ref }}
+          git push "${REMOTE_REPO}" HEAD:${{ env.branch }}
+      - name: Create PR
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          base: "${{ github.ref }}"
+          branch: "${{ github.ref }}-version-bump"
+          version: "${{ needs.gather_facts.outputs.version }}"
+          title: "Bump version to ${{ steps.update_project_go.outputs.new_version }}"
+        run: |
+          hub pull-request -f  -m "${{ env.title }}" -b ${{ env.base }} -h ${{ env.branch }} -r ${{ github.actor }}
   create_release:
     name: Create release
     runs-on: ubuntu-18.04
@@ -180,7 +193,6 @@ jobs:
         with:
           tag_name: "v${{ needs.gather_facts.outputs.version }}"
           release_name: "v${{ needs.gather_facts.outputs.version }}"
-
   create-release-branch:
     name: Create release branch
     runs-on: ubuntu-18.04

--- a/.github/workflows/zz_generated.create_release_pr.yaml
+++ b/.github/workflows/zz_generated.create_release_pr.yaml
@@ -97,43 +97,6 @@ jobs:
         with:
           name: "${{ env.BINARY }}"
           path: "${{ env.DIR }}/${{ env.BINARY }}"
-  install_hub:
-    name: Install hub
-    runs-on: ubuntu-18.04
-    env:
-      BINARY: "hub"
-      DIR: "/opt/cache"
-      VERSION: "2.14.2"
-      URL: "https://github.com/github/hub/releases/download/v2.14.2/hub-linux-amd64-2.14.2.tgz"
-    outputs:
-      cache_key: ${{ steps.get_cache_key.outputs.cache_key }}
-    steps:
-      - name: Get cache key
-        id: get_cache_key
-        run: |
-          cache_key="install-${{ env.BINARY }}-${{ env.VERSION }}"
-          echo "::set-output name=cache_key::${cache_key}"
-      - name: Cache
-        id: cache
-        uses: actions/cache@v1
-        with:
-          key: "${{ steps.get_cache_key.outputs.cache_key }}"
-          path: "${{ env.DIR }}"
-      - name: Download
-        if: ${{ steps.cache.outputs.cache-hit != 'true' }}
-        run: |
-          mkdir ${{ env.DIR }}
-          curl -fsSLo - ${{ env.URL }} | tar xvz --strip-components=1 --wildcards '*/bin/${{ env.BINARY }}'
-          mv bin/${{ env.BINARY }} ${{ env.DIR }}
-          chmod +x ${{ env.DIR }}/${{ env.BINARY }}
-      - name: Smoke test
-        run: |
-          ${{ env.DIR }}/${{ env.BINARY }} version
-      - name: Upload artifact
-        uses: actions/upload-artifact@v1
-        with:
-          name: "${{ env.BINARY }}"
-          path: "${{ env.DIR }}/${{ env.BINARY }}"
   create_release_pr:
     name: Create release PR
     runs-on: ubuntu-18.04
@@ -141,7 +104,6 @@ jobs:
     needs:
       - gather_facts
       - install_architect
-      - install_hub
     env:
       architect_flags: "--organisation ${{ github.repository_owner }} --project ${{ github.event.repository.name }}"
     steps:
@@ -149,19 +111,13 @@ jobs:
         id: cache
         uses: actions/cache@v1
         with:
-          key: "${{ needs.install_architect.outputs.cache_key }}+++${{ needs.install_hub.outputs.cache_key }}"
+          key: "${{ needs.install_architect.outputs.cache_key }}"
           path: /opt/bin
       - name: Download architect artifact to /opt/bin
         if: ${{ steps.cache.outputs.cache-hit != 'true' }}
         uses: actions/download-artifact@v2
         with:
           name: architect
-          path: /opt/bin
-      - name: Download hub artifact to /opt/bin
-        if: ${{ steps.cache.outputs.cache-hit != 'true' }}
-        uses: actions/download-artifact@v2
-        with:
-          name: hub
           path: /opt/bin
       - name: Prepare /opt/bin
         run: |

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -5,7 +5,7 @@ var (
 	gitSHA             = "n/a"
 	name        string = "kvm-operator"
 	source      string = "https://github.com/giantswarm/kvm-operator"
-	version            = "3.12.1"
+	version            = "3.12.2-dev"
 )
 
 func Description() string {


### PR DESCRIPTION
Automatic post v3.12.1 release workflow failed, it's trying to push to master while branch is protected https://github.com/giantswarm/kvm-operator/runs/918834629?check_suite_focus=true

This PR bumps the project version to next dev, and updated the workflow to latest where post-release workflow creates a PR, just like pre-release one.