### PR TITLE
List only deployments managed by kvm-operator

### DIFF
--- a/service/controller/resource/deployment/current.go
+++ b/service/controller/resource/deployment/current.go
@@ -26,7 +26,8 @@ func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interf
 	var currentDeployments []*v1.Deployment
 	{
 		namespace := key.ClusterNamespace(customResource)
-		deploymentList, err := r.k8sClient.AppsV1().Deployments(namespace).List(ctx, metav1.ListOptions{})
+		labelSelector := metav1.ListOptions{LabelSelector: key.LabelManagedBy + "=" + key.OperatorName}
+		deploymentList, err := r.k8sClient.AppsV1().Deployments(namespace).List(ctx, labelSelector)
 		if err != nil {
 			return nil, microerror.Mask(err)
 		} else {


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/10713

We need to bump `cluster-operator` to `v0.27.1` to stop ensuring the `v1beta1` `kvmconfig`. The problem is that that version creates `app-operator` app deployment in the cluster namespace. Since `kvm-operator` lists all deployments, it iterates over the `app-operator` one and ends up deleting it.