### PR TITLE
Configure gsoci.azurecr.io as the registry to use by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [3.18.6] - 2022-07-04
+### Changed
+
+- Configure `gsoci.azurecr.io` as the default container image registry.
 
 ## [3.18.6] - 2022-07-01
 
@@ -114,7 +116,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Use Release.Revision in Helm chart for Helm 3 support.
 - Fix OIDC settings.
-
 
 ## [3.11.0] 2020-04-27
 

--- a/helm/kvm-operator/values.yaml
+++ b/helm/kvm-operator/values.yaml
@@ -33,9 +33,9 @@ proxy:
   no_proxy: []
 
 registry:
-  domain: docker.io
+  domain: gsoci.azurecr.io
   mirrors:
-  - giantswarm.azurecr.io
+    - giantswarm.azurecr.io
   pullSecret:
     dockerConfigJSON: ""
 


### PR DESCRIPTION
Towards

- https://github.com/giantswarm/roadmap/issues/3017

This PR replaces any occurrence of `docker.io` in `values.yaml` files with `gsoci.azurecr.io`,
to make the new ACR registry the default one.
