### PR TITLE
Update k8s-kvm to v0.4.0 with QEMU v5.2.0 (v3.14.x cherry-pick)

### DIFF
--- a/.github/workflows/zz_generated.gitleaks.yaml
+++ b/.github/workflows/zz_generated.gitleaks.yaml
@@ -14,4 +14,4 @@ jobs:
       with:
         fetch-depth: '0'
     - name: gitleaks-action
-      uses: zricethezav/gitleaks-action@v1.1.4
+      uses: zricethezav/gitleaks-action@v1.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Update k8s-kvm to v0.4.0 with QEMU v5.2.0.
+
 ## [3.14.0] - 2020-11-25
 
 ### Added

--- a/service/controller/key/key.go
+++ b/service/controller/key/key.go
@@ -67,7 +67,7 @@ const (
 	FlatcarChannel  = "stable"
 
 	K8SEndpointUpdaterDocker = "quay.io/giantswarm/k8s-endpoint-updater:0.1.0"
-	K8SKVMDockerImage        = "quay.io/giantswarm/k8s-kvm:0.2.0"
+	K8SKVMDockerImage        = "quay.io/giantswarm/k8s-kvm:0.4.0"
 	K8SKVMHealthDocker       = "quay.io/giantswarm/k8s-kvm-health:0.1.0"
 	ShutdownDeferrerDocker   = "quay.io/giantswarm/shutdown-deferrer:0.1.0"
 


### PR DESCRIPTION
Follow-up to https://github.com/giantswarm/giantswarm/issues/15456 for release https://github.com/giantswarm/roadmap/issues/247