### PR TITLE
Update k8s-kvm

### DIFF
--- a/service/controller/key/key.go
+++ b/service/controller/key/key.go
@@ -67,7 +67,7 @@ const (
 	FlatcarChannel  = "stable"
 
 	K8SEndpointUpdaterDocker = "quay.io/giantswarm/k8s-endpoint-updater:0.1.0"
-	K8SKVMDockerImage        = "quay.io/giantswarm/k8s-kvm:0.2.0"
+	K8SKVMDockerImage        = "quay.io/giantswarm/k8s-kvm:0.3.0"
 	K8SKVMHealthDocker       = "quay.io/giantswarm/k8s-kvm-health:0.1.0"
 	ShutdownDeferrerDocker   = "quay.io/giantswarm/shutdown-deferrer:0.1.0"
 


### PR DESCRIPTION
## 0.3.0 - 2020-12-08

### Changed

- Switch from Fedora 32 to Fedora 33 (qemu 4.2.0 -> 5.0.0).