### PR TITLE
Increase memory limit and request

### DIFF
--- a/helm/kvm-operator/templates/deployment.yaml
+++ b/helm/kvm-operator/templates/deployment.yaml
@@ -58,9 +58,9 @@ spec:
         resources:
           requests:
             cpu: 250m
-            memory: 250Mi
+            memory: 400Mi
           limits:
             cpu: 250m
-            memory: 250Mi
+            memory: 400Mi
       imagePullSecrets:
       - name: {{ include "resource.pullSecret.name" . }}


### PR DESCRIPTION
In certain deployments we have `kvm-operator` reaching 300MB of memory usage causing it to be killed. 400MB gives us ~33% of wiggle room.

PM here https://github.com/giantswarm/giantswarm/issues/15101