### PR TITLE
Bump project version to 3.12.3-dev

### DIFF
--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -1,11 +1,11 @@
 package project
 
 var (
-	description string = "The kvm-operator handles Kubernetes clusters running on a Kubernetes cluster."
-	gitSHA             = "n/a"
-	name        string = "kvm-operator"
-	source      string = "https://github.com/giantswarm/kvm-operator"
-	version            = "3.12.2"
+	description = "The kvm-operator handles Kubernetes clusters running on a Kubernetes cluster."
+	gitSHA      = "n/a"
+	name        = "kvm-operator"
+	source      = "https://github.com/giantswarm/kvm-operator"
+	version     = "3.12.3-dev"
 )
 
 func Description() string {


### PR DESCRIPTION
Project.go was changed manually due to release issues with v3.12.2 so this needs to be done manually.