### PR TITLE
Disable flow control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Disable apiserver flow control to mitigate etcd memory usage issues temporarily.
+
 ## [3.18.1] - 2021-09-10
+
+### Changed
+
+- Update `k8scloudconfig` to fix RBAC issues for `calico-kube-controllers`.
 
 ## [3.18.0] - 2021-09-01
 

--- a/service/controller/cloudconfig/cloud_config.go
+++ b/service/controller/cloudconfig/cloud_config.go
@@ -93,7 +93,11 @@ func New(config Config) (*CloudConfig, error) {
 		return nil, microerror.Maskf(invalidConfigError, "%T.IgnitionPath must not be empty", config)
 	}
 
-	var k8sAPIExtraArgs []string
+	k8sAPIExtraArgs := []string{
+		// Mitigation for https://github.com/giantswarm/giantswarm/issues/19003, remove once issue is resolved
+		"--enable-priority-and-fairness=false",
+	}
+
 	{
 		if config.OIDC.ClientID != "" {
 			k8sAPIExtraArgs = append(k8sAPIExtraArgs, fmt.Sprintf("--oidc-client-id=%s", config.OIDC.ClientID))


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/19003

Disabling [flow control](https://kubernetes.io/docs/concepts/cluster-administration/flow-control/) which increases load and memory usage of apiserver and etcd.