### PR TITLE
Prevent service account deletion during cluster deletion

### DIFF
--- a/service/controller/key/key.go
+++ b/service/controller/key/key.go
@@ -365,18 +365,6 @@ func ArePodContainersTerminated(pod *corev1.Pod) bool {
 	return true
 }
 
-// ArePodContainersWaiting checks ContainerState for all containers present
-// in given pod. When all containers are in Waiting state, true is returned.
-func ArePodContainersWaiting(pod *corev1.Pod) bool {
-	for _, cs := range pod.Status.ContainerStatuses {
-		if cs.State.Waiting == nil {
-			return false
-		}
-	}
-
-	return true
-}
-
 func LivenessPort(customObject v1alpha1.KVMConfig) int32 {
 	return int32(livenessPortBase + customObject.Spec.KVM.Network.Flannel.VNI)
 }

--- a/service/controller/resource/endpoint/current.go
+++ b/service/controller/resource/endpoint/current.go
@@ -107,14 +107,7 @@ func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interf
 		} else {
 			r.logger.LogCtx(ctx, "level", "debug", "message", "found current version of the reconciled pod in the Kubernetes API")
 
-			// Due to a bug in Kubernetes, if the liveness probe fails while the pod is being terminated, the containers will
-			// change to ContainerCreating state even though the containers will never actually be started by the kubelet. We
-			// consider the pod to be terminated if all containers are terminated or all containers are in creating state and
-			// there is a deletion timestamp as coded below.
-			containersTerminated := key.ArePodContainersTerminated(currentPod) ||
-				(key.ArePodContainersWaiting(currentPod) && key.IsPodDeleted(currentPod))
-
-			if !containersTerminated {
+			if !key.ArePodContainersTerminated(currentPod) {
 				r.logger.LogCtx(ctx, "level", "debug", "message", "pod containers are still running")
 				r.logger.LogCtx(ctx, "level", "debug", "message", "canceling resource")
 				resourcecanceledcontext.SetCanceled(ctx)


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/14213

I found that `shutdown-deferrer` was not working during cluster deletion because the service account and cluster role binding was being deleted while the draining was still ongoing. I took the logic from the config map resource to skip reconciliation of these two resources during cluster deletion. The cleanup is then handled by the namespace deletion. I have confirmed that this allows deletion draining to work as expected avoiding stuck finalizers:

```
{"caller":"github.com/giantswarm/shutdown-deferrer/service/deferrer/service.go:62","level":"debug","message":"finding pod name and namespace","time":"2020-11-10T20:11:03.480107+00:00"}
{"caller":"github.com/giantswarm/shutdown-deferrer/service/deferrer/service.go:73","level":"debug","message":"found pod name and namespace: master-22k49-6c85458985-2scdv, mab95","time":"2020-11-10T20:11:03.480217+00:00"}
{"caller":"github.com/giantswarm/shutdown-deferrer/service/deferrer/service.go:78","level":"debug","message":"finding drainerconfig for pod","time":"2020-11-10T20:11:03.480236+00:00"}
{"caller":"github.com/giantswarm/shutdown-deferrer/service/deferrer/service.go:88","level":"debug","message":"found drainerconfig for pod","time":"2020-11-10T20:11:03.495855+00:00"}
{"caller":"github.com/giantswarm/shutdown-deferrer/service/deferrer/service.go:92","level":"debug","message":"finding if node termination has to be defered","time":"2020-11-10T20:11:03.495894+00:00"}
{"caller":"github.com/giantswarm/shutdown-deferrer/service/deferrer/service.go:111","level":"debug","message":"found node termination should be deferred","time":"2020-11-10T20:11:03.495909+00:00"}
```