### PR TITLE
Update k8s-kvm to 0.2.1 (v3.13.x)

### DIFF
--- a/.github/workflows/zz_generated.gitleaks.yaml
+++ b/.github/workflows/zz_generated.gitleaks.yaml
@@ -14,4 +14,4 @@ jobs:
       with:
         fetch-depth: '0'
     - name: gitleaks-action
-      uses: zricethezav/gitleaks-action@v1.1.4
+      uses: zricethezav/gitleaks-action@v1.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Update `k8s-kvm` to mitigate DNS issues affecting node booting.
+
 ## [3.13.0] - 2020-10-30
 
 ### Changed

--- a/service/controller/key/key.go
+++ b/service/controller/key/key.go
@@ -67,7 +67,7 @@ const (
 	FlatcarChannel  = "stable"
 
 	K8SEndpointUpdaterDocker = "quay.io/giantswarm/k8s-endpoint-updater:0.1.0"
-	K8SKVMDockerImage        = "quay.io/giantswarm/k8s-kvm:db67d78e1caf4d9dfb951cd4455deeb2783f6eaf"
+	K8SKVMDockerImage        = "quay.io/giantswarm/k8s-kvm:0.2.0-db67d78e1caf4d9dfb951cd4455deeb2783f6eaf"
 	K8SKVMHealthDocker       = "quay.io/giantswarm/k8s-kvm-health:0.1.0"
 	ShutdownDeferrerDocker   = "quay.io/giantswarm/shutdown-deferrer:0.1.0"
 

--- a/service/controller/key/key.go
+++ b/service/controller/key/key.go
@@ -67,7 +67,7 @@ const (
 	FlatcarChannel  = "stable"
 
 	K8SEndpointUpdaterDocker = "quay.io/giantswarm/k8s-endpoint-updater:0.1.0"
-	K8SKVMDockerImage        = "quay.io/giantswarm/k8s-kvm:0.2.0"
+	K8SKVMDockerImage        = "quay.io/giantswarm/k8s-kvm:db67d78e1caf4d9dfb951cd4455deeb2783f6eaf"
 	K8SKVMHealthDocker       = "quay.io/giantswarm/k8s-kvm-health:0.1.0"
 	ShutdownDeferrerDocker   = "quay.io/giantswarm/shutdown-deferrer:0.1.0"
 

--- a/service/controller/key/key.go
+++ b/service/controller/key/key.go
@@ -67,7 +67,7 @@ const (
 	FlatcarChannel  = "stable"
 
 	K8SEndpointUpdaterDocker = "quay.io/giantswarm/k8s-endpoint-updater:0.1.0"
-	K8SKVMDockerImage        = "quay.io/giantswarm/k8s-kvm:0.2.0-db67d78e1caf4d9dfb951cd4455deeb2783f6eaf"
+	K8SKVMDockerImage        = "quay.io/giantswarm/k8s-kvm:0.2.1"
 	K8SKVMHealthDocker       = "quay.io/giantswarm/k8s-kvm-health:0.1.0"
 	ShutdownDeferrerDocker   = "quay.io/giantswarm/shutdown-deferrer:0.1.0"
 


### PR DESCRIPTION
Releasing Flatcar DNS hotfix from https://github.com/giantswarm/k8s-kvm/pull/71