### PR TITLE
Add vertical pod autoscaler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add vertical pod autoscaler for operator pods
+
 ### Changed
 
 - Do not drain node pods when cluster is being deleted.

--- a/helm/kvm-operator/templates/vpa.yaml
+++ b/helm/kvm-operator/templates/vpa.yaml
@@ -10,6 +10,9 @@ spec:
     containerPolicies:
     - containerName: {{ .Chart.Name }}
       controlledValues: RequestsAndLimits
+      maxAllowed:
+        cpu: "500m"
+        memory: "500Mi"
       mode: Auto
   targetRef:
     apiVersion: apps/v1

--- a/helm/kvm-operator/templates/vpa.yaml
+++ b/helm/kvm-operator/templates/vpa.yaml
@@ -1,0 +1,19 @@
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: {{ include "resource.default.name" . }}
+  namespace: {{ include "resource.default.namespace" . }}
+  labels:
+    {{- include "labels.common" . | nindent 4 }}
+spec:
+  resourcePolicy:
+    containerPolicies:
+    - containerName: {{ .Chart.Name }}
+      controlledValues: RequestsAndLimits
+      mode: Auto
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name:  {{ include "resource.default.name" . }}
+  updatePolicy:
+    updateMode: Auto


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/12395

This will create a vpa for each kvm-operator deployment. Testing in on gorgoth I got:
```
Recommendation:
  Container Recommendations:
    Container Name:  kvm-operator
    Lower Bound:
      Cpu:     33m
      Memory:  104857600
    Target:
      Cpu:     63m
      Memory:  272061154
    Uncapped Target:
      Cpu:     63m
      Memory:  272061154
    Upper Bound:
      Cpu:     2309m
      Memory:  4986478263
```

where: 
* Target: the requests values that will get configured on the pods at the next iteration.
* Lower/Upper bound: the values that the pod needs to go under/above to get **evicted and up/downscaled**.

The limits to request ratio gets preserved from the values passed in the deployment initially. So in our case they will be [1:1](https://github.com/giantswarm/kvm-operator/blob/12ebe236628d4360ce2ce6b466c612c179322181/helm/kvm-operator/templates/deployment.yaml#L58-L64). 

Also the more it runs, the more data about the usage it gets so the predictions get better. After about an hour of running, the recommendation changed to (upper bound wasn't that random anymore):

```
 Recommendation:
   Container Recommendations:
     Container Name:  kvm-operator
     Lower Bound:
       Cpu:     34m
       Memory:  104857600
     Target:
       Cpu:     49m
       Memory:  272061154
     Uncapped Target:
       Cpu:     49m
       Memory:  272061154
     Upper Bound:
       Cpu:     879m
       Memory:  3798855408
```

Logs in the `vertical-pod-autoscaler` to prove that it actually does something:
```
I0105 08:45:19.416775       1 update_priority_calculator.go:133] not updating a short-lived pod giantswarm/kvm-operator-vpa-75fcddc7d7-dxrrb, request within recommended range
I0105 08:46:19.419168       1 update_priority_calculator.go:133] not updating a short-lived pod giantswarm/kvm-operator-vpa-75fcddc7d7-dxrrb, request within recommended range
I0105 08:47:19.417194       1 update_priority_calculator.go:147] pod accepted for update giantswarm/kvm-operator-vpa-75fcddc7d7-dxrrb with priority 0.7858309402465821
I0105 08:47:19.417273       1 updater.go:193] evicting pod kvm-operator-vpa-75fcddc7d7-dxrrb
I0105 08:48:19.418728       1 update_priority_calculator.go:133] not updating a short-lived pod giantswarm/kvm-operator-vpa-75fcddc7d7-2gbwq, request within recommended range
I0105 08:49:19.423243       1 update_priority_calculator.go:133] not updating a short-lived pod giantswarm/kvm-operator-vpa-75fcddc7d7-2gbwq, request within recommended range
```