### PR TITLE
Consider new control-plane taint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+ - Consider new control-plane taint when determining when a node is unschedulable.
+
 ## [3.18.6] - 2022-07-04
 
 ## [3.18.6] - 2022-07-01

--- a/service/controller/key/key.go
+++ b/service/controller/key/key.go
@@ -527,7 +527,9 @@ func NodeIsUnschedulable(node corev1.Node) bool {
 	}
 
 	for _, t := range node.Spec.Taints {
-		if (t.Effect == corev1.TaintEffectNoSchedule && t.Key != "node-role.kubernetes.io/master") ||
+		if (t.Effect == corev1.TaintEffectNoSchedule &&
+			t.Key != "node-role.kubernetes.io/master" &&
+			t.Key != "node-role.kubernetes.io/control-plane") ||
 			t.Effect == corev1.TaintEffectNoExecute {
 			return true
 		}


### PR DESCRIPTION
This PR considers the new taint `node-role.kubernetes.io/control-plane` when determining whether a node is unschedulable.

Towards https://github.com/giantswarm/roadmap/issues/2468
