### PR TITLE
Adds support to push images to dockerhub

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,6 +15,18 @@ workflows:
               only: /^v.*/
 
       - architect/push-to-docker:
+          name: push-to-docker
+          context: "architect"
+          image: "docker.io/giantswarm/kvm-operator"
+          username_envar: "DOCKER_USERNAME"
+          password_envar: "DOCKER_PASSWORD"
+          requires:
+            - go-build
+          filters:
+            tags:
+              only: /^v.*/
+
+      - architect/push-to-docker:
           name: push-to-quay
           image: "quay.io/giantswarm/kvm-operator"
           username_envar: "QUAY_USERNAME"
@@ -31,6 +43,7 @@ workflows:
           app_catalog_test: "control-plane-test-catalog"
           chart: "kvm-operator"
           requires:
+            - push-to-docker
             - push-to-quay
           filters:
             branches:


### PR DESCRIPTION
To avoid having `crsync` synchronise images, we can push to dockerhub directly - see https://hub.docker.com/layers/giantswarm/kvm-operator/3.17.3-f9af19c1d3add368b9ee9c77c3768b2ac8e8ae3c/images/sha256-908609ca1c73e839bd76526856ceaf16d987cc53e92efe0bcc7eb32c09ab2db8