### PR TITLE
bump version to v3.15.0-dev

### DIFF
--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -5,7 +5,7 @@ var (
 	gitSHA      = "n/a"
 	name        = "kvm-operator"
 	source      = "https://github.com/giantswarm/kvm-operator"
-	version     = "3.14.1-dev"
+	version     = "3.15.0-dev"
 )
 
 func Description() string {


### PR DESCRIPTION
The next release of `kvm-operator` based on the `master` branch will be v3.15.0 so I'm bumping the project version to the next minor.